### PR TITLE
do not use apt autoremove;

### DIFF
--- a/usr/bin/purge-old-kernels
+++ b/usr/bin/purge-old-kernels
@@ -66,4 +66,3 @@ if [ -z "$PURGE" ]; then
 fi
 
 apt $APT_OPTS remove --purge $PURGE
-apt $APT_OPTS autoremove --purge


### PR DESCRIPTION
apt autoremove may remove more kernels than intended. Besides autoremove is not known option in precise/trusty.