### PR TITLE
fix building wrong PROMPT_COMMAND

### DIFF
--- a/usr/bin/byobu-launch
+++ b/usr/bin/byobu-launch
@@ -58,7 +58,7 @@ elif [ "$BYOBU_SOURCED_PROFILE" != "1" ] && [ "$LC_BYOBU" != "0" ] && [ "$BYOBU_
 						esac
 					fi
 				done
-				[ -n "$PROMPT_COMMAND" ] && PROMPT_COMMAND="$PROMPT_COMMAND;history -a;history -r" || PROMPT_COMMAND="history -a;history -r"
+				PROMPT_COMMAND="history -a;history -r;$PROMPT_COMMAND"
 				# Source profile, if necessary
 				[ -z "$_byobu_sourced" ] && [ -r "$HOME/.profile" ] && . "$HOME/.profile"
 				if byobu-launcher; then


### PR DESCRIPTION
If one previously declared a perfectly valid `PROMPT_COMMAND` like 

    PROMPT_COMMAND="do_something;"

, *byobu* would have corrupted it: 

    PROMPT_COMMAND="$PROMPT_COMMAND;history -a;history -r"

resulted in

    "do_something;;history -a;history -r"

, but the double semicolons are illegal:

    bash: PROMPT_COMMAND: line 0: syntax error near unexpected token `;'
    bash: PROMPT_COMMAND: line 0: `do_something; ;history -a;history -r'