### PR TITLE
replace deprecated option -e with --

### DIFF
--- a/usr/share/byobu/desktop/byobu.desktop
+++ b/usr/share/byobu/desktop/byobu.desktop
@@ -2,7 +2,7 @@
 Name=Byobu Terminal
 Comment=Advanced Command Line and Text Window Manager
 Icon=byobu
-Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -e byobu
+Exec=gnome-terminal --app-id us.kirkland.terminals.byobu --class=us.kirkland.terminals.byobu -- byobu
 Type=Application
 Categories=GNOME;GTK;System;Utility;TerminalEmulator;
 StartupWMClass=us.kirkland.terminals.byobu


### PR DESCRIPTION
Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
Use “-- ” to terminate the options and put the command line to execute after it.