### PR TITLE
use VERSION in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([byobu], [5.121], [http://byobu.org])
+AC_INIT([byobu], [6.12], [http://byobu.org])
 AC_CONFIG_SRCDIR([usr/bin/byobu.in])
 AM_INIT_AUTOMAKE([foreign])
 AC_PROG_LN_S

--- a/usr/bin/byobu.in
+++ b/usr/bin/byobu.in
@@ -18,7 +18,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-VERSION=6.12
+VERSION=@VERSION@
 PKG="byobu"
 
 # All sorts of things go wrong if you don't own your $HOME dir.


### PR DESCRIPTION
The generated usr/bin/byobu did not track the version specified in configure.ac (via the AC_INIT macro) which lead to an incorrect naming of the distribution file when using "make dist".

This commit makes usr/bin/byobu.in reference the autoconf VERSION variable (derived from the AC_INIT macro) to ensure that there is one source of version information.