### PR TITLE
Fix check for sed's follow-symlinks feature

### DIFF
--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -49,7 +49,7 @@ $BYOBU_TEST greadlink >/dev/null 2>&1 && export BYOBU_READLINK="greadlink" || ex
 $BYOBU_TEST sensible-pager >/dev/null 2>&1 && export BYOBU_PAGER="sensible-pager" || export BYOBU_PAGER="less"
 
 # Check sed's follow-symlinks feature
-$BYOBU_SED --follow-symlinks "s///" </dev/null 2>/dev/null && BYOBU_SED="$BYOBU_SED --follow-symlinks" || true
+$BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED="$BYOBU_SED --follow-symlinks" || true
 
 # Determine if we have ulimit support
 $BYOBU_TEST ulimit >/dev/null 2>&1 && export BYOBU_ULIMIT="ulimit" || export BYOBU_ULIMIT="false"


### PR DESCRIPTION
I'm on Fedora 22, the check for sed's follow-symlinks fails and sed is used without the option, destroying my ~/.bashrc symlink.
This change fixes the issue.