### PR TITLE
Fix culling sessions with named groups

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -99,10 +99,10 @@ def cull_zombies(session_name):
 		if not output:
 			return
 
-		# Find the master session to extract the group number. We use
+		# Find the master session to extract the group name. We use
 		# the group number to be extra sure the right session is getting
 		# killed. We don't want to accidentally kill the wrong one
-		pattern = "^%s:.+\\((group \\d+)\\).*$" % session_name
+		pattern = "^%s:.+\\((group \\w+)\\).*$" % session_name
 		master = re.search(pattern, output, re.MULTILINE)
 		if not master:
 			return


### PR DESCRIPTION
* tmux 2.4 changed the groups to be names instead of numbers:  tmux/tmux@c6a3446

Example:
```
_ari-19275: 2 windows (created Mon Nov 13 12:03:30 2017) [158x39] (group ari) (attached)
ari: 2 windows (created Fri Nov 10 22:22:27 2017) [158x39] (group ari)
```