### PR TITLE
Use dpkg first when APT is broken

### DIFF
--- a/usr/bin/purge-old-kernels
+++ b/usr/bin/purge-old-kernels
@@ -65,5 +65,11 @@ if [ -z "$PURGE" ]; then
 	exit 0
 fi
 
+if ! apt install --fix-broken --dry-run >/dev/null 2>&1; then
+	echo "APT is broken, trying with dpkg"
+	dpkg --purge $PURGE
+	apt install --fix-broken
+fi
+
 apt $APT_OPTS remove --purge $PURGE
 apt $APT_OPTS autoremove --purge


### PR DESCRIPTION
Hi Dustin,

Sometimes purge-old-kernels won't work if `/boot` is already full and APT was left in a broken state. In such cases, purging old kernels with `dpkg --purge` does the trick, so I hacked this quick recipe.

Feel free to use it or discard it, I just wanted to share it with you in case you find it worthwhile.

Cheers!
Alex
