### PR TITLE
Fix battery for OSX

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -81,7 +81,7 @@ __battery() {
 		# MacOS support
 		local key
 		for key in CurrentCapacity MaxCapacity ExternalChargeCapable FullyCharged; do
-			line=$(/usr/sbin/ioreg -n AppleSmartBattery -w0 | grep $key | sed -e 's/|//g' | awk '{ print $3 }')
+			line=$(/usr/sbin/ioreg -n AppleSmartBattery -w0 | grep -w $key | sed -e 's/|//g' | awk '{ print $3 }')
 			case "$key" in
 				CurrentCapacity) rem="$line";;
 				MaxCapacity) full="$line";;


### PR DESCRIPTION
Use word-regexp for osx cause we have "AppleRawCurrentCapacity" and "CurrentCapacity"