### PR TITLE
Fixed --hostname argument typo in documentation

### DIFF
--- a/usr/bin/byobu-select-profile.in
+++ b/usr/bin/byobu-select-profile.in
@@ -63,7 +63,7 @@ Usage: $0 [OPTION]
     -l,--list                list available profiles
     -b,--background COLOR    set the background color
     -f,--foreground COLOR    set the foreground color
-    -h,--hostnmae            set the colors based on a hash of the hostname
+    -h,--hostname            set the colors based on a hash of the hostname
     -i,--ip                  set the colors based on a hash of the ip
     -r,--random              set the colors randomly
     --help                   this help

--- a/usr/share/man/man1/byobu-select-profile.1
+++ b/usr/share/man/man1/byobu-select-profile.1
@@ -13,7 +13,7 @@ byobu\-select\-profile \- select your Byobu foreground and background colors
 
     -f,--foreground COLOR    set the foreground color
 
-    -h,--hostnmae            set the colors based on a hash of the hostname
+    -h,--hostname            set the colors based on a hash of the hostname
 
     -i,--ip                  set the colors based on a hash of the ip
 


### PR DESCRIPTION
There is a typo in the `usr/share/man/man1/byobu-select-profile.1` and `usr/bin/byobu-select-profile.in` where the documentation mentions the argument `--hostnmae` instead of `--hostname`. The typo can be seen when executing the command `byobu-select-profile` without any arguments.

I fixed that, swapping a couple of letters a couple of times as you can see :)