### PR TITLE
Use `POWER_SUPPLY_CAPACITY` for battery if available 

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -41,11 +41,11 @@ __battery() {
 					case "$POWER_SUPPLY_NAME" in AC|ac|Ac|aC) continue ;; esac
 					present="$POWER_SUPPLY_PRESENT"
 					# Some use "CHARGE", others use "ENERGY", still others "CAPACITY"
-					#[ -n "$POWER_SUPPLY_CAPACITY" ] && rem="$POWER_SUPPLY_CAPACITY" && full="100"
 					[ -n "$POWER_SUPPLY_CHARGE_FULL" ] && full=$((POWER_SUPPLY_CHARGE_FULL+full))
 					[ -n "$POWER_SUPPLY_ENERGY_FULL" ] && full=$((POWER_SUPPLY_ENERGY_FULL+full))
 					[ -n "$POWER_SUPPLY_CHARGE_NOW" ] && rem=$((POWER_SUPPLY_CHARGE_NOW+rem))
 					[ -n "$POWER_SUPPLY_ENERGY_NOW" ] && rem=$((POWER_SUPPLY_ENERGY_NOW+rem))
+          [ -n "$POWER_SUPPLY_CAPACITY" ] && [ $full -gt 0 ] && rem=$((($POWER_SUPPLY_CAPACITY*$full)/100))
 					[ "$POWER_SUPPLY_STATUS" != "Unknown" ] && state="$POWER_SUPPLY_STATUS"
 				fi
 			;;


### PR DESCRIPTION
It looks like this was removed when battery summing was added
(https://github.com/dustinkirkland/byobu/commit/6939b919), as it
would return weird results when we calculated the capacity across
batteries. I've reintroduced it in a way that should work with multiple
batteries by calculating what `rem` should be based on the percentage
capacity. This works for my Moto E Android device running Ubuntu Touch,
whereas before I would see the battery always reported at 0%.

Not sure if you are accepting PRs on this mirror, but please let me know how to contribute if not. Also, an abundance of thanks from a happy byobu user of many years :smile: 