### PR TITLE
bashrc: export BYOBU_RUN_DIR and BYOBU_PREFIX

### DIFF
--- a/usr/share/byobu/profiles/bashrc
+++ b/usr/share/byobu/profiles/bashrc
@@ -25,6 +25,8 @@ case "$TERM" in
 esac
 [ -n "$BYOBU_CHARMAP" ] || BYOBU_CHARMAP=$(locale charmap 2>/dev/null || echo)
 [ -z "$USER" ] && export USER=$(whoami)
+[ -z "$BYOBU_RUN_DIR" ] && export BYOBU_RUN_DIR=/tmp
+[ -z "$BYOBU_PREFIX" ] && export BYOBU_PREFIX=/usr
 byobu_prompt_status() { local e=$?; [ $e != 0 ] && echo -e " $e "; }
 byobu_prompt_symbol() { [ "$USER" = "root" ] && printf "%s" "#" || printf "%s" "\$"; }
 byobu_prompt_runtime() {


### PR DESCRIPTION
This is to address https://launchpad.net/bugs/2051995 where users will see the phrase

bash: /timer.6217: Permission denied

Whenever any command is ran. This occurs because byobu-prompt uses this bashrc and tries to write to $BYOBU_RUN_DIR/timer.$$ but BYOBU_RUN_DIR is not yet defined. This caused byobu to try to write to /timer.$$ which fails as a regular user.

Also added BYOBU_PREFIX in-case the user sets BYOBU_DISTRO to Ubuntu.