### PR TITLE
Fix F-KEY disable

### DIFF
--- a/usr/share/byobu/keybindings/f-keys.tmux.disable
+++ b/usr/share/byobu/keybindings/f-keys.tmux.disable
@@ -78,7 +78,7 @@ unbind-key -n C-F9
 unbind-key -n M-F11
 unbind-key -n C-F11
 unbind-key -n S-F11
-bind-key -n S-F12 source $BYOBU_PREFIX/share/byobu/keybindings/f-keys.tmux \; source $HOME/.byobu/keybindings.tmux \; display-message "Byobu F-keys: ENABLED"
+bind-key -n S-F12 source $BYOBU_PREFIX/share/byobu/keybindings/f-keys.tmux \; source $BYOBU_CONFIG_DIR/keybindings.tmux \; display-message "Byobu F-keys: ENABLED"
 unbind-key -n M-F12
 unbind-key -n C-S-F12
 unbind-key -n M-IC


### PR DESCRIPTION
When you use `~/.config/byobu` instead of `~/.byobu` for configuration directory, `Shift+F12` did not work
correctly with tmux backend.