### PR TITLE
Fix disk_io notification bug

### DIFF
--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -62,7 +62,7 @@ __disk_io() {
 		if [ $t2 -le $t1 ]; then
 			rate=0
 		else
-			[ -r "$cache" ] && read x1 < "$cache" || x1=0
+			[ -r "$cache" ] && read x1 < "$cache"
 			local a1= a2= a3= a4= a5= a6= a7= a8= a9= a10=
 			read a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 other < "/sys/block/$disk/stat"
 			if [ "$i" = "read" ]; then


### PR DESCRIPTION
This fixes a bug that makes disk_io stats incorrect and forever increasing, due to the "baseline" stats always being 0.

[This commit](https://github.com/dustinkirkland/byobu/commit/e991e535e44a7809c9150d32527ca6fa3d2baba3) intended to catch read failures, but actually just always sets x1 to 0. This is because "read" returns 1 if no newline is read, and the code doesn't write a newline to $cache.

Instead, this just always trusts that read works, as x1 is set even if there's no newline. A more robust way might be via cat.