### PR TITLE
Add Raspbian logo/colors.

### DIFF
--- a/usr/lib/byobu/logo
+++ b/usr/lib/byobu/logo
@@ -115,6 +115,10 @@ __logo() {
 			logo="OWrt"
 			$MARKUP && printf "$(color b colour66 W)%s$(color -)" "$logo" || printf "$logo"
 		;;
+		*raspbian*)
+			logo=" @ "
+			$MARKUP && printf "$(color colour125 colour15)%s$(color -)" "$logo" || printf "$logo"
+		;;
 		*red*hat*|*rhel*)
 			logo=" RH "
 			$MARKUP && printf "$(color R k)%s$(color -)" "$logo" || printf "$logo"


### PR DESCRIPTION
This PR adds logo/color support for Raspbian, the Debian-based Raspberry Pi distro.

The background color is the closest I could match to "Raspberry Pi Red" and the foreground color is white. I couldn't find a clever unicode character for the logo. Since Raspbian is Debian based, I kept the '@' that is used for Debian.