### PR TITLE
Added FreeBSD memory model

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -99,6 +99,19 @@ __battery() {
 				;;
 			esac
 		done
+	elif [ $(uname -s) = 'FreeBSD' ]; then
+		bat_state=$(sysctl -n hw.acpi.battery.state)
+		if [ "$?" -eq 0 ]; then
+			full=100
+			rem=$(sysctl -n hw.acpi.battery.life)
+			if [ "$bat_state" -eq 1 ]; then
+				state="discharging"
+			elif [ "$bat_state" -eq 2 ]; then
+				state="charging"
+			else
+				state="unknown"
+			fi
+		fi
 	fi
 	if [ $rem -ge 0 ] && [ $full -gt 0 ]; then
 		percent=$(((100*$rem)/$full))

--- a/usr/lib/byobu/cpu_count
+++ b/usr/lib/byobu/cpu_count
@@ -20,12 +20,20 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __cpu_count_detail() {
-	grep -i "^model name" /proc/cpuinfo
+	if [ $(uname -s) = 'Linux' ]; then
+		grep -i "^model name" /proc/cpuinfo
+	elif [ $(uname -s) = 'FreeBSD' ]; then
+		sysctl -n hw.model | gsed 's/\s\+/ /g'
+	fi
 }
 
 __cpu_count() {
 	local c
-	c=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /proc/cpuinfo)
+	if [ $(uname -s) = 'Linux' ]; then
+		c=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /proc/cpuinfo)
+	elif [ $(uname -s) = 'FreeBSD' ]; then
+		c=$(sysctl -n hw.ncpu)
+	fi
 	[ "$c" = "1" ] || printf "%sx" "$c"
 }
 

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -30,12 +30,12 @@ __cpu_freq() {
 		fpdiv $hz "1000000" 1 # 1Ghz
 		freq="$_RET"
 	elif [ -r "/proc/cpuinfo" ]; then
-		if egrep -q -s -i -m 1 "^cpu MHz|^clock" /compat/linux/proc/cpuinfo; then
-			freq=$(egrep -i -m 1 "^cpu MHz|^clock" /compat/linux/proc/cpuinfo | awk -F"[:.]" '{ printf "%01.1f", $2 / 1000 }')
+		if egrep -q -s -i -m 1 "^cpu MHz|^clock" /proc/cpuinfo; then
+			freq=$(egrep -i -m 1 "^cpu MHz|^clock" /proc/cpuinfo | awk -F"[:.]" '{ printf "%01.1f", $2 / 1000 }')
 		else
 			# Must scale frequency by number of processors, if counting bogomips
-			count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /compat/linux/proc/cpuinfo)
-			freq=$(egrep -i -m 1 "^bogomips" /compat/linux/proc/cpuinfo | awk -F"[:.]" '{ print $2 }')
+			count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /proc/cpuinfo)
+			freq=$(egrep -i -m 1 "^bogomips" /proc/cpuinfo | awk -F"[:.]" '{ print $2 }')
 			freq=$(printf "%s %s" "$freq" "$count" | awk '{printf "%01.1f\n", $1/$2/1000}')
 		fi
 	elif [ $(uname -s) = 'FreeBSD' ]; then
@@ -53,7 +53,7 @@ __cpu_freq() {
 			freq="$_RET"
 		fi
 	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null); then
-		fpdiv $hz "1000000000" 1 # 1Ghz
+		'fpdiv $hz "1000000000" 1 # 1Ghz
 		freq="$_RET"
 	fi
 	[ -n "$freq" ] || return

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -53,7 +53,7 @@ __cpu_freq() {
 			freq="$_RET"
 		fi
 	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null); then
-		'fpdiv $hz "1000000000" 1 # 1Ghz
+		fpdiv $hz "1000000000" 1 # 1Ghz
 		freq="$_RET"
 	fi
 	[ -n "$freq" ] || return

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -30,13 +30,27 @@ __cpu_freq() {
 		fpdiv $hz "1000000" 1 # 1Ghz
 		freq="$_RET"
 	elif [ -r "/proc/cpuinfo" ]; then
-		if egrep -q -s -i -m 1 "^cpu MHz|^clock" /proc/cpuinfo; then
-			freq=$(egrep -i -m 1 "^cpu MHz|^clock" /proc/cpuinfo | awk -F"[:.]" '{ printf "%01.1f", $2 / 1000 }')
+		if egrep -q -s -i -m 1 "^cpu MHz|^clock" /compat/linux/proc/cpuinfo; then
+			freq=$(egrep -i -m 1 "^cpu MHz|^clock" /compat/linux/proc/cpuinfo | awk -F"[:.]" '{ printf "%01.1f", $2 / 1000 }')
 		else
 			# Must scale frequency by number of processors, if counting bogomips
-			count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /proc/cpuinfo)
-			freq=$(egrep -i -m 1 "^bogomips" /proc/cpuinfo | awk -F"[:.]" '{ print $2 }')
+			count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /compat/linux/proc/cpuinfo)
+			freq=$(egrep -i -m 1 "^bogomips" /compat/linux/proc/cpuinfo | awk -F"[:.]" '{ print $2 }')
 			freq=$(printf "%s %s" "$freq" "$count" | awk '{printf "%01.1f\n", $1/$2/1000}')
+		fi
+	elif [ $(uname -s) = 'FreeBSD' ]; then
+		# Unless powerd running, this sysctl variable is unavailable.
+		# powerd may also not function in VMs, making this unusable.
+		hz=$(sysctl -in dev.cpu.0.freq)
+		if [ ! -z $hz ]; then
+			fpdiv $hz "1000" 1 # 1GHz
+			freq="$_RET"
+		if [ $(sysctl -n hw.model) =~ 'GHz' ]; then
+			freq=$(sysctl -n hw.model | gsed -e 's/.* //' -e 's/\([0-9]\)0[A-Za-z]\+/\1/')
+		elif [ $(sysctl -n hw.model) =~ 'MHz' ]; then
+			hz=$(sysctl -n hw.model | gsed -e 's/.* //' -e 's/[A-Za-z]\+$//')
+			fpdiv $hz "1000" 1
+			freq="$_RET"
 		fi
 	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null); then
 		fpdiv $hz "1000000000" 1 # 1Ghz

--- a/usr/lib/byobu/logo
+++ b/usr/lib/byobu/logo
@@ -83,6 +83,10 @@ __logo() {
 			logo="<@>"
 			$MARKUP && printf "$(color b W g)%s$(color -)" "$logo" || printf "$logo"
 		;;
+		*freebsd*)
+			logo="^O^"
+			$MARKUP && printf "$(color R k b)%s$(color -)" "$logo" || printf "$logo"
+		;;
 		*gentoo*)
 			logo=" > "
 			$MARKUP && printf "$(color b c w)%s$(color -)" "$logo" || printf "$logo"

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -36,6 +36,18 @@ __memory() {
 			esac
 			[ -n "${free}" -a -n "${total}" -a -n "${buffers}" -a -n "${cached}" ] && break;
 		done < /proc/meminfo
+	elif [ $(uname) = 'FreeBSD']; then
+		# FreeBSD support
+		# Adapted from https://www.cyberciti.biz/files/scripts/freebsd-memory.pl.txt
+		# Copyright (c) 2003-2004 Ralf S. Engelschall <rse@engelschall.com>
+		total=$(($(sysctl -n hw.physmem)/1024))
+		page_size=$(sysctl -n hw.pagesize)
+		vm_inactive=$(($(sysctl -n vm.stats.vm.v_inactive_count)*$page_size))
+		vm_cached=$(($(sysctl -n vm.stats.vm.v_cache_count)*$page_size))
+		vm_free=$(($(sysctl -n vm.stats.vm.v_free_count)*$page_size))
+		free=$((($vm_cached+$vm_free+$vm_inactive)/1024))
+		buffers=0
+		cached=0
 	elif eval $BYOBU_TEST vm_stat >/dev/null 2>&1; then
 		# MacOS support
 		# calculation borrowed from http://apple.stackexchange.com/a/48195/18857
@@ -48,12 +60,12 @@ __memory() {
 		buffers=0
 		cached=0
 	fi
-        kb_main_used=$(($total-$free))
-        buffers_plus_cached=$(($buffers+$cached))
-        # "free output" buffers and cache (output from 'free')
-        fo_buffers=$(($kb_main_used - $buffers_plus_cached))
-        fpdiv $((100*${fo_buffers})) "${total}" 0;
-        usage=${_RET}
+	kb_main_used=$(($total-$free))
+	buffers_plus_cached=$(($buffers+$cached))
+	# "free output" buffers and cache (output from 'free')
+	fo_buffers=$(($kb_main_used - $buffers_plus_cached))
+	fpdiv $((100*${fo_buffers})) "${total}" 0;
+	usage=${_RET}
 	if [ $total -ge 1048576 ]; then
 		fpdiv "$total" 1048567 1
 		total=${_RET}

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -36,7 +36,7 @@ __memory() {
 			esac
 			[ -n "${free}" -a -n "${total}" -a -n "${buffers}" -a -n "${cached}" ] && break;
 		done < /proc/meminfo
-	elif [ $(uname) = 'FreeBSD' ]; then
+	elif [ $(uname -s) = 'FreeBSD' ]; then
 		# FreeBSD support
 		# Adapted from https://www.cyberciti.biz/files/scripts/freebsd-memory.pl.txt
 		# Copyright (c) 2003-2004 Ralf S. Engelschall <rse@engelschall.com>

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -36,7 +36,7 @@ __memory() {
 			esac
 			[ -n "${free}" -a -n "${total}" -a -n "${buffers}" -a -n "${cached}" ] && break;
 		done < /proc/meminfo
-	elif [ $(uname) = 'FreeBSD']; then
+	elif [ $(uname) = 'FreeBSD' ]; then
 		# FreeBSD support
 		# Adapted from https://www.cyberciti.biz/files/scripts/freebsd-memory.pl.txt
 		# Copyright (c) 2003-2004 Ralf S. Engelschall <rse@engelschall.com>


### PR DESCRIPTION
Added code to the memory widget to correctly handle the FreeBSD memory model.

This is the first of many changes I hope to make for FreeBSD support. This is step 1 in removing the need for the Linux compatibility procfs.