### PR TITLE
* usr/lib/byobu/include/select-session.py: LP: #1750430

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -80,7 +80,7 @@ def get_sessions():
 		if output:
 			for s in output.splitlines():
 				# Ignore hidden sessions (named sessions that start with a "_")
-				if s and not s.startswith("_"):
+				if s and not s.startswith("_") and s.find("-") == -1:
 					text.append("tmux: %s" % s.strip())
 					sessions.append("tmux____%s" % s.split(":")[0])
 					i += 1
@@ -132,7 +132,10 @@ def attach_session(session):
 	cull_zombies(session_name)
 	# must use the binary, not the wrapper!
 	if backend == "tmux":
-		os.execvp("tmux", ["tmux", "-u", "attach", "-t", session_name])
+		if reuse_sessions:
+			os.execvp("tmux", ["tmux", "-u", "new-session", "-t", session_name, ";", "set-option", "destroy-unattached"])
+		else:
+			os.execvp("tmux", ["tmux", "-u", "attach", "-t", session_name])
 	else:
 		os.execvp("screen", ["screen", "-AOxRR", session_name])
 


### PR DESCRIPTION
- commit edeae41 fixed the excessive creation of sessions by not
creating different sessions. This commit adjust the behavior in a way
that having .reuse-sessions enabled tmux will properly attach and remove
sessions when dettaching and will also kill the last session available.
- When more than two sessions exist, tmux asks which session to use