### PR TITLE
Fix python shebang in executable scripts

### DIFF
--- a/usr/lib/byobu/include/config.py.in
+++ b/usr/lib/byobu/include/config.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 #    config.py
 #    Copyright (C) 2008 Canonical Ltd.

--- a/usr/lib/byobu/include/ec2instancespricing.py
+++ b/usr/lib/byobu/include/ec2instancespricing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2012 Eran Sandler (eran@sandler.co.il),  http://eran.sandler.co.il,  http://forecastcloudy.net
 #

--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 #    select-session.py
 #    Copyright (C) 2010 Canonical Ltd.


### PR DESCRIPTION
Hi! I found byobu's scripts not working under NixOS (https://nixos.org/ which becomes more and more popular) because of assumption that `python` interpreter must be located at `/usr/bin/python`, which is true in most Linux distributions, but not exactly correct. For example in NixOS:
```
> which python
/home/max/.nix-profile/bin/python
```
resulting:
```
> byobu-tmux
/home/max/.nix-profile/bin/byobu-select-session: /nix/store/31ii4b484smgj3ay9k64nh6rn56kwkdp-byobu-5.87/lib/byobu/include/select-session.py: /usr/bin/python: bad interpreter: No such file or directory
```
Thus, the patch fixes this assumption.