### PR TITLE
Make ctail handle files with spaces in their name

### DIFF
--- a/usr/bin/ctail
+++ b/usr/bin/ctail
@@ -20,7 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 if which ccze >/dev/null 2>&1; then
-	tail -F $@ | ccze -A
+	tail -F "$@" | ccze -A
 else
 	echo "ERROR: ccze not found, hint..." 1>&2
 	echo "  sudo apt-get install ccze" 2>&1


### PR DESCRIPTION
Quotes are needed around "$@" to keep parameters from splitting on spaces.