### PR TITLE
Fix: use modern SUSE name

### DIFF
--- a/usr/lib/byobu/logo
+++ b/usr/lib/byobu/logo
@@ -124,7 +124,7 @@ __logo() {
 			$MARKUP && printf "$(color u B k)%s$(color -)" "$logo" || printf "$logo"
 		;;
 		*suse*)
-			logo="SuSE"
+			logo="SUSE"
 			$MARKUP && printf "$(color W g)%s$(color -)" "$logo" || printf "$logo"
 		;;
 		*xandros*)


### PR DESCRIPTION
"SuSE" name is an outdated version of it. Use the modern one: SUSE