### PR TITLE
Fix BSD portability issues in status scripts

### DIFF
--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -42,7 +42,7 @@ __cpu_freq() {
 				freq=$(dmidecode -t processor 2>/dev/null | awk -F': ' '/Current Speed:/ { print $2; exit }' | awk '{ printf "%01.1f", $1 / 1000 }')
 			fi
 		fi
-	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null); then
+	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null) && [ -n "$hz" ]; then
 		fpdiv $hz "1000000000" 1 # 1Ghz
 		freq="$_RET"
 	fi

--- a/usr/lib/byobu/disk
+++ b/usr/lib/byobu/disk
@@ -28,7 +28,13 @@ __disk() {
 	# Default to /, but let users override
 	[ -z "$MONITORED_DISK" ] && MP="/" || MP="$MONITORED_DISK"
 	case $MP in
-		/dev/*) MP=$(awk '$1 == m { print $2; exit(0); }' "m=$MP" /proc/mounts);;
+		/dev/*)
+			if [ -r /proc/mounts ]; then
+				MP=$(awk '$1 == m { print $2; exit(0); }' "m=$MP" /proc/mounts)
+			else
+				MP=$(mount | awk -v m="$MP" '$1 == m { print $3; exit(0); }')
+			fi
+		;;
 	esac
 	# this could be done faster with 'stat --file-system --format'
 	# but then we'd have to do blocks -> human units ourselves

--- a/usr/lib/byobu/include/cycle-status
+++ b/usr/lib/byobu/include/cycle-status
@@ -35,7 +35,7 @@ for i in $all $all; do
 done
 
 # Disable all
-sed -i -e "s/^tmux_right=/#tmux_right=/" "$BYOBU_CONFIG_DIR/status"
+$BYOBU_SED_INLINE -e "s/^tmux_right=/#tmux_right=/" "$BYOBU_CONFIG_DIR/status"
 
 # Enable the next one
-sed -i -e "${next}s/^#tmux_right=/tmux_right=/" "$BYOBU_CONFIG_DIR/status"
+$BYOBU_SED_INLINE -e "${next}s/^#tmux_right=/tmux_right=/" "$BYOBU_CONFIG_DIR/status"

--- a/usr/lib/byobu/include/dirs.in
+++ b/usr/lib/byobu/include/dirs.in
@@ -44,7 +44,7 @@ fi
 [ -r "$BYOBU_CONFIG_DIR/socketdir" ] && . "$BYOBU_CONFIG_DIR/socketdir"
 
 # Create and export the runtime cache directory
-if [ -w /dev/shm ]; then
+if [ -d /dev/shm ] && [ -w /dev/shm ]; then
 	# Use shm for performance, if possible
 	for i in /dev/shm/$PKG-$USER-*; do
 		if [ -d "$i" ] && [ -O "$i" ]; then

--- a/usr/lib/byobu/include/toggle-utf8.in
+++ b/usr/lib/byobu/include/toggle-utf8.in
@@ -25,14 +25,14 @@ PKG="byobu"
 
 if [ "$BYOBU_CHARMAP" = "UTF-8" ]; then
 	if grep -qs "^BYOBU_CHARMAP=" $BYOBU_CONFIG_DIR/statusrc 2>/dev/null; then
-		sed -i -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=x/" $BYOBU_CONFIG_DIR/statusrc
+		$BYOBU_SED_INLINE -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=x/" $BYOBU_CONFIG_DIR/statusrc
 	else
 		echo "BYOBU_CHARMAP=x" >> $BYOBU_CONFIG_DIR/statusrc
 	fi
 	export BYOBU_CHARMAP=x
 else
 	if grep -qs "^BYOBU_CHARMAP=" $BYOBU_CONFIG_DIR/statusrc 2>/dev/null; then
-		sed -i -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=UTF-8/" $BYOBU_CONFIG_DIR/statusrc
+		$BYOBU_SED_INLINE -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=UTF-8/" $BYOBU_CONFIG_DIR/statusrc
 	else
 		echo "BYOBU_CHARMAP=UTF-8" >> $BYOBU_CONFIG_DIR/statusrc
 	fi

--- a/usr/lib/byobu/ip_address
+++ b/usr/lib/byobu/ip_address
@@ -34,7 +34,13 @@ __ip_address() {
 		interface="$MONITORED_NETWORK"
 	else
 		case "$IPV6" in
-			1|true|yes) interface=$(awk '$10 != "lo" { iface=$10 ; }; END { print iface; }' /proc/net/ipv6_route);;
+			1|true|yes)
+				if [ -r /proc/net/ipv6_route ]; then
+					interface=$(awk '$10 != "lo" { iface=$10 ; }; END { print iface; }' /proc/net/ipv6_route)
+				else
+					get_network_interface; interface="$_RET"
+				fi
+			;;
 			*) get_network_interface; interface="$_RET";;
 		esac
 	fi


### PR DESCRIPTION
## Summary

- Use `$BYOBU_SED_INLINE` instead of hardcoded `sed -i` in `cycle-status`
  and `toggle-utf8` (BSD sed requires different `-i` syntax)
- Fall back to `mount` command when `/proc/mounts` is unavailable (`disk`)
- Fall back to `get_network_interface` when `/proc/net/ipv6_route` is
  missing (`ip_address`)
- Check `/dev/shm` exists before testing writability (`dirs.in`)
- Guard `hw.cpufrequency` sysctl against empty output (`cpu_freq`)