### PR TITLE
Extend home directory ownership test for non-standard setups

### DIFF
--- a/usr/bin/byobu.in
+++ b/usr/bin/byobu.in
@@ -24,8 +24,8 @@ PKG="byobu"
 # All sorts of things go wrong if you don't own your $HOME dir.
 # This happens under sudo, if you don't use the -H option; Byobu will
 # create a bunch of files in your $HOME which will be owned by root.
-if [ ! -O "$HOME" ]; then
-	echo "Cannot run $PKG because [$USER] does not own [$HOME]" 1>&2
+if [ ! -O "$HOME" ] && [ ! -O "$HOME/.profile" ]; then
+	echo "Cannot run $PKG because [$USER] does not own [$HOME] or [$HOME/.profile]" 1>&2
 	if [ -n "$SUDO_USER" ]; then
 		echo "To run $PKG under sudo, you MUST use 'sudo -H'" 1>&2
 	fi


### PR DESCRIPTION
Various networked environments exist where a user's home directory is not owned by that user:

```
$ls -ld $HOME
drwx------ 139 root daemon 28672 Nov 30 10:48 /home/userfs/j/jonathon
```

With this patch Byobu checks ownership of `$HOME/.profile` too, as a default inclusion of `/etc/skel`.