### PR TITLE
[Trivial] Fix compatibility with Python 3.6

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -135,6 +135,7 @@ def attach_session(session):
 	else:
 		os.execvp("screen", ["screen", "-AOxRR", session_name])
 
+
 sessions = get_sessions()
 
 show_shell = os.path.exists("%s/.always-select" % (BYOBU_CONFIG_DIR))


### PR DESCRIPTION
This fixes the Byobu build in the Python 3.6 staging PPA for Ubuntu. The error reads:
```
usr/lib/byobu/include/select-session.py:138:1: E305 expected 2 blank lines after class or function definition, found 1
```
After running:
```
pep8 --verbose --repeat --ignore W191,E501 usr/lib/byobu/include/config.py usr/lib/byobu/include/select-session.py
```
This fixes that error by adding that line.