### PR TITLE
Fixing BYOBU_TEST issues

### DIFF
--- a/usr/bin/byobu-janitor.in
+++ b/usr/bin/byobu-janitor.in
@@ -113,11 +113,11 @@ rm -f "$FLAG" "/var/run/screen/S-$USER/$PKG.reload-required"
 
 # Affects: Upgrades from <= byobu 5.50, install byobu prompt if using stock bashrc
 if ! (grep -qs "#byobu-prompt#$" "$HOME/.bashrc") && ! [ -e "$BYOBU_CONFIG_DIR/prompt" ]; then
-	if $BYOBU_TEST diff >/dev/null 2>&1; then
+	if eval $BYOBU_TEST diff >/dev/null 2>&1; then
 		if  diff /etc/skel/.bashrc "$HOME/.bashrc" >/dev/null 2>&1; then
 			printf "[ -r $BYOBU_CONFIG_DIR/prompt ] && . $BYOBU_CONFIG_DIR/prompt   #byobu-prompt#\n" >> "$HOME/.bashrc"
 		fi
-	elif $BYOBU_TEST md5sum >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST md5sum >/dev/null 2>&1; then
 		if [ "$(cat /etc/skel/.bashrc | md5sum)" = "$(cat $HOME/.bashrc | md5sum)" ]; then
 			printf "[ -r $BYOBU_CONFIG_DIR/prompt ] && . $BYOBU_CONFIG_DIR/prompt   #byobu-prompt#\n" >> "$HOME/.bashrc"
 		fi

--- a/usr/bin/byobu-launch.in
+++ b/usr/bin/byobu-launch.in
@@ -51,7 +51,7 @@ elif [ "$BYOBU_SOURCED_PROFILE" != "1" ] && [ "$LC_BYOBU" != "0" ] && [ "$BYOBU_
 			*i*)
 				# Attempt to merge shell history across sessions/windows (works with some exceptions)
 				for i in shopt setopt; do
-					if $BYOBU_TEST $i >/dev/null; then
+					if eval $BYOBU_TEST $i >/dev/null; then
 						case $i in
 							shopt) $i -s histappend || true ;;
 							setopt) $i appendhistory || true ;;

--- a/usr/bin/byobu-select-profile.in
+++ b/usr/bin/byobu-select-profile.in
@@ -51,7 +51,7 @@ COLORS="default_light \
 
 # Find a hash utility
 for i in md5sum md5 sha512sum sha256sum sha1sum shasum shasum5.12 shasum5.10; do
-	if $BYOBU_TEST $i >/dev/null 2>&1; then
+	if eval $BYOBU_TEST $i >/dev/null 2>&1; then
 		HASH="$i"
 		break
 	fi
@@ -187,7 +187,7 @@ setcolor_screen() {
 get_contrast() {
 	# See section 2.2: http://www.w3.org/TR/AERT#color-contrast
 	local awk="awk"
-	if $BYOBU_TEST gawk >/dev/null 2>&1; then
+	if eval $BYOBU_TEST gawk >/dev/null 2>&1; then
 		awk="gawk"
 	fi
 	local hex="$(echo "$1" | sed -e "s/\(..\)\(..\)\(..\)/\1 \2 \3/")"

--- a/usr/bin/byobu-status.in
+++ b/usr/bin/byobu-status.in
@@ -153,11 +153,11 @@ case "$1" in
 	;;
 	--detail)
 		VER=
-		if $BYOBU_TEST dpkg-query >/dev/null; then
+		if eval $BYOBU_TEST dpkg-query >/dev/null; then
 			VER=$(set -- $(dpkg-query --show $PKG); printf "%s\n" "$2")
 		fi
 		printf "$PKG-$VER Detailed Status Navigation\n"
-		if $BYOBU_TEST vim >/dev/null && `vim --version | grep -q +folding`; then
+		if eval $BYOBU_TEST vim >/dev/null && `vim --version | grep -q +folding`; then
 			printf "  Expand all - zr\t\tCollapse all - zm\n  Expand one - zo\t\tCollapse one - zc\n\n"
 		fi
 		for i in "$BYOBU_PREFIX/lib/$PKG"/*; do

--- a/usr/bin/byobu.in
+++ b/usr/bin/byobu.in
@@ -72,7 +72,7 @@ if [ "$#" = "1" ]; then
 	case "$1" in
 		-v|--version)
 			echo "$PKG version $VERSION"
-			if $BYOBU_TEST bash >/dev/null 2>&1; then
+			if eval $BYOBU_TEST bash >/dev/null 2>&1; then
 				# Check ulimits
 				u=$(bash -c "ulimit -n")
 				[ "$u" = "unlimited" ] || [ $u -ge 15 ] || echo "WARNING: ulimit -n is too low" 1>&2
@@ -117,7 +117,7 @@ fi
 
 # Check if our terminfo supports 256 colors
 CAN_SHOW_COLORS=
-if $BYOBU_TEST tput >/dev/null 2>&1; then
+if eval $BYOBU_TEST tput >/dev/null 2>&1; then
 	if [ "$(tput colors 2>/dev/null || echo 0)" = "256" ]; then
 		CAN_SHOW_COLORS=1
 	fi
@@ -125,7 +125,7 @@ fi
 
 # Check if the color terminfo is available
 HAS_COLOR_TERM=
-if $BYOBU_TEST infocmp >/dev/null 2>&1; then
+if eval $BYOBU_TEST infocmp >/dev/null 2>&1; then
 	if infocmp "$BYOBU_COLOR_TERM" >/dev/null 2>&1; then
 		HAS_COLOR_TERM=1
 	fi

--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -77,7 +77,7 @@ __battery() {
 		esac
 	done
 	# Mac OS X support
-	if $BYOBU_TEST /usr/sbin/ioreg >/dev/null 2>&1; then
+	if eval $BYOBU_TEST /usr/sbin/ioreg >/dev/null 2>&1; then
 		# MacOS support
 		local key
 		for key in CurrentCapacity MaxCapacity ExternalChargeCapable FullyCharged; do

--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -20,7 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __disk_io_detail() {
-	if $BYOBU_TEST iostat >/dev/null; then
+	if eval $BYOBU_TEST iostat >/dev/null; then
 		iostat -d -m -h
 	else
 		printf "%s\n" "Please install iostat if you want detailed information on your disk throughput"

--- a/usr/lib/byobu/include/common
+++ b/usr/lib/byobu/include/common
@@ -24,7 +24,7 @@ if [ -z "${BYOBU_INCLUDED_LIBS}" ]; then
 
 	# Find command/type/which
 	for BYOBU_TEST in "command -v" "type" "which"; do
-		eval $BYOBU_TEST >/dev/null 2>&1 && break || true
+		eval $BYOBU_TEST ls >/dev/null 2>&1 && break || true
 	done
 
 	# If the backend is already set (eg. running `byobu-tmux`), do nothing.

--- a/usr/lib/byobu/include/common
+++ b/usr/lib/byobu/include/common
@@ -24,7 +24,7 @@ if [ -z "${BYOBU_INCLUDED_LIBS}" ]; then
 
 	# Find command/type/which
 	for BYOBU_TEST in "command -v" "type" "which"; do
-		$BYOBU_TEST >/dev/null 2>&1 && break || true
+		eval $BYOBU_TEST >/dev/null 2>&1 && break || true
 	done
 
 	# If the backend is already set (eg. running `byobu-tmux`), do nothing.
@@ -34,9 +34,9 @@ if [ -z "${BYOBU_INCLUDED_LIBS}" ]; then
 		# Just in case there's no config file at all
 		if [ -z "${BYOBU_BACKEND}" ]; then
 			# New byobu configuration, default to tmux
-			if $BYOBU_TEST tmux >/dev/null; then
+			if eval $BYOBU_TEST tmux >/dev/null; then
 				BYOBU_BACKEND="tmux"
-			elif $BYOBU_TEST screen >/dev/null; then
+			elif eval $BYOBU_TEST screen >/dev/null; then
 				BYOBU_BACKEND="screen"
 			else
 				printf "%s\n" "ERROR: $PKG won't work without tmux or screen installed" 1>&2

--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -44,15 +44,15 @@ case "$BYOBU_BACKEND" in
 esac
 
 # MacOS Support
-$BYOBU_TEST gsed >/dev/null 2>&1 && export BYOBU_SED="gsed" || export BYOBU_SED="sed"
-$BYOBU_TEST greadlink >/dev/null 2>&1 && export BYOBU_READLINK="greadlink" || export BYOBU_READLINK="readlink"
-$BYOBU_TEST sensible-pager >/dev/null 2>&1 && export BYOBU_PAGER="sensible-pager" || export BYOBU_PAGER="less"
+eval $BYOBU_TEST gsed >/dev/null 2>&1 && export BYOBU_SED="gsed" || export BYOBU_SED="sed"
+eval $BYOBU_TEST greadlink >/dev/null 2>&1 && export BYOBU_READLINK="greadlink" || export BYOBU_READLINK="readlink"
+eval $BYOBU_TEST sensible-pager >/dev/null 2>&1 && export BYOBU_PAGER="sensible-pager" || export BYOBU_PAGER="less"
 
 # Check sed's follow-symlinks feature
 $BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || BYOBU_SED_INLINE="$BYOBU_SED -i"
 
 # Determine if we have ulimit support
-$BYOBU_TEST ulimit >/dev/null 2>&1 && export BYOBU_ULIMIT="ulimit" || export BYOBU_ULIMIT="false"
+eval $BYOBU_TEST ulimit >/dev/null 2>&1 && export BYOBU_ULIMIT="ulimit" || export BYOBU_ULIMIT="false"
 
 # Find a suitable python interpreter, if undefined
 if [ -z "$BYOBU_PYTHON" ]; then

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -302,7 +302,7 @@ get_network_interface() {
 			[ "$Mask" = "00000000" ] && break
 		done < /proc/net/route
 		_RET="$Iface"
-	elif $BYOBU_TEST route >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST route >/dev/null 2>&1; then
 		# Route command on path
 		_RET=$(route get default|grep interface:|awk '{print $2}')
 	elif [ -x "/sbin/route" ]; then
@@ -337,7 +337,7 @@ get_distro() {
 				distro="${issue%% *}";
 			;;
 		esac
-	elif $BYOBU_TEST lsb_release >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST lsb_release >/dev/null 2>&1; then
 		# If lsb_release is available, use it
 		local r=$(lsb_release -s -d)
 		case "$r" in
@@ -351,9 +351,9 @@ get_distro() {
 				distro=$(lsb_release -s -i)
 			;;
 		esac
-	elif $BYOBU_TEST sw_vers >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST sw_vers >/dev/null 2>&1; then
 		distro="$(sw_vers -productName)"
-	elif $BYOBU_TEST uname >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST uname >/dev/null 2>&1; then
 		distro="$(uname -s)"
 	else
 		distro="Byobu"

--- a/usr/lib/byobu/ip_address
+++ b/usr/lib/byobu/ip_address
@@ -48,7 +48,7 @@ __ip_address() {
 				# Background an update
 				if [ -x /sbin/ip ]; then
 					LC_ALL=C /sbin/ip -6 addr list dev "$interface" scope global </dev/null >"$cache" 2>/dev/null &
-				elif $BYOBU_TEST ifconfig >/dev/null 2>&1; then
+				elif eval $BYOBU_TEST ifconfig >/dev/null 2>&1; then
 					LC_ALL=c ifconfig "$interface" | grep "inet6 " | awk '{print $2}' | sed -e "s/%.*//" >"$cache" 2>/dev/null &
 
 				fi
@@ -74,7 +74,7 @@ __ip_address() {
 					ipaddr=$(LC_ALL=C /sbin/ip -4 addr list dev "$interface" scope global 2>/dev/null)
 					ipaddr=${ipaddr#* inet }
 					ipaddr=${ipaddr%%/*}
-				elif $BYOBU_TEST ifconfig >/dev/null 2>&1; then
+				elif eval $BYOBU_TEST ifconfig >/dev/null 2>&1; then
 					ipaddr=$(ifconfig "$interface" | grep "inet " | awk '{print $2}')
 				fi
 			fi

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -36,7 +36,7 @@ __memory() {
 			esac
 			[ -n "${free}" -a -n "${total}" -a -n "${buffers}" -a -n "${cached}" ] && break;
 		done < /proc/meminfo
-	elif $BYOBU_TEST vm_stat >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST vm_stat >/dev/null 2>&1; then
 		# MacOS support
 		# calculation borrowed from http://apple.stackexchange.com/a/48195/18857
 		free_blocks=$(vm_stat | grep free | awk '{ print $3 }' | sed -e 's/\.//')

--- a/usr/lib/byobu/release
+++ b/usr/lib/byobu/release
@@ -46,10 +46,10 @@ __release() {
 				RELEASE="$ver"
 			;;
 		esac
-	elif $BYOBU_TEST sw_vers >/dev/null 2>&1; then
+	elif eval $BYOBU_TEST sw_vers >/dev/null 2>&1; then
 		RELEASE="$(sw_vers -productVersion)"
 	fi
-	if [ -z "$RELEASE" ] && $BYOBU_TEST lsb_release >/dev/null 2>&1; then
+	if [ -z "$RELEASE" ] && eval $BYOBU_TEST lsb_release >/dev/null 2>&1; then
 		# If lsb_release is available, use it
 		RELEASE=$(lsb_release -s -r)
 	fi

--- a/usr/lib/byobu/updates_available
+++ b/usr/lib/byobu/updates_available
@@ -51,25 +51,25 @@ ___update_cache() {
 	if [ -x /usr/lib/update-notifier/apt-check ]; then
 		# If apt-check binary exists, use it
 		flock -xn "$flock" /usr/lib/update-notifier/apt-check 2>&1 | awk '-F;' 'END { print $1, $2 }' >"$mycache" 2>/dev/null &
-	elif $BYOBU_TEST apt-get >/dev/null; then
+	elif eval $BYOBU_TEST apt-get >/dev/null; then
 		# If apt-get exists, use it
 		flock -xn "$flock" apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst >$mycache 2>/dev/null &
-	elif $BYOBU_TEST pkcon >/dev/null; then
+	elif eval $BYOBU_TEST pkcon >/dev/null; then
 		# use packagekit to show list of packages
 		LC_ALL=C flock -xn "$flock" pkcon get-updates -p | awk '/^Results:$/ { start=NR }; /^Security/ { security++ }; END { if (!/There are no updates available at this time./) { print NR-start, security }}' > "$mycache" 2>/dev/null &
-	elif $BYOBU_TEST zypper >/dev/null; then
+	elif eval $BYOBU_TEST zypper >/dev/null; then
 		# If zypper exists, use it
 		flock -xn "$flock" zypper --no-refresh lu --best-effort | grep -c 'v |' >$mycache 2>/dev/null &
-	elif $BYOBU_TEST yum >/dev/null; then
+	elif eval $BYOBU_TEST yum >/dev/null; then
 		# If yum exists, use it
 		# TODO: We need a better way of counting updates available from a RH expert
 		flock -xn "$flock" yum list updates -q | grep -vc "Updated Packages" >$mycache 2>/dev/null &
-	elif $BYOBU_TEST pacman >/dev/null; then
+	elif eval $BYOBU_TEST pacman >/dev/null; then
 		# If pacman (Archlinux) exists, use it
 		LC_ALL=C flock -xn "$flock" pacman -Sup | grep -vc "^\(::\| \)" >$mycache 2>/dev/null &
-	elif $BYOBU_TEST brew >/dev/null; then
+	elif eval $BYOBU_TEST brew >/dev/null; then
 		# If homebrew (Mac OSX) exists, use it, also background if flock exists
-		if $BYOBU_TEST flock; then
+		if eval $BYOBU_TEST flock; then
 			flock -xn "$flock" brew outdated | wc -l >$mycache 2>/dev/null &
 		else
 			brew outdated | wc -l >$mycache &
@@ -83,21 +83,21 @@ ___update_needed() {
 	local mycache=$1
 	# The cache doesn't exist: create it
 	[ ! -e "$mycache" ] && return 0
-	if $BYOBU_TEST apt-get >/dev/null; then
+	if eval $BYOBU_TEST apt-get >/dev/null; then
 		# Debian/ubuntu
 		[ "/var/lib/apt" -nt "$mycache" ] || [ "/var/lib/apt/lists" -nt "$mycache" ]
 		return $?
 	elif [ -e "/var/lib/PackageKit/transactions.db" ]; then
 		[ "/var/lib/PackageKit/transactions.db" -nt "$mycache" ]
 		return $?
-	elif $BYOBU_TEST pacman >/dev/null; then
+	elif eval $BYOBU_TEST pacman >/dev/null; then
 		# Archlinux
 		local db
 		for db in /var/lib/pacman/sync/*.db; do
 			[ "$db" -nt "$mycache" ] && return 0
 		done
 		return 1
-	elif $BYOBU_TEST brew >/dev/null; then
+	elif eval $BYOBU_TEST brew >/dev/null; then
 		# Mac OSX
 		# check if any new versions have been installed since
 		# we last cached. this may not recognize formulae
@@ -114,7 +114,7 @@ ___update_needed() {
 }
 
 __updates_available_detail() {
-	if $BYOBU_TEST apt-get >/dev/null; then
+	if eval $BYOBU_TEST apt-get >/dev/null; then
 		local detail=`apt-get -s -o Debug::NoLocking=true upgrade`
 		if [ "$1" = "--detail" ]; then
 			printf "$detail"


### PR DESCRIPTION
The first issue was that `command -v`, `which` and `type` were always returning an error code when executed without an extra argument. so BYOBU_TEST was always falling to `which` because it was the last one.

The second issue was, `command -v` didn't work because of a different reason. When executed in a shell (at least my shell) using variable substitution, the shell was trying to find a binary called `"command -v"` so it was failing.

My problem was that it took a lot of time running `command-not-found` trying to get the package that may contain the the binary with that name. Always failing :(