### PR TITLE
byobu.desktop Exec command options

### DIFF
--- a/usr/share/byobu/desktop/byobu.desktop
+++ b/usr/share/byobu/desktop/byobu.desktop
@@ -2,7 +2,7 @@
 Name=Byobu Terminal
 Comment=Advanced Command Line and Text Window Manager
 Icon=byobu
-Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -- byobu
+Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -- byobu -S new-session
 Type=Application
 Categories=GNOME;GTK;System;Utility;TerminalEmulator;
 StartupWMClass=us.kirkland.terminals.byobu

--- a/usr/share/byobu/desktop/byobu.desktop
+++ b/usr/share/byobu/desktop/byobu.desktop
@@ -2,7 +2,7 @@
 Name=Byobu Terminal
 Comment=Advanced Command Line and Text Window Manager
 Icon=byobu
-Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -e byobu
+Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -- byobu
 Type=Application
 Categories=GNOME;GTK;System;Utility;TerminalEmulator;
 StartupWMClass=us.kirkland.terminals.byobu


### PR DESCRIPTION
Minor change: Use `--` in place of **deprecated** `-e` to execute `byobu`.

Addition:          Open new `byobu` session with `-S new-session` to avoid multiple windows with same session, restricting session size to smallest window.