### PR TITLE
Force UTF-8 when attaching in `select-session.py`

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -132,7 +132,7 @@ def attach_session(session):
 	cull_zombies(session_name)
 	# must use the binary, not the wrapper!
 	if backend == "tmux":
-		os.execvp("tmux", ["tmux", "attach", "-t", session_name])
+		os.execvp("tmux", ["tmux", "-u", "attach", "-t", session_name])
 	else:
 		os.execvp("screen", ["screen", "-AOxRR", session_name])
 


### PR DESCRIPTION
Call `tmux attach` with `-u` flag, which forces UTF-8.

This is default in the main script `/usr/bin/byobu`, but not in `select-session.py`, which will cause issues when connecting via ssh. For example, `ssh $SERVER byobu` will show unicode characters as underscores (_).