### PR TITLE
tmux grouped session support and a bug fix

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -85,6 +85,7 @@ def get_sessions():
 					i += 1
 	return sessions
 
+
 def cull_zombies(session_name):
 	# When using tmux session groups, closing a client will leave
 	# unattached "zombie" sessions that will never be reattached.
@@ -109,8 +110,8 @@ def cull_zombies(session_name):
 		# Kill all the matching hidden & unattached sessions
 		pattern = "^_%s-\\d+:.+\\(%s\\)$" % (session_name, master.group(1))
 		for s in re.findall(pattern, output, re.MULTILINE):
-			print("Killing", s.split(":")[0]);
 			subprocess.Popen(["tmux", "kill-session", "-t", s.split(":")[0]])
+
 
 def update_environment(session):
 	backend, session_name = session.split("____", 2)

--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -85,6 +85,32 @@ def get_sessions():
 					i += 1
 	return sessions
 
+def cull_zombies(session_name):
+	# When using tmux session groups, closing a client will leave
+	# unattached "zombie" sessions that will never be reattached.
+	# Search for and kill any unattached hidden sessions in the same group
+	if BYOBU_BACKEND == "tmux":
+		output = subprocess.Popen(["tmux", "list-sessions"], stdout=subprocess.PIPE).communicate()[0]
+		if sys.stdout.encoding is None:
+			output = output.decode("UTF-8")
+		else:
+			output = output.decode(sys.stdout.encoding)
+		if not output:
+			return
+
+		# Find the master session to extract the group number. We use
+		# the group number to be extra sure the right session is getting
+		# killed. We don't want to accidentally kill the wrong one
+		pattern = "^%s:.+\\((group \\d+)\\).*$" % session_name
+		master = re.search(pattern, output, re.MULTILINE)
+		if not master:
+			return
+
+		# Kill all the matching hidden & unattached sessions
+		pattern = "^_%s-\\d+:.+\\(%s\\)$" % (session_name, master.group(1))
+		for s in re.findall(pattern, output, re.MULTILINE):
+			print("Killing", s.split(":")[0]);
+			subprocess.Popen(["tmux", "kill-session", "-t", s.split(":")[0]])
 
 def update_environment(session):
 	backend, session_name = session.split("____", 2)
@@ -101,9 +127,10 @@ def update_environment(session):
 def attach_session(session):
 	update_environment(session)
 	backend, session_name = session.split("____", 2)
+	cull_zombies(session_name)
 	# must use the binary, not the wrapper!
 	if backend == "tmux":
-		os.execvp("tmux", ["", "-2", "attach", "-t", session_name])
+		os.execvp("tmux", ["", "-2", "new-session", "-t", session_name, "-s", "_%s-%i" % (session_name, os.getpid())])
 	else:
 		os.execvp("screen", ["", "-AOxRR", session_name])
 

--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -130,9 +130,9 @@ def attach_session(session):
 	cull_zombies(session_name)
 	# must use the binary, not the wrapper!
 	if backend == "tmux":
-		os.execvp("tmux", ["", "-2", "new-session", "-t", session_name, "-s", "_%s-%i" % (session_name, os.getpid())])
+		os.execvp("tmux", ["tmux", "-2", "new-session", "-t", session_name, "-s", "_%s-%i" % (session_name, os.getpid())])
 	else:
-		os.execvp("screen", ["", "-AOxRR", session_name])
+		os.execvp("screen", ["screen", "-AOxRR", session_name])
 
 sessions = get_sessions()
 
@@ -180,9 +180,9 @@ if choice >= 1:
 	if sessions[choice - 1] == "NEW":
 		# Create a new session
 		if BYOBU_BACKEND == "tmux":
-			os.execvp("byobu", ["", "new-session", SHELL])
+			os.execvp("byobu", ["byobu", "new-session", SHELL])
 		else:
-			os.execvp("byobu", ["", SHELL])
+			os.execvp("byobu", ["byobu", SHELL])
 	elif sessions[choice - 1] == "SHELL":
 		os.execvp(SHELL, [SHELL])
 	else:
@@ -194,4 +194,4 @@ if BYOBU_BACKEND == "tmux":
 	args = ""
 else:
 	args = "-AOxRR"
-os.execvp("byobu", ["", args])
+os.execvp("byobu", ["byobu", args])


### PR DESCRIPTION
Hi Dustin,

I've been using byobu for many years now, but the default behavour of tmux (all clients see the same view) is not useful for me. I did have an extra script that would force grouped sessions, but it was pretty ugly. I finally got around to implementing it properly within byobu, which is the first commit in this pull request.

The second commit is a simple bug fix to make the argument list include the command name when calling os.execvp() so that it shows up correctly when listing processes.

Cheers,
g.