### PR TITLE
Added shortcut Alt-F9 to toggle input to all splits

### DIFF
--- a/usr/share/byobu/keybindings/f-keys.tmux
+++ b/usr/share/byobu/keybindings/f-keys.tmux
@@ -73,6 +73,7 @@ bind-key -n C-S-F8 command-prompt -p "Save byobu layout as:" "run-shell \"byobu-
 bind-key -n F9 new-window -k -n config byobu-config
 bind-key -n S-F9 command-prompt -p "Send command to all panes:" "run-shell \"$BYOBU_PREFIX/lib/byobu/include/tmux-send-command-to-all-panes '%%'\""
 bind-key -n C-F9 command-prompt -p "Send command to all windows:" "run-shell \"$BYOBU_PREFIX/lib/byobu/include/tmux-send-command-to-all-windows '%%'\""
+bind-key -n M-F9 display-panes \; setw synchronize-panes
 bind-key -n M-F11 break-pane
 bind-key -n C-F11 join-pane -h -s :. -t :-1
 bind-key -n S-F11 resize-pane -Z

--- a/usr/share/byobu/keybindings/f-keys.tmux.disable
+++ b/usr/share/byobu/keybindings/f-keys.tmux.disable
@@ -72,6 +72,7 @@ unbind-key -n C-S-F8
 unbind-key -n M-S-F8
 unbind-key -n S-F8
 unbind-key -n F9
+unbind-key -n M-F9
 unbind-key -n S-F9
 unbind-key -n C-F9
 unbind-key -n M-F11

--- a/usr/share/doc/byobu/help.tmux.txt
+++ b/usr/share/doc/byobu/help.tmux.txt
@@ -36,6 +36,7 @@ and some convenient keybindings:
   F9                             Launch byobu-config window
     Ctrl-F9                      Enter command and run in all windows
     Shift-F9                     Enter command and run in all splits
+    Alt-F9                       Send keyboard input to all splits toggle
   F10                            * Used by X11 *
   F11                            * Used by X11 *
     Alt-F11                      Expand split to a full window


### PR DESCRIPTION
Added shortcut Alt-F9 to toggle input to all splits. tmux equivalent of `:setw synchronize-panes`
