### PR TITLE
Updated README

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,7 @@ install locally, using the following instructions...
     otherwise you will have issues in step 5 make process:
       mv byobu byobu-src
     Then you need to run:
+      cd byobu-src
       ./debian/rules autoconf
  1) Or download the latest officially released version from:
       https://launchpad.net/byobu/+download

--- a/README
+++ b/README
@@ -8,7 +8,10 @@ install locally, using the following instructions...
  0) If you pull the source from the upstream bzr or git:
       bzr branch lp:byobu
       git clone git://github.com/dustinkirkland/byobu.git
-    Then you first need to run:
+    Change the directory name to something different like byobu-src,
+    otherwise you will have issues in step 5 make process:
+      mv byobu byobu-src
+    Then you need to run:
       ./debian/rules autoconf
  1) Or download the latest officially released version from:
       https://launchpad.net/byobu/+download
@@ -35,4 +38,4 @@ Note that you will need to have a few dependencies installed:
  * gsed (if your sed implementation doesn't support -i)
 
 Dustin Kirkland <kirkland@byobu.co>
-2013-01-15
+2015-03-01


### PR DESCRIPTION
`make` process in step 5 raises errors when the src directory is also called `byobu`. This happens when doing `git clone` from GitHub. The remedy is to rename the dorectory to something different like `byobu-src`.
