### PR TITLE
Reduce status power usage out of the box

### DIFF
--- a/usr/share/byobu/profiles/common
+++ b/usr/share/byobu/profiles/common
@@ -42,7 +42,7 @@ backtick 12	9999999	9999999		byobu-status color
 backtick 1001 	9999999	9999999		byobu-status screen_upper_left
 backtick 1002 	127	127		byobu-status screen_upper_right
 backtick 1003 	599	599		byobu-status screen_lower_left
-backtick 1004 	2	2		byobu-status screen_lower_right
+backtick 1004 	15	15		byobu-status screen_lower_right
 
 hardstatus alwayslastline
 

--- a/usr/share/byobu/profiles/tmux
+++ b/usr/share/byobu/profiles/tmux
@@ -79,7 +79,7 @@ set -g default-command $SHELL
 
 set -g status-bg $BYOBU_DARK
 set -g status-fg $BYOBU_LIGHT
-set -g status-interval 1
+set -g status-interval 15
 set -g status-left-length 256
 set -g status-right-length 256
 set -g status-left '#(byobu-status tmux_left)'


### PR DESCRIPTION
On a fresh byobu installation on Linux on a new laptop, running `powertop` reports that `byobu-status` is responsible for more than 100 mW of power usage, which is not totally insignificant. This changes the default refresh time to be a bit nicer out of the box, and it can always be customized (at least for tmux?). I wasn't sure if it also made sense to disable time in status by default since it includes seconds.