### PR TITLE
Add support for battery status indicator on termux

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -100,6 +100,13 @@ __battery() {
 			esac
 		done
 	fi
+	# Android Termux support
+	if eval $BYOBU_TEST termux-battery-status -h >/dev/null 2>&1; then
+		BATTERY_STATUS=$(termux-battery-status)
+		full=100
+		rem=$(printf "%s" "$BATTERY_STATUS" | awk '/percentage/ { gsub(/[,]/,""); print $2}')
+		state=$(printf "%s" "$BATTERY_STATUS" | awk '/status/ { gsub(/[",]/,""); print $2}')
+	fi
 	if [ $rem -ge 0 ] && [ $full -gt 0 ]; then
 		percent=$(((100*$rem)/$full))
 		if [ "$percent" -lt 33 ]; then


### PR DESCRIPTION
Hi @dustinkirkland ,

Thank you for this awesome utility. I have been using byobu for many years, and have recently started using this on Android via Termux

### Background of this pull request
I noticed that the battery status indicator does not work on the Termux app in Android

### Details of this pull request
Proposed change uses the `termux-battery-status` API from the "Termux:API" app to get the battery status of the android device


### Requirements

1. An Android device
2. Termux ([Play Store](https://play.google.com/store/apps/details?id=com.termux)) ([F-Droid](https://f-droid.org/en/packages/com.termux/))
3. Termux:API ([Play Store](https://play.google.com/store/apps/details?id=com.termux.api)) ([F-Droid](https://f-droid.org/en/packages/com.termux.api/))
