### PR TITLE
fixes Ubuntu #2067490: don't output byobu_prompt_runtime to stderr

### DIFF
--- a/usr/share/byobu/profiles/bashrc
+++ b/usr/share/byobu/profiles/bashrc
@@ -52,7 +52,7 @@ byobu_prompt_runtime() {
 	[ "$hours" = "0" ] && hours= || hours="${hours}h "
 	[ "$minutes" = "0" ] && minutes= || minutes="${minutes}m "
 	str="${days}${hours}${minutes}${seconds}.${microseconds}s"
-	printf "[%s] " "$str" 1>&2
+	printf "[%s] " "$str"
 }
 # Requires Bash 4.x
 export PS0='$(printf "%s" ${EPOCHREALTIME/./} >"$BYOBU_RUN_DIR/timer.$$")'


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/byobu/+bug/2067490