### PR TITLE
add synopsis to man byobu-ctrl-a

### DIFF
--- a/usr/share/man/man1/byobu-ctrl-a.1
+++ b/usr/share/man/man1/byobu-ctrl-a.1
@@ -2,6 +2,11 @@
 .SH NAME
 byobu\-ctrl\-a \- Configure Byobu's ctrl-a behavior
 
+.SH SYNOPSIS
+.B byobu-ctrl-a
+['screen'|'tmux']
+[key]
+
 .SH DESCRIPTION
 \fBbyobu\-ctrl\-a\fP is an interactive program that allows a user to configure the behavior of the 'ctrl-a' key sequence.
 


### PR DESCRIPTION
man(1) of `byobu-ctrl-a` shows optional arguments for setting ctrl-a behavior non-interactively