### PR TITLE
Update S-F1 binding in f-keys.tmux

### DIFF
--- a/usr/share/byobu/keybindings/f-keys.tmux
+++ b/usr/share/byobu/keybindings/f-keys.tmux
@@ -27,7 +27,7 @@ source $BYOBU_PREFIX/share/byobu/keybindings/f-keys.tmux.disable
 # Byobu's Keybindings
 # Documented in: $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt
 bind-key -n F1 new-window -k -n config byobu-config
-bind-key -n S-F1 new-window -k -n help '$BYOBU_PAGER $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt'
+bind-key -n S-F1 new-window -k -n help "sh -c '$BYOBU_PAGER $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt'"
 bind-key -n F2 new-window \; rename-window "-"
 bind-key -n C-F2 display-panes \; split-window -h
 bind-key -n S-F2 display-panes \; split-window -v


### PR DESCRIPTION
The previous binding will not work with shells that don't allow variables as commands (fish shell being one of those). Use `sh -c` to explicitly use a POSIX shell to interpret the command
