### PR TITLE
Fix for VSCode, fish and byobu installations

### DIFF
--- a/usr/bin/byobu-launcher-install.in
+++ b/usr/bin/byobu-launcher-install.in
@@ -49,7 +49,9 @@ install_launcher() {
 
 install_launcher_fish() {
 	$PKG-launcher-uninstall "$1" || true
-	printf "status --is-login; and status --is-interactive; and exec byobu-launcher" >> "$1"
+	printf "if not set -q VSCODE_CWD" >> "$1"
+	printf "  status --is-login; and status --is-interactive; and exec byobu-launcher" >> "$1"
+	printf "end" >> "$1"
 }
 
 # Sanitize the environment


### PR DESCRIPTION
This code fixes the problem on VSCode "Unable to resolve your shell environment: Unexpected exit code from spawned shell (code 1, signal null)"

This happens when fish and byobu installed, and VSCode is started from the Unity bar (or the dock on Gnome). I believe VSCode has a "shell inspector" on it's startup to detect what type of shell it should integrate. 

![image](https://user-images.githubusercontent.com/1264354/197241390-4eac01cb-f7a0-47e8-9437-e7fe9c181886.png)
