### PR TITLE
Find python3 path via /usr/bin/env

### DIFF
--- a/usr/lib/byobu/include/config.py.in
+++ b/usr/lib/byobu/include/config.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #    config.py
 #    Copyright (C) 2008 Canonical Ltd.

--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #    select-session.py
 #    Copyright (C) 2010 Canonical Ltd.


### PR DESCRIPTION
This allows python3 binaries located in other directories to be used.

My use case for this is Mac OS X using pyenv.