### PR TITLE
Tmux -bg/fg/attr command is deprecated in next version

### DIFF
--- a/usr/lib/byobu/include/mondrian
+++ b/usr/lib/byobu/include/mondrian
@@ -62,10 +62,10 @@ white_color=231
 
 tmux kill-window -t mondrian
 tmux new-window -n mondrian "$BYOBU_PREFIX/lib/byobu/include/mondrian color $white_color" \; \
-	set-option -g pane-active-border-bg colour231 \; \
-	set-option -g pane-active-border-fg black \; \
-	set-option -g pane-border-bg colour231 \; \
-	set-option -g pane-border-fg black \; \
+	set-option -g pane-active-border-style bg=colour231 \; \
+	set-option -g pane-active-border-style fg=black \; \
+	set-option -g pane-border-style bg=colour231 \; \
+	set-option -g pane-border-style fg=black \; \
 	split-window $(get_random_direction) "$BYOBU_PREFIX/lib/byobu/include/mondrian color $white_color" \; \
 	split-window $(get_random_direction) -t $((RANDOM % 2)) "$BYOBU_PREFIX/lib/byobu/include/mondrian color $white_color" \; \
 	split-window $(get_random_direction) -t $((RANDOM % 3)) "$BYOBU_PREFIX/lib/byobu/include/mondrian color $white_color" \; \

--- a/usr/share/byobu/profiles/tmux
+++ b/usr/share/byobu/profiles/tmux
@@ -52,18 +52,18 @@ set-option -g mode-keys vi
 set-option -g mode-style bg=$BYOBU_ACCENT
 set-option -g mode-style fg=$BYOBU_LIGHT
 
-set-window-option -g window-status-style attr=default
+set-window-option -g window-status-style default
 set-window-option -g window-status-style bg=$BYOBU_DARK
 set-window-option -g window-status-style fg=$BYOBU_LIGHT
-set-window-option -g window-status-current-style attr=reverse
+set-window-option -g window-status-current-style reverse
 set-window-option -g window-status-current-style bg=$BYOBU_DARK
 set-window-option -g window-status-current-style fg=$BYOBU_LIGHT
 #set-window-option -g window-status-alert-style bg=$BYOBU_DARK
 #set-window-option -g window-status-alert-style fg=$BYOBU_LIGHT
-#set-window-option -g window-status-alert-style attr=bold
+#set-window-option -g window-status-alert-style bold
 set-window-option -g window-status-activity-style bg=$BYOBU_DARK
 set-window-option -g window-status-activity-style fg=$BYOBU_LIGHT
-set-window-option -g window-status-activity-style attr=bold
+set-window-option -g window-status-activity-style bold
 set-window-option -g automatic-rename on
 set-window-option -g aggressive-resize on
 set-window-option -g monitor-activity on

--- a/usr/share/byobu/profiles/tmux
+++ b/usr/share/byobu/profiles/tmux
@@ -39,9 +39,9 @@ set-window-option -g xterm-keys on
 
 #set-option -g set-titles on
 #set-option -g set-titles-string '#(whoami)@#H - byobu (#S)'
-set-option -g pane-active-border-bg $BYOBU_HIGHLIGHT
-set-option -g pane-active-border-fg $BYOBU_HIGHLIGHT
-set-option -g pane-border-fg $BYOBU_ACCENT
+set-option -g pane-active-border-style bg=$BYOBU_HIGHLIGHT
+set-option -g pane-active-border-style fg=$BYOBU_HIGHLIGHT
+set-option -g pane-border-style fg=$BYOBU_ACCENT
 set-option -g history-limit 100000
 set-option -g display-panes-time 150
 set-option -g display-panes-colour $BYOBU_ACCENT
@@ -49,21 +49,21 @@ set-option -g display-panes-active-colour $BYOBU_HIGHLIGHT
 set-option -g clock-mode-colour $BYOBU_ACCENT
 set-option -g clock-mode-style 24
 set-option -g mode-keys vi
-set-option -g mode-bg $BYOBU_ACCENT
-set-option -g mode-fg $BYOBU_LIGHT
+set-option -g mode-style bg=$BYOBU_ACCENT
+set-option -g mode-style fg=$BYOBU_LIGHT
 
-set-window-option -g window-status-attr default
-set-window-option -g window-status-bg $BYOBU_DARK
-set-window-option -g window-status-fg $BYOBU_LIGHT
-set-window-option -g window-status-current-attr reverse
-set-window-option -g window-status-current-bg $BYOBU_DARK
-set-window-option -g window-status-current-fg $BYOBU_LIGHT
-#set-window-option -g window-status-alert-bg $BYOBU_DARK
-#set-window-option -g window-status-alert-fg $BYOBU_LIGHT
-#set-window-option -g window-status-alert-attr bold
-set-window-option -g window-status-activity-bg $BYOBU_DARK
-set-window-option -g window-status-activity-fg $BYOBU_LIGHT
-set-window-option -g window-status-activity-attr bold
+set-window-option -g window-status-style attr=default
+set-window-option -g window-status-style bg=$BYOBU_DARK
+set-window-option -g window-status-style fg=$BYOBU_LIGHT
+set-window-option -g window-status-current-style attr=reverse
+set-window-option -g window-status-current-style bg=$BYOBU_DARK
+set-window-option -g window-status-current-style fg=$BYOBU_LIGHT
+#set-window-option -g window-status-alert-style bg=$BYOBU_DARK
+#set-window-option -g window-status-alert-style fg=$BYOBU_LIGHT
+#set-window-option -g window-status-alert-style attr=bold
+set-window-option -g window-status-activity-style bg=$BYOBU_DARK
+set-window-option -g window-status-activity-style fg=$BYOBU_LIGHT
+set-window-option -g window-status-activity-style attr=bold
 set-window-option -g automatic-rename on
 set-window-option -g aggressive-resize on
 set-window-option -g monitor-activity on
@@ -79,12 +79,12 @@ set -g terminal-overrides 'xterm*:smcup@:rmcup@'
 #set -g default-command 'exec byobu-shell'
 set -g default-command $SHELL
 
-set -g status-bg $BYOBU_DARK
-set -g status-fg $BYOBU_LIGHT
+set -g status-style bg=$BYOBU_DARK
+set -g status-style fg=$BYOBU_LIGHT
 set -g status-interval 1
 set -g status-left-length 256
 set -g status-right-length 256
 set -g status-left '#(byobu-status tmux_left)'
 set -g status-right '#(byobu-status tmux_right)'$BYOBU_DATE$BYOBU_TIME
-set -g message-bg $BYOBU_ACCENT
-set -g message-fg white
+set -g message-style bg=$BYOBU_ACCENT
+set -g message-style fg=white


### PR DESCRIPTION
On tmux version 1.9 all the styles *-bg/fg/attr were deprecated and replaced with *-style bg=/ fg=/ attribute
In the upcoming version 2.9, this commands are gone and will break byobu style. this fix that issue and mantain compatibility with upcoming tmux versions. 