### PR TITLE
Escape colores in bash prompt

### DIFF
--- a/usr/share/byobu/profiles/bashrc
+++ b/usr/share/byobu/profiles/bashrc
@@ -54,7 +54,7 @@ if [ -n "$TMUX" ] || [ "${TERMCAP#*screen}" != "${TERMCAP}" ]; then
 			;;
 			*)
 				# Use Googley colors (blue / red / yellow / blue / green / red )
-                                PS1="${debian_chroot:+($debian_chroot)}\[\e[31m\]\$(byobu_prompt_status)\[\e[38;5;69m\]\u\[\e[38;5;214m\]@\[\e[38;5;167m\]\h\[\e[38;5;214m\]:\[\e[38;5;71m\]\w\[\e[38;5;214m\]\$(byobu_prompt_symbol)\e[00m\] "
+                                PS1="${debian_chroot:+($debian_chroot)}\[\e[31m\]\$(byobu_prompt_status)\[\e[38;5;69m\]\u\[\e[38;5;214m\]@\[\e[38;5;167m\]\h\[\e[38;5;214m\]:\[\e[38;5;71m\]\w\[\e[38;5;214m\]\$(byobu_prompt_symbol)\[\e[00m\] "
 			;;
 		esac
 	fi


### PR DESCRIPTION
Unescaping colors in bash prompt causes problems with scrolling
history in bash prompt. you can see leftovers from previous
commands when going back by history.
All colors in command prompt should be escaped with \[ \]