### PR TITLE
Allow for different numeric format in EPOCHREALTIME for non-English locale

### DIFF
--- a/usr/share/byobu/profiles/bashrc
+++ b/usr/share/byobu/profiles/bashrc
@@ -37,8 +37,8 @@ byobu_prompt_runtime() {
 	local starttime endtime duration days hours minutes seconds microseconds nanoseconds str
 	[ ! -r $BYOBU_RUN_DIR/timer.$$ ] && printf "[0.000s]" && return
 	read starttime < $BYOBU_RUN_DIR/timer.$$ 2>/dev/null || true
-	endtime=${EPOCHREALTIME/./}
-	starttime=${starttime/./}
+	endtime=${EPOCHREALTIME/[^0-9]/}
+	starttime=${starttime/[^0-9]/}
 	duration=$((endtime - starttime))
 	days=$((duration/1000000/60/60/24))
 	hours=$((duration/1000000/60/60%24))
@@ -55,7 +55,7 @@ byobu_prompt_runtime() {
 	printf "[%s] " "$str" 1>&2
 }
 # Requires Bash 4.x
-export PS0='$(printf "%s" ${EPOCHREALTIME/./} >"$BYOBU_RUN_DIR/timer.$$")'
+export PS0='$(printf "%s" ${EPOCHREALTIME/[^0-9]/} >"$BYOBU_RUN_DIR/timer.$$")'
 
 case "$BYOBU_DISTRO" in
 	"Ubuntu")


### PR DESCRIPTION
For German and Czech locale, the format of EPOCHREALTIME is with decimal comma, not decimal dot. This breaks byobu PS1 prompt.

See for example https://askubuntu.com/questions/1515032/ubuntu-server-24-04-print-0-004s-or-bash-1716451538-009859-value-too-great-f

This patch aims at making the removal of decimal marker independant of what the decimal separator actually is. It should also work in case there are other non-numeric characters in the string like spaces separating thousands, etc...

To try out different formats that EPOCHREALTIME can be depending on locale, try:

```
$ LC_ALL=C bash -c 'echo $EPOCHREALTIME'
1737532802.890318

$ LC_ALL=cs_CZ.UTF-8 bash -c 'echo $EPOCHREALTIME'
1737532826,238379
```