### PR TITLE
Replace $HOME/.byobu by $BYOBU_CONFIG_DIR

### DIFF
--- a/usr/share/byobu/keybindings/f-keys.tmux.disable
+++ b/usr/share/byobu/keybindings/f-keys.tmux.disable
@@ -78,7 +78,7 @@ unbind-key -n C-F9
 unbind-key -n M-F11
 unbind-key -n C-F11
 unbind-key -n S-F11
-bind-key -n S-F12 source $BYOBU_PREFIX/share/byobu/keybindings/f-keys.tmux \; source $HOME/.byobu/keybindings.tmux \; display-message "Byobu F-keys: ENABLED"
+bind-key -n S-F12 source $BYOBU_PREFIX/share/byobu/keybindings/f-keys.tmux \; source $BYOBU_CONFIG_DIR/keybindings.tmux \; display-message "Byobu F-keys: ENABLED"
 unbind-key -n M-F12
 unbind-key -n C-S-F12
 unbind-key -n M-IC


### PR DESCRIPTION
The man page says that the byobu config directory is configurable (see [link](https://github.com/dustinkirkland/byobu/blob/bfb7a763d0ea458b310962a4fd7538420f613b6b/usr/share/man/man1/byobu.1#L19)). Therefore, the respective variable `$BYOBU_CONFIG_DIR` should be used instead of a hard-coded home-path.