### PR TITLE
Add OpenBSD support for status indicators

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -22,7 +22,7 @@
 
 __battery_detail() {
 	local bat
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		apm 2>/dev/null || true
 		return
 	fi
@@ -38,7 +38,7 @@ __battery() {
 	# Linux support
 	present=""; full="0"; rem="0"; state=""
 	# OpenBSD support via apm(8)
-	if [ "$(uname -s)" = "OpenBSD" ] && eval $BYOBU_TEST apm >/dev/null 2>&1; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ] && eval $BYOBU_TEST apm >/dev/null 2>&1; then
 		local apm_pct apm_ac
 		apm_pct=$(apm -l 2>/dev/null)
 		apm_ac=$(apm -a 2>/dev/null)

--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -22,6 +22,10 @@
 
 __battery_detail() {
 	local bat
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		apm 2>/dev/null || true
+		return
+	fi
 	for bat in /proc/acpi/battery/*; do
 		cat "$bat/info"
 		cat "$bat/state"
@@ -33,6 +37,24 @@ __battery() {
 	local bat line present sign state percent full rem color bcolor
 	# Linux support
 	present=""; full="0"; rem="0"; state=""
+	# OpenBSD support via apm(8)
+	if [ "$(uname -s)" = "OpenBSD" ] && eval $BYOBU_TEST apm >/dev/null 2>&1; then
+		local apm_pct apm_ac
+		apm_pct=$(apm -l 2>/dev/null)
+		apm_ac=$(apm -a 2>/dev/null)
+		if [ -n "$apm_pct" ] && [ "$apm_pct" != "255" ]; then
+			rem="$apm_pct"
+			full="100"
+			present="1"
+			case "$apm_ac" in
+				0) state="discharging" ;;
+				1) state="charging" ;;
+				2) state="charged" ;;
+				*) state="unknown" ;;
+			esac
+		fi
+	fi
+	if [ -z "$present" ]; then
 	for bat in $BATTERY /sys/class/power_supply/* /proc/acpi/battery/*; do
 		case "$bat" in
 			/sys/*)
@@ -100,6 +122,7 @@ __battery() {
 			esac
 		done
 	fi
+	fi  # end non-OpenBSD block
 	# Android Termux support
 	if eval $BYOBU_TEST termux-battery-status -h >/dev/null 2>&1; then
 		BATTERY_STATUS=$(termux-battery-status)

--- a/usr/lib/byobu/cpu_count
+++ b/usr/lib/byobu/cpu_count
@@ -20,12 +20,16 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __cpu_count_detail() {
-	grep -i "^model name" /proc/cpuinfo
+	if [ -r /proc/cpuinfo ]; then
+		grep -i "^model name" /proc/cpuinfo
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		sysctl -n hw.model 2>/dev/null
+	fi
 }
 
 __cpu_count() {
 	local c
-	c=$(getconf _NPROCESSORS_ONLN 2>/dev/null || grep -ci "^processor" /proc/cpuinfo)
+	c=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpuonline 2>/dev/null || grep -ci "^processor" /proc/cpuinfo 2>/dev/null || echo 1)
 	[ "$c" = "1" ] || printf "%sx" "$c"
 }
 

--- a/usr/lib/byobu/cpu_count
+++ b/usr/lib/byobu/cpu_count
@@ -22,7 +22,7 @@
 __cpu_count_detail() {
 	if [ -r /proc/cpuinfo ]; then
 		grep -i "^model name" /proc/cpuinfo
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		sysctl -n hw.model 2>/dev/null
 	fi
 }

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -20,7 +20,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __cpu_freq_detail() {
-	cat /proc/cpuinfo
+	if [ -r /proc/cpuinfo ]; then
+		cat /proc/cpuinfo
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		sysctl hw.cpuspeed hw.setperf 2>/dev/null
+	fi
 }
 
 __cpu_freq() {
@@ -42,6 +46,10 @@ __cpu_freq() {
 				freq=$(dmidecode -t processor 2>/dev/null | awk -F': ' '/Current Speed:/ { print $2; exit }' | awk '{ printf "%01.1f", $1 / 1000 }')
 			fi
 		fi
+	elif [ "$(uname -s)" = "OpenBSD" ] && hz=$(sysctl -n hw.cpuspeed 2>/dev/null) && [ -n "$hz" ]; then
+		# OpenBSD: hw.cpuspeed is in MHz
+		fpdiv $hz "1000" 1
+		freq="$_RET"
 	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null) && [ -n "$hz" ]; then
 		fpdiv $hz "1000000000" 1 # 1Ghz
 		freq="$_RET"

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -22,7 +22,7 @@
 __cpu_freq_detail() {
 	if [ -r /proc/cpuinfo ]; then
 		cat /proc/cpuinfo
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		sysctl hw.cpuspeed hw.setperf 2>/dev/null
 	fi
 }
@@ -46,7 +46,7 @@ __cpu_freq() {
 				freq=$(dmidecode -t processor 2>/dev/null | awk -F': ' '/Current Speed:/ { print $2; exit }' | awk '{ printf "%01.1f", $1 / 1000 }')
 			fi
 		fi
-	elif [ "$(uname -s)" = "OpenBSD" ] && hz=$(sysctl -n hw.cpuspeed 2>/dev/null) && [ -n "$hz" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ] && hz=$(sysctl -n hw.cpuspeed 2>/dev/null) && [ -n "$hz" ]; then
 		# OpenBSD: hw.cpuspeed is in MHz
 		fpdiv $hz "1000" 1
 		freq="$_RET"

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -42,7 +42,7 @@ __cpu_freq() {
 				freq=$(dmidecode -t processor 2>/dev/null | awk -F': ' '/Current Speed:/ { print $2; exit }' | awk '{ printf "%01.1f", $1 / 1000 }')
 			fi
 		fi
-	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null); then
+	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null) && [ -n "$hz" ]; then
 		fpdiv $hz "1000000000" 1 # 1Ghz
 		freq="$_RET"
 	fi

--- a/usr/lib/byobu/cpu_freq
+++ b/usr/lib/byobu/cpu_freq
@@ -48,10 +48,10 @@ __cpu_freq() {
 		fi
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ] && hz=$(sysctl -n hw.cpuspeed 2>/dev/null) && [ -n "$hz" ]; then
 		# OpenBSD: hw.cpuspeed is in MHz
-		fpdiv $hz "1000" 1
+		fpdiv "$hz" "1000" 1
 		freq="$_RET"
 	elif hz=$(sysctl -n hw.cpufrequency 2>/dev/null) && [ -n "$hz" ]; then
-		fpdiv $hz "1000000000" 1 # 1Ghz
+		fpdiv "$hz" "1000000000" 1 # 1Ghz
 		freq="$_RET"
 	fi
 	[ -n "$freq" ] || return

--- a/usr/lib/byobu/cpu_temp
+++ b/usr/lib/byobu/cpu_temp
@@ -36,11 +36,13 @@ __cpu_temp() {
 	local i t unit
 	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: read CPU temperature from hw.sensors
-		t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '/cpu[0-9]*\.temp[0-9]/ { print $2; exit }')
-		if [ -z "$t" ]; then
-			# Try acpitz thermal zone
-			t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '/acpitz[0-9]*\.temp[0-9]/ { print $2; exit }')
-		fi
+		# Match CPU temp sensors: cpu (Intel coretemp), km/ksmn (AMD),
+		# inteldrm, or acpitz as fallback
+		t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '
+			/(cpu|km|ksmn|inteldrm)[0-9]*\.temp[0-9]/ { print $2; exit }
+			/acpitz[0-9]*\.temp[0-9]/ { if (!f) f=$2 }
+			END { if (f) print f }
+		')
 		if [ -n "$t" ] && [ "$t" -gt 0 ] 2>/dev/null; then
 			unit="$ICON_C"
 			if [ "$TEMP" = "F" ]; then

--- a/usr/lib/byobu/cpu_temp
+++ b/usr/lib/byobu/cpu_temp
@@ -21,7 +21,7 @@
 
 __cpu_temp_detail() {
 	local i
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		sysctl hw.sensors 2>/dev/null | grep -i temp
 		return
 	fi
@@ -34,7 +34,7 @@ __cpu_temp_detail() {
 
 __cpu_temp() {
 	local i t unit
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: read CPU temperature from hw.sensors
 		t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '/cpu[0-9]*\.temp[0-9]/ { print $2; exit }')
 		if [ -z "$t" ]; then

--- a/usr/lib/byobu/cpu_temp
+++ b/usr/lib/byobu/cpu_temp
@@ -21,6 +21,10 @@
 
 __cpu_temp_detail() {
 	local i
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		sysctl hw.sensors 2>/dev/null | grep -i temp
+		return
+	fi
 	for i in $MONITORED_TEMP /sys/class/hwmon/hwmon*/device/temp*_input /sys/class/hwmon/hwmon*/temp*_input /proc/acpi/ibm/thermal /proc/acpi/thermal_zone/*/temperature /sys/class/thermal/thermal_zone*/temp; do
 		[ -r "$i" ] || continue
 		printf "%s\n" "$i:"
@@ -30,6 +34,23 @@ __cpu_temp_detail() {
 
 __cpu_temp() {
 	local i t unit
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD: read CPU temperature from hw.sensors
+		t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '/cpu[0-9]*\.temp[0-9]/ { print $2; exit }')
+		if [ -z "$t" ]; then
+			# Try acpitz thermal zone
+			t=$(sysctl hw.sensors 2>/dev/null | awk -F'[=.]' '/acpitz[0-9]*\.temp[0-9]/ { print $2; exit }')
+		fi
+		if [ -n "$t" ] && [ "$t" -gt 0 ] 2>/dev/null; then
+			unit="$ICON_C"
+			if [ "$TEMP" = "F" ]; then
+				t=$(($t*9/5 + 32))
+				unit="$ICON_F"
+			fi
+			color b k Y; printf "%s" "$t"; color -; color k Y; printf "%s" "$unit"; color --
+		fi
+		return
+	fi
 	for i in $MONITORED_TEMP /sys/class/hwmon/hwmon*/device/temp*_input /sys/class/hwmon/hwmon*/temp*_input /proc/acpi/ibm/thermal /proc/acpi/thermal_zone/*/temperature /sys/class/thermal/thermal_zone*/temp; do
 		case "$i" in
 			*temp*_input|*thermal_zone*/temp)

--- a/usr/lib/byobu/disk
+++ b/usr/lib/byobu/disk
@@ -28,7 +28,13 @@ __disk() {
 	# Default to /, but let users override
 	[ -z "$MONITORED_DISK" ] && MP="/" || MP="$MONITORED_DISK"
 	case $MP in
-		/dev/*) MP=$(awk '$1 == m { print $2; exit(0); }' "m=$MP" /proc/mounts);;
+		/dev/*)
+			if [ -r /proc/mounts ]; then
+				MP=$(awk '$1 == m { print $2; exit(0); }' "m=$MP" /proc/mounts)
+			else
+				MP=$(mount | awk -v m="$MP" '$1 == m { print $3; exit(0); }')
+			fi
+		;;
 	esac
 	# this could be done faster with 'stat --file-system --format'
 	# but then we'd have to do blocks -> human units ourselves

--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -109,7 +109,7 @@ __disk_io_openbsd() {
 __disk_io() {
 	local part= i=
 	# OpenBSD: use iostat -DI instead of /sys/block
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		__disk_io_openbsd
 		return
 	fi

--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -62,14 +62,14 @@ __disk_io_openbsd() {
 	[ -n "$part" ] || return
 	disk="${part##*/}"
 	# Strip partition letter (sd0a -> sd0)
-	disk=$(echo "$disk" | sed 's/[a-p]$//')
+	disk="${disk%[a-p]}"
 	# Parse iostat -DI for cumulative KB transferred for this disk
 	# Output format: disk_name  KB  xfr  time
 	local iostat_line
 	iostat_line=$(iostat -DI 2>/dev/null | awk -v d="$disk" '$1 == d { print $2; exit }')
 	[ -n "$iostat_line" ] || return
 	# iostat -DI gives total KB transferred (read+write combined)
-	x2=$(echo "$iostat_line" | awk '{ printf "%d", $1 }')
+	x2="$iostat_line"
 	[ -n "$x2" ] || return
 	cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/disk.io"
 	t2=$(date +%s)
@@ -86,7 +86,8 @@ __disk_io_openbsd() {
 		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/disk_io"*
 		return
 	fi
-	symbol="$ICON_RD"
+	# Combined read+write from iostat; show both direction symbols
+	symbol="${ICON_RD}${ICON_WR}"
 	if [ "$rate" -gt 1048576 ]; then
 		unit="GB/s"
 		fpdiv "$rate" 1048576 0
@@ -114,7 +115,7 @@ __disk_io() {
 	fi
 	# Default to disk providing /, but let users override with MONITORED_DISK
 	[ -z "$MONITORED_DISK" ] && mount_point="/" ||  mount_point="$MONITORED_DISK"
-	# By default, we won't bug the user with the display of network traffic
+	# By default, we won't bug the user with the display of disk throughput
 	# below DISK_IO_THRESHOLD in kB/s; override in $BYOBU_CONFIG_DIR/status
 	[ -n "$DISK_IO_THRESHOLD" ] || DISK_IO_THRESHOLD=50
 	case "$mount_point" in

--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -53,8 +53,66 @@ getdisk() {
 	fi
 }
 
+__disk_io_openbsd() {
+	local mount_point disk part kb xfr t2 t1 cache x1 x2 rate symbol unit
+	[ -z "$MONITORED_DISK" ] && mount_point="/" || mount_point="$MONITORED_DISK"
+	[ -n "$DISK_IO_THRESHOLD" ] || DISK_IO_THRESHOLD=50
+	# Find the disk device for the mount point (e.g., /dev/sd0a -> sd0)
+	part=$(mount | awk -v mp="$mount_point" '$3 == mp { print $1; exit }')
+	[ -n "$part" ] || return
+	disk="${part##*/}"
+	# Strip partition letter (sd0a -> sd0)
+	disk=$(echo "$disk" | sed 's/[a-p]$//')
+	# Parse iostat -DI for cumulative KB transferred for this disk
+	# Output format: disk_name  KB  xfr  time
+	local iostat_line
+	iostat_line=$(iostat -DI 2>/dev/null | awk -v d="$disk" '$1 == d { print $2; exit }')
+	[ -n "$iostat_line" ] || return
+	# iostat -DI gives total KB transferred (read+write combined)
+	x2=$(echo "$iostat_line" | awk '{ printf "%d", $1 }')
+	[ -n "$x2" ] || return
+	cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/disk.io"
+	t2=$(date +%s)
+	t1=$(stat -f %m "$cache" 2>/dev/null) || t1=0
+	x1=0
+	[ -r "$cache" ] && read x1 < "$cache"
+	printf "%s" "$x2" > "$cache"
+	if [ "$t2" -le "$t1" ] || [ "$t1" -eq 0 ]; then
+		return
+	fi
+	rate=$(( (x2 - x1) / (t2 - t1) ))
+	if [ "$rate" -lt "$DISK_IO_THRESHOLD" ]; then
+		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/disk_io"*
+		return
+	elif [ "$rate" -lt 0 ]; then
+		rate=0
+	fi
+	symbol="$ICON_RD"
+	if [ "$rate" -gt 1048576 ]; then
+		unit="GB/s"
+		fpdiv "$rate" 1048576 0
+		rate=${_RET}
+	elif [ "$rate" -gt 1024 ]; then
+		unit="MB/s"
+		fpdiv "$rate" 1024 0
+		rate=${_RET}
+	else
+		unit="kB/s"
+	fi
+	if [ -z "$rate" ] || [ "$rate" = "0" ]; then
+		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/disk_io"*
+	else
+		color b M W; printf "%s%s" "$symbol" "$rate"; color -; color M W; printf "%s" "$unit"; color --
+	fi
+}
+
 __disk_io() {
 	local part= i=
+	# OpenBSD: use iostat -DI instead of /sys/block
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		__disk_io_openbsd
+		return
+	fi
 	# Default to disk providing /, but let users override with MONITORED_DISK
 	[ -z "$MONITORED_DISK" ] && mount_point="/" ||  mount_point="$MONITORED_DISK"
 	# By default, we won't bug the user with the display of network traffic

--- a/usr/lib/byobu/disk_io
+++ b/usr/lib/byobu/disk_io
@@ -81,11 +81,10 @@ __disk_io_openbsd() {
 		return
 	fi
 	rate=$(( (x2 - x1) / (t2 - t1) ))
+	[ "$rate" -lt 0 ] && rate=0
 	if [ "$rate" -lt "$DISK_IO_THRESHOLD" ]; then
 		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/disk_io"*
 		return
-	elif [ "$rate" -lt 0 ]; then
-		rate=0
 	fi
 	symbol="$ICON_RD"
 	if [ "$rate" -gt 1048576 ]; then

--- a/usr/lib/byobu/entropy
+++ b/usr/lib/byobu/entropy
@@ -28,7 +28,8 @@ __entropy_detail() {
 
 __entropy() {
 	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		color K Y; printf "e%s" "N/A"; color --
+		# OpenBSD uses arc4random(3); entropy is always sufficient
+		return
 	elif [ -r /proc/sys/kernel/random/entropy_avail ]; then
 		local e=$(cat /proc/sys/kernel/random/entropy_avail)
 		[ -n "$e" ] || return

--- a/usr/lib/byobu/entropy
+++ b/usr/lib/byobu/entropy
@@ -19,7 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __entropy_detail() {
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		printf "%s\n" "OpenBSD uses arc4random(3) -- always seeded, no pool metric."
 	else
 		cat /proc/sys/kernel/random/entropy_avail 2>/dev/null
@@ -27,7 +27,7 @@ __entropy_detail() {
 }
 
 __entropy() {
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		color K Y; printf "e%s" "N/A"; color --
 	elif [ -r /proc/sys/kernel/random/entropy_avail ]; then
 		local e=$(cat /proc/sys/kernel/random/entropy_avail)

--- a/usr/lib/byobu/entropy
+++ b/usr/lib/byobu/entropy
@@ -19,11 +19,17 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __entropy_detail() {
-	cat /proc/sys/kernel/random/entropy_avail 2>/dev/null
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		printf "%s\n" "OpenBSD uses arc4random(3) -- always seeded, no pool metric."
+	else
+		cat /proc/sys/kernel/random/entropy_avail 2>/dev/null
+	fi
 }
 
 __entropy() {
-	if [ -r /proc/sys/kernel/random/entropy_avail ]; then
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		color K Y; printf "e%s" "N/A"; color --
+	elif [ -r /proc/sys/kernel/random/entropy_avail ]; then
 		local e=$(cat /proc/sys/kernel/random/entropy_avail)
 		[ -n "$e" ] || return
 		color K Y; printf "e%s" "$e"; color --

--- a/usr/lib/byobu/fan_speed
+++ b/usr/lib/byobu/fan_speed
@@ -26,6 +26,16 @@ __fan_speed_detail() {
 
 __fan_speed() {
 	local i="" speed=0
+	# OpenBSD: read fan speed from hw.sensors
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		speed=$(sysctl hw.sensors 2>/dev/null | awk -F'=' '/fan[0-9]/ { gsub(/ RPM/,"",$2); print $2; exit }')
+		if [ -n "$speed" ] && [ "$speed" -gt 0 ] 2>/dev/null; then
+			color bold1; printf "%s" "$speed"; color -; color none; printf "rpm"; color --
+			return 0
+		fi
+		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/fan_speed"*
+		return 0
+	fi
 	# Let's check a few different probes for fan speed
 	# This seems to cover most of them:
 	for i in $FAN /sys/class/hwmon/*/*/fan1_input /sys/class/hwmon/*/device/hwmon/*/fan1_input; do

--- a/usr/lib/byobu/fan_speed
+++ b/usr/lib/byobu/fan_speed
@@ -27,7 +27,7 @@ __fan_speed_detail() {
 __fan_speed() {
 	local i="" speed=0
 	# OpenBSD: read fan speed from hw.sensors
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		speed=$(sysctl hw.sensors 2>/dev/null | awk -F'=' '/fan[0-9]/ { gsub(/ RPM/,"",$2); print $2; exit }')
 		if [ -n "$speed" ] && [ "$speed" -gt 0 ] 2>/dev/null; then
 			color bold1; printf "%s" "$speed"; color -; color none; printf "rpm"; color --

--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -56,7 +56,7 @@ eval $BYOBU_TEST "$BYOBU_EDITOR" >/dev/null 2>&1 || export BYOBU_EDITOR="vim"
 
 # Cache the OS name to avoid repeated uname forks in status scripts.
 # uname is POSIX-mandated and present on all supported platforms.
-export BYOBU_OSTYPE=$(uname -s 2>/dev/null)
+[ -z "$BYOBU_OSTYPE" ] && export BYOBU_OSTYPE=$(uname -s 2>/dev/null)
 
 # Check sed's follow-symlinks feature
 $BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || BYOBU_SED_INLINE="$BYOBU_SED -i"

--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -54,6 +54,10 @@ eval $BYOBU_TEST sensible-editor >/dev/null 2>&1 && export BYOBU_EDITOR="sensibl
 eval $BYOBU_TEST "$BYOBU_EDITOR" >/dev/null 2>&1 || export BYOBU_EDITOR="vim"
 
 
+# Cache the OS name to avoid repeated uname forks in status scripts.
+# uname is POSIX-mandated and present on all supported platforms.
+BYOBU_OSTYPE=$(uname -s 2>/dev/null)
+
 # Check sed's follow-symlinks feature
 $BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || BYOBU_SED_INLINE="$BYOBU_SED -i"
 

--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -56,7 +56,7 @@ eval $BYOBU_TEST "$BYOBU_EDITOR" >/dev/null 2>&1 || export BYOBU_EDITOR="vim"
 
 # Cache the OS name to avoid repeated uname forks in status scripts.
 # uname is POSIX-mandated and present on all supported platforms.
-BYOBU_OSTYPE=$(uname -s 2>/dev/null)
+export BYOBU_OSTYPE=$(uname -s 2>/dev/null)
 
 # Check sed's follow-symlinks feature
 $BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || BYOBU_SED_INLINE="$BYOBU_SED -i"

--- a/usr/lib/byobu/include/cycle-status
+++ b/usr/lib/byobu/include/cycle-status
@@ -35,7 +35,7 @@ for i in $all $all; do
 done
 
 # Disable all
-sed -i -e "s/^tmux_right=/#tmux_right=/" "$BYOBU_CONFIG_DIR/status"
+$BYOBU_SED_INLINE -e "s/^tmux_right=/#tmux_right=/" "$BYOBU_CONFIG_DIR/status"
 
 # Enable the next one
-sed -i -e "${next}s/^#tmux_right=/tmux_right=/" "$BYOBU_CONFIG_DIR/status"
+$BYOBU_SED_INLINE -e "${next}s/^#tmux_right=/tmux_right=/" "$BYOBU_CONFIG_DIR/status"

--- a/usr/lib/byobu/include/dirs.in
+++ b/usr/lib/byobu/include/dirs.in
@@ -44,7 +44,7 @@ fi
 [ -r "$BYOBU_CONFIG_DIR/socketdir" ] && . "$BYOBU_CONFIG_DIR/socketdir"
 
 # Create and export the runtime cache directory
-if [ -w /dev/shm ]; then
+if [ -d /dev/shm ] && [ -w /dev/shm ]; then
 	# Use shm for performance, if possible
 	for i in /dev/shm/$PKG-$USER-*; do
 		if [ -d "$i" ] && [ -O "$i" ]; then

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -287,7 +287,7 @@ get_now() {
 		local s c
 		read s c < /proc/uptime
 		_RET=${s%.*}
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		local btsec
 		btsec=$(sysctl -n kern.boottime)
 		_RET=$(( $(date +%s) - btsec ))
@@ -300,7 +300,7 @@ get_network_interface() {
         if [ -n "$MONITORED_NETWORK" ]; then
 		# Manual override
                 _RET="$MONITORED_NETWORK"
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: use route to find the default interface
 		_RET=$(route -n get default 2>/dev/null | awk '/interface:/ { print $2 }')
         elif [ -e /proc/net/route ]; then
@@ -371,7 +371,7 @@ get_distro() {
 	elif eval $BYOBU_TEST sw_vers >/dev/null 2>&1; then
 		distro="$(sw_vers -productName)"
 	elif eval $BYOBU_TEST uname >/dev/null 2>&1; then
-		distro="$(uname -s)"
+		distro="$BYOBU_OSTYPE"
 	else
 		distro="Byobu"
 	fi

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -304,9 +304,6 @@ get_network_interface() {
         if [ -n "$MONITORED_NETWORK" ]; then
 		# Manual override
                 _RET="$MONITORED_NETWORK"
-	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		# OpenBSD: use route to find the default interface
-		_RET=$(route -n get default 2>/dev/null | awk '/interface:/ { print $2 }')
         elif [ -e /proc/net/route ]; then
 		# Linux systems, read route and interface from procfs
 		local Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT
@@ -315,11 +312,10 @@ get_network_interface() {
 		done < /proc/net/route
 		_RET="$Iface"
 	elif eval $BYOBU_TEST route >/dev/null 2>&1; then
-		# Route command on path
-		_RET=$(route get default|grep interface:|awk '{print $2}')
+		# BSD/macOS: use route to find the default interface
+		_RET=$(route -n get default 2>/dev/null | awk '/interface:/ { print $2 }')
 	elif [ -x "/sbin/route" ]; then
-		# Mac OSX, shell out to the route command
-		_RET=$(/sbin/route get default|grep interface:|awk '{print $2}')
+		_RET=$(/sbin/route -n get default 2>/dev/null | awk '/interface:/ { print $2 }')
 	fi
 }
 

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -287,6 +287,10 @@ get_now() {
 		local s c
 		read s c < /proc/uptime
 		_RET=${s%.*}
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		local btsec
+		btsec=$(sysctl -n kern.boottime)
+		_RET=$(( $(date +%s) - btsec ))
 	else
 		_RET=$(date +%s);
 	fi
@@ -296,6 +300,9 @@ get_network_interface() {
         if [ -n "$MONITORED_NETWORK" ]; then
 		# Manual override
                 _RET="$MONITORED_NETWORK"
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD: use route to find the default interface
+		_RET=$(route -n get default 2>/dev/null | awk '/interface:/ { print $2 }')
         elif [ -e /proc/net/route ]; then
 		# Linux systems, read route and interface from procfs
 		local Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -288,10 +288,12 @@ get_now() {
 		read s c < /proc/uptime
 		_RET=${s%.*}
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		local btsec
-		btsec=$(sysctl -n kern.boottime 2>/dev/null)
-		if [ -n "$btsec" ]; then
-			_RET=$(( $(date +%s) - btsec ))
+		# Cache kern.boottime since it is constant
+		if [ -z "$_BYOBU_BOOTTIME" ]; then
+			_BYOBU_BOOTTIME=$(sysctl -n kern.boottime 2>/dev/null)
+		fi
+		if [ -n "$_BYOBU_BOOTTIME" ]; then
+			_RET=$(( $(date +%s) - _BYOBU_BOOTTIME ))
 		else
 			_RET=$(date +%s)
 		fi

--- a/usr/lib/byobu/include/shutil
+++ b/usr/lib/byobu/include/shutil
@@ -289,8 +289,12 @@ get_now() {
 		_RET=${s%.*}
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		local btsec
-		btsec=$(sysctl -n kern.boottime)
-		_RET=$(( $(date +%s) - btsec ))
+		btsec=$(sysctl -n kern.boottime 2>/dev/null)
+		if [ -n "$btsec" ]; then
+			_RET=$(( $(date +%s) - btsec ))
+		else
+			_RET=$(date +%s)
+		fi
 	else
 		_RET=$(date +%s);
 	fi

--- a/usr/lib/byobu/include/toggle-utf8.in
+++ b/usr/lib/byobu/include/toggle-utf8.in
@@ -25,14 +25,14 @@ PKG="byobu"
 
 if [ "$BYOBU_CHARMAP" = "UTF-8" ]; then
 	if grep -qs "^BYOBU_CHARMAP=" $BYOBU_CONFIG_DIR/statusrc 2>/dev/null; then
-		sed -i -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=x/" $BYOBU_CONFIG_DIR/statusrc
+		$BYOBU_SED_INLINE -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=x/" $BYOBU_CONFIG_DIR/statusrc
 	else
 		echo "BYOBU_CHARMAP=x" >> $BYOBU_CONFIG_DIR/statusrc
 	fi
 	export BYOBU_CHARMAP=x
 else
 	if grep -qs "^BYOBU_CHARMAP=" $BYOBU_CONFIG_DIR/statusrc 2>/dev/null; then
-		sed -i -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=UTF-8/" $BYOBU_CONFIG_DIR/statusrc
+		$BYOBU_SED_INLINE -e "s/^BYOBU_CHARMAP=.*/BYOBU_CHARMAP=UTF-8/" $BYOBU_CONFIG_DIR/statusrc
 	else
 		echo "BYOBU_CHARMAP=UTF-8" >> $BYOBU_CONFIG_DIR/statusrc
 	fi

--- a/usr/lib/byobu/ip_address
+++ b/usr/lib/byobu/ip_address
@@ -34,7 +34,13 @@ __ip_address() {
 		interface="$MONITORED_NETWORK"
 	else
 		case "$IPV6" in
-			1|true|yes) interface=$(awk '$10 != "lo" { iface=$10 ; }; END { print iface; }' /proc/net/ipv6_route);;
+			1|true|yes)
+				if [ -r /proc/net/ipv6_route ]; then
+					interface=$(awk '$10 != "lo" { iface=$10 ; }; END { print iface; }' /proc/net/ipv6_route)
+				else
+					get_network_interface; interface="$_RET"
+				fi
+			;;
 			*) get_network_interface; interface="$_RET";;
 		esac
 	fi

--- a/usr/lib/byobu/load_average
+++ b/usr/lib/byobu/load_average
@@ -20,12 +20,21 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __load_average_detail() {
-	cat /proc/loadavg
+	if [ -r /proc/loadavg ]; then
+		cat /proc/loadavg
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		sysctl vm.loadavg 2>/dev/null
+	else
+		uptime
+	fi
 }
 
 __load_average() {
 	if [ -r "/proc/loadavg" ]; then
 		read one five fifteen other < /proc/loadavg
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# vm.loadavg returns "x.xx y.yy z.zz"
+		one=$(sysctl -n vm.loadavg 2>/dev/null | awk '{ print $1 }')
 	else
 		one=$(uptime | sed -e "s/.*://" | awk '{print $1}')
 	fi

--- a/usr/lib/byobu/load_average
+++ b/usr/lib/byobu/load_average
@@ -23,7 +23,7 @@ __load_average_detail() {
 	if [ -r /proc/loadavg ]; then
 		cat /proc/loadavg
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		sysctl vm.loadavg 2>/dev/null
+		sysctl -n vm.loadavg 2>/dev/null
 	else
 		uptime
 	fi

--- a/usr/lib/byobu/load_average
+++ b/usr/lib/byobu/load_average
@@ -22,7 +22,7 @@
 __load_average_detail() {
 	if [ -r /proc/loadavg ]; then
 		cat /proc/loadavg
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		sysctl vm.loadavg 2>/dev/null
 	else
 		uptime
@@ -32,7 +32,7 @@ __load_average_detail() {
 __load_average() {
 	if [ -r "/proc/loadavg" ]; then
 		read one five fifteen other < /proc/loadavg
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# vm.loadavg returns "x.xx y.yy z.zz"
 		one=$(sysctl -n vm.loadavg 2>/dev/null | awk '{ print $1 }')
 	else

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -20,7 +20,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __memory_detail() {
-	free
+	if eval $BYOBU_TEST free >/dev/null 2>&1; then
+		free
+	else
+		vmstat
+	fi
 }
 
 __memory() {
@@ -45,6 +49,20 @@ __memory() {
 		inactive_count=$(sysctl -n vm.stats.vm.v_inactive_count)
 		total=$(((${page_size} * ${page_count}) / 1024))
 		free=$(((${page_size} * (${free_count} + ${cache_count} + ${inactive_count})) / 1024))
+		buffers=0
+		cached=0
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD support: use sysctl and vmstat
+		local physmem pagesize free_pages
+		physmem=$(sysctl -n hw.physmem)
+		total=$((physmem / 1024))
+		pagesize=$(sysctl -n hw.pagesize)
+		free_pages=$(vmstat -s 2>/dev/null | awk '/pages free$/ { print $1; exit }')
+		if [ -n "$free_pages" ] && [ -n "$pagesize" ]; then
+			free=$(( free_pages * pagesize / 1024 ))
+		else
+			free=0
+		fi
 		buffers=0
 		cached=0
 	elif eval $BYOBU_TEST vm_stat >/dev/null 2>&1; then

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -53,14 +53,16 @@ __memory() {
 		cached=0
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD support: use sysctl and vmstat
-		local physmem pagesize free_pages
+		local physmem pagesize free_pages inactive_pages
 		physmem=$(sysctl -n hw.physmem 2>/dev/null)
 		[ -n "$physmem" ] || return
 		total=$((physmem / 1024))
 		pagesize=$(sysctl -n hw.pagesize 2>/dev/null)
-		free_pages=$(vmstat -s 2>/dev/null | awk '/pages free$/ { print $1; exit }')
+		# Count both free and inactive pages as available memory
+		free_pages=$(vmstat -s 2>/dev/null | awk '/pages free$/ { f=$1 } /pages inactive$/ { i=$1 } END { print f+0, i+0 }')
 		if [ -n "$free_pages" ] && [ -n "$pagesize" ]; then
-			free=$(( free_pages * pagesize / 1024 ))
+			set -- $free_pages
+			free=$(( ($1 + $2) * pagesize / 1024 ))
 		else
 			free=0
 		fi

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -40,7 +40,7 @@ __memory() {
 			esac
 			[ -n "${free}" -a -n "${total}" -a -n "${buffers}" -a -n "${cached}" ] && break;
 		done < /proc/meminfo
-	elif [ "$(uname -s)" = "FreeBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "FreeBSD" ]; then
 		# FreeBSD support
 		page_size=$(sysctl -n vm.stats.vm.v_page_size)
 		page_count=$(sysctl -n vm.stats.vm.v_page_count)
@@ -51,7 +51,7 @@ __memory() {
 		free=$(((${page_size} * (${free_count} + ${cache_count} + ${inactive_count})) / 1024))
 		buffers=0
 		cached=0
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD support: use sysctl and vmstat
 		local physmem pagesize free_pages
 		physmem=$(sysctl -n hw.physmem)

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -62,7 +62,7 @@ __memory() {
 		free_pages=$(vmstat -s 2>/dev/null | awk '/pages free$/ { f=$1 } /pages inactive$/ { i=$1 } END { print f+0, i+0 }')
 		if [ -n "$free_pages" ] && [ -n "$pagesize" ]; then
 			set -- $free_pages
-			free=$(( ($1 + $2) * pagesize / 1024 ))
+			free=$(( (${1:-0} + ${2:-0}) * pagesize / 1024 ))
 		else
 			free=0
 		fi

--- a/usr/lib/byobu/memory
+++ b/usr/lib/byobu/memory
@@ -54,9 +54,10 @@ __memory() {
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD support: use sysctl and vmstat
 		local physmem pagesize free_pages
-		physmem=$(sysctl -n hw.physmem)
+		physmem=$(sysctl -n hw.physmem 2>/dev/null)
+		[ -n "$physmem" ] || return
 		total=$((physmem / 1024))
-		pagesize=$(sysctl -n hw.pagesize)
+		pagesize=$(sysctl -n hw.pagesize 2>/dev/null)
 		free_pages=$(vmstat -s 2>/dev/null | awk '/pages free$/ { print $1; exit }')
 		if [ -n "$free_pages" ] && [ -n "$pagesize" ]; then
 			free=$(( free_pages * pagesize / 1024 ))

--- a/usr/lib/byobu/network
+++ b/usr/lib/byobu/network
@@ -30,12 +30,17 @@ __network_detail() {
 
 __network() {
 	get_network_interface; local interface="$_RET"
-	local x1=0 x2=0 tx1=0 i= t= unit= symbol= cache= rate=
+	local x1=0 x2=0 i= t= unit= symbol= cache= rate=
 	status_freq network
 	t="$_RET"
 	# By default, we won't bug the user with the display of network traffic
 	# below NETWORK_THRESHOLD in kbps; override in $BYOBU_CONFIG_DIR/status
 	[ -n "$NETWORK_THRESHOLD" ] || NETWORK_THRESHOLD=20
+	# OpenBSD: cache netstat output once for both directions
+	local _netstat_out=""
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
+		_netstat_out=$(netstat -ibn 2>/dev/null)
+	fi
 	for i in up down; do
 		unit="kb"
 		case $i in
@@ -43,71 +48,37 @@ __network() {
 			down) symbol="$ICON_DN" ;;
 		esac
 		cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/network.$i"
-		[ -r "$cache" ] && read x1 < "$cache" || tx1=0
-		if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-			# OpenBSD: use netstat -ibn to get byte counts
+		[ -r "$cache" ] && read x1 < "$cache" || x1=0
+		if [ -n "$_netstat_out" ]; then
+			# OpenBSD netstat -ibn columns:
+			# Name Mtu Network Address Ipkts Ierrs Ibytes Opkts Oerrs Obytes Coll
 			local nb
 			if [ "$i" = "up" ]; then
-				nb=$(netstat -ibn 2>/dev/null | awk -v iface="$interface" '$1 == iface && $3 ~ /^[0-9a-f]*:/ { print $10; exit }')
+				nb=$(printf '%s\n' "$_netstat_out" | awk -v iface="$interface" '$1 == iface && $4 ~ /:/ { print $10; exit }')
 			else
-				nb=$(netstat -ibn 2>/dev/null | awk -v iface="$interface" '$1 == iface && $3 ~ /^[0-9a-f]*:/ { print $7; exit }')
+				nb=$(printf '%s\n' "$_netstat_out" | awk -v iface="$interface" '$1 == iface && $4 ~ /:/ { print $7; exit }')
 			fi
 			[ -n "$nb" ] && x2="$nb" || x2=0
 			printf "%s" "$x2" > "$cache"
 			[ "${t:-0}" -gt 0 ] 2>/dev/null || continue
-			rate=$((8*($x2 - $x1) / $t / 1024))  # in kbps
-			[ "$rate" -lt 0 ] && rate=0
-			if [ "$rate" -gt "$NETWORK_THRESHOLD" ]; then
-				case "$NETWORK_UNITS" in
-					bytes)
-						rate=$(($rate/8))
-						if [ "$rate" -gt 1048576 ]; then
-							fpdiv "$rate" 1048576 1
-							rate=${_RET}
-							unit="GB/s"
-						elif [ "$rate" -gt 1024 ]; then
-							fpdiv "$rate" 1024 1
-							rate=${_RET}
-							unit="MB/s"
-						else
-							unit="kB/s"
-						fi
+		else
+			local iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed
+			cat /proc/net/dev > "$cache".dev
+			while read iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed; do
+				case "$iface" in
+					${interface}:)
+						[ "$i" = "up" ] && x2=${tbytes} || x2=${rbytes}
+						break;
 					;;
-					*)
-						if [ "$rate" -gt 1000000 ]; then
-							fpdiv "$rate" 1000000 1
-							rate=${_RET}
-							unit="Gb"
-						elif [ "$rate" -gt 1000 ]; then
-							fpdiv "$rate" 1000 1
-							rate=${_RET}
-							unit="Mb"
-						fi
+					${interface}:*)
+						# Interface and tbytes got munged together
+						[ "$i" = "up" ] && x2=${rmulticast##*:} || x2=${iface##*:}
+						break;
 					;;
 				esac
-				[ -n "$rate" ] || continue
-				color b m w; printf "%s%s" "$symbol" "$rate"; color -; color m w; printf "%s" "$unit"; color --
-			else
-				rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/network"*
-			fi
-			continue
+			done < "$cache".dev
+			printf "%s" "$x2" > "$cache"
 		fi
-		local iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed
-		cat /proc/net/dev > "$cache".dev
-		while read iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed; do
-			case "$iface" in
-				${interface}:)
-					[ "$i" = "up" ] && x2=${tbytes} || x2=${rbytes}
-					break;
-				;;
-				${interface}:*)
-					# Interface and tbytes got munged together
-					[ "$i" = "up" ] && x2=${rmulticast##*:} || x2=${iface##*:}
-					break;
-				;;
-			esac
-		done < "$cache".dev
-		printf "%s" "$x2" > "$cache"
 		rate=$((8*($x2 - $x1) / $t / 1024))  # in kbps
 		[ "$rate" -lt 0 ] && rate=0
 		if [ $rate -gt $NETWORK_THRESHOLD ]; then

--- a/usr/lib/byobu/network
+++ b/usr/lib/byobu/network
@@ -44,7 +44,7 @@ __network() {
 		esac
 		cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/network.$i"
 		[ -r "$cache" ] && read x1 < "$cache" || tx1=0
-		if [ "$(uname -s)" = "OpenBSD" ]; then
+		if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 			# OpenBSD: use netstat -ibn to get byte counts
 			local nb
 			if [ "$i" = "up" ]; then

--- a/usr/lib/byobu/network
+++ b/usr/lib/byobu/network
@@ -54,9 +54,37 @@ __network() {
 			fi
 			[ -n "$nb" ] && x2="$nb" || x2=0
 			printf "%s" "$x2" > "$cache"
+			[ "${t:-0}" -gt 0 ] 2>/dev/null || continue
 			rate=$((8*($x2 - $x1) / $t / 1024))  # in kbps
 			[ "$rate" -lt 0 ] && rate=0
-			if [ $rate -gt $NETWORK_THRESHOLD ]; then
+			if [ "$rate" -gt "$NETWORK_THRESHOLD" ]; then
+				case "$NETWORK_UNITS" in
+					bytes)
+						rate=$(($rate/8))
+						if [ "$rate" -gt 1048576 ]; then
+							fpdiv "$rate" 1048576 1
+							rate=${_RET}
+							unit="GB/s"
+						elif [ "$rate" -gt 1024 ]; then
+							fpdiv "$rate" 1024 1
+							rate=${_RET}
+							unit="MB/s"
+						else
+							unit="kB/s"
+						fi
+					;;
+					*)
+						if [ "$rate" -gt 1000000 ]; then
+							fpdiv "$rate" 1000000 1
+							rate=${_RET}
+							unit="Gb"
+						elif [ "$rate" -gt 1000 ]; then
+							fpdiv "$rate" 1000 1
+							rate=${_RET}
+							unit="Mb"
+						fi
+					;;
+				esac
 				[ -n "$rate" ] || continue
 				color b m w; printf "%s%s" "$symbol" "$rate"; color -; color m w; printf "%s" "$unit"; color --
 			else

--- a/usr/lib/byobu/network
+++ b/usr/lib/byobu/network
@@ -21,7 +21,11 @@
 
 __network_detail() {
 	get_network_interface; local interface="$_RET"
-	LC_ALL=C /sbin/ip addr show "$interface" | $BYOBU_SED 's/\s*$//'
+	if [ -x /sbin/ip ]; then
+		LC_ALL=C /sbin/ip addr show "$interface" | $BYOBU_SED 's/\s*$//'
+	else
+		ifconfig "$interface" 2>/dev/null
+	fi
 }
 
 __network() {
@@ -40,6 +44,26 @@ __network() {
 		esac
 		cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/network.$i"
 		[ -r "$cache" ] && read x1 < "$cache" || tx1=0
+		if [ "$(uname -s)" = "OpenBSD" ]; then
+			# OpenBSD: use netstat -ibn to get byte counts
+			local nb
+			if [ "$i" = "up" ]; then
+				nb=$(netstat -ibn 2>/dev/null | awk -v iface="$interface" '$1 == iface && $3 ~ /^[0-9a-f]*:/ { print $10; exit }')
+			else
+				nb=$(netstat -ibn 2>/dev/null | awk -v iface="$interface" '$1 == iface && $3 ~ /^[0-9a-f]*:/ { print $7; exit }')
+			fi
+			[ -n "$nb" ] && x2="$nb" || x2=0
+			printf "%s" "$x2" > "$cache"
+			rate=$((8*($x2 - $x1) / $t / 1024))  # in kbps
+			[ "$rate" -lt 0 ] && rate=0
+			if [ $rate -gt $NETWORK_THRESHOLD ]; then
+				[ -n "$rate" ] || continue
+				color b m w; printf "%s%s" "$symbol" "$rate"; color -; color m w; printf "%s" "$unit"; color --
+			else
+				rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/network"*
+			fi
+			continue
+		fi
 		local iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed
 		cat /proc/net/dev > "$cache".dev
 		while read iface rbytes rpackets rerrs rdrop rfifo rframe rcompressed rmulticast tbytes tpackets terrs tdrop tfifo tcolls tcarrier tcompressed; do

--- a/usr/lib/byobu/processes
+++ b/usr/lib/byobu/processes
@@ -20,7 +20,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __processes_detail() {
-	ps -ej 2>/dev/null
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		ps -ax 2>/dev/null
+	else
+		ps -ej 2>/dev/null
+	fi
 }
 
 __processes() {

--- a/usr/lib/byobu/processes
+++ b/usr/lib/byobu/processes
@@ -28,7 +28,7 @@ __processes() {
 	if [ -r /proc ]; then
 		count=$(ls -d /proc/[0-9]* 2>/dev/null | wc -l)
 	else
-		count=$(ps -ef | wc -l)
+		count=$(($(ps -ef | wc -l) - 1))
 	fi
 	[ -n "$count" ] || return
 	color b y w; printf "%s" "$count"; color -; color y w; printf "&"; color --

--- a/usr/lib/byobu/processes
+++ b/usr/lib/byobu/processes
@@ -20,11 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __processes_detail() {
-	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		ps -ax 2>/dev/null
-	else
-		ps -ej 2>/dev/null
-	fi
+	ps -ej 2>/dev/null || ps -ax 2>/dev/null
 }
 
 __processes() {

--- a/usr/lib/byobu/processes
+++ b/usr/lib/byobu/processes
@@ -20,7 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __processes_detail() {
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		ps -ax 2>/dev/null
 	else
 		ps -ej 2>/dev/null

--- a/usr/lib/byobu/raid
+++ b/usr/lib/byobu/raid
@@ -20,7 +20,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __raid_detail() {
-	[ -r /proc/mdstat ] && cat /proc/mdstat || true
+	if [ -r /proc/mdstat ]; then
+		cat /proc/mdstat
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD uses bioctl(8) for RAID
+		bioctl softraid0 2>/dev/null || true
+	else
+		true
+	fi
 }
 
 __raid() {

--- a/usr/lib/byobu/raid
+++ b/usr/lib/byobu/raid
@@ -33,18 +33,8 @@ __raid_detail() {
 __raid() {
 	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: check softraid status via bioctl
-		local msg=""
-		local line
-		bioctl softraid0 2>/dev/null | while read line; do
-			case "$line" in
-				*Degraded*|*Failed*|*Rebuild*)
-					msg="RAID"
-					break
-				;;
-			esac
-		done
-		if [ -n "$msg" ]; then
-			color B w r; printf "%s" "$msg"; color --
+		if bioctl softraid0 2>/dev/null | grep -qE 'Degraded|Failed|Rebuild'; then
+			color B w r; printf "%s" "RAID"; color --
 		fi
 		return
 	fi

--- a/usr/lib/byobu/raid
+++ b/usr/lib/byobu/raid
@@ -31,6 +31,23 @@ __raid_detail() {
 }
 
 __raid() {
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
+		# OpenBSD: check softraid status via bioctl
+		local msg=""
+		local line
+		bioctl softraid0 2>/dev/null | while read line; do
+			case "$line" in
+				*Degraded*|*Failed*|*Rebuild*)
+					msg="RAID"
+					break
+				;;
+			esac
+		done
+		if [ -n "$msg" ]; then
+			color B w r; printf "%s" "$msg"; color --
+		fi
+		return
+	fi
 	[ -r /proc/mdstat ] || return
 	while read line; do
 		local p msg

--- a/usr/lib/byobu/raid
+++ b/usr/lib/byobu/raid
@@ -22,7 +22,7 @@
 __raid_detail() {
 	if [ -r /proc/mdstat ]; then
 		cat /proc/mdstat
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD uses bioctl(8) for RAID
 		bioctl softraid0 2>/dev/null || true
 	else

--- a/usr/lib/byobu/swap
+++ b/usr/lib/byobu/swap
@@ -34,9 +34,10 @@ __swap() {
 		local swapline sused
 		swapline=$(swapctl -sk 2>/dev/null | tail -1)
 		if [ -n "$swapline" ]; then
+			# Output: "total: 524288 1k-blocks allocated, 0 used, 524288 available"
 			set -- $swapline
 			stotal="${2:-0}"
-			sused="${3:-0}"
+			sused="${5:-0}"
 			sfree=$(($stotal - $sused))
 		fi
 	elif [ -r /proc/meminfo ]; then

--- a/usr/lib/byobu/swap
+++ b/usr/lib/byobu/swap
@@ -36,7 +36,7 @@ __swap() {
 		if [ -n "$swapline" ]; then
 			stotal=$(echo "$swapline" | awk '{ print $2 }')
 			sused=$(echo "$swapline" | awk '{ print $3 }')
-			sfree=$((stotal - sused))
+			sfree=$((${stotal:-0} - ${sused:-0}))
 		fi
 	elif [ -r /proc/meminfo ]; then
 		while read name val unit; do

--- a/usr/lib/byobu/swap
+++ b/usr/lib/byobu/swap
@@ -22,14 +22,14 @@
 __swap_detail() {
 	if [ -r /proc/meminfo ]; then
 		cat /proc/meminfo
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		swapctl -l 2>/dev/null
 	fi
 }
 
 __swap() {
 	local stotal="" sfree="" name="" val="" unit="" mem="" f="";
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: use swapctl -sk for summary in kB
 		local swapline sused
 		swapline=$(swapctl -sk 2>/dev/null | tail -1)

--- a/usr/lib/byobu/swap
+++ b/usr/lib/byobu/swap
@@ -34,9 +34,10 @@ __swap() {
 		local swapline sused
 		swapline=$(swapctl -sk 2>/dev/null | tail -1)
 		if [ -n "$swapline" ]; then
-			stotal=$(echo "$swapline" | awk '{ print $2 }')
-			sused=$(echo "$swapline" | awk '{ print $3 }')
-			sfree=$((${stotal:-0} - ${sused:-0}))
+			set -- $swapline
+			stotal="${2:-0}"
+			sused="${3:-0}"
+			sfree=$(($stotal - $sused))
 		fi
 	elif [ -r /proc/meminfo ]; then
 		while read name val unit; do

--- a/usr/lib/byobu/swap
+++ b/usr/lib/byobu/swap
@@ -20,21 +20,36 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __swap_detail() {
-	cat /proc/meminfo
+	if [ -r /proc/meminfo ]; then
+		cat /proc/meminfo
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		swapctl -l 2>/dev/null
+	fi
 }
 
 __swap() {
 	local stotal="" sfree="" name="" val="" unit="" mem="" f="";
-	while read name val unit; do
-		if [ "$name" = "SwapTotal:" ]; then
-			stotal="$val"
-		elif [ "$name" = "SwapFree:" ]; then
-			sfree="$val"
-		else
-			continue
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD: use swapctl -sk for summary in kB
+		local swapline sused
+		swapline=$(swapctl -sk 2>/dev/null | tail -1)
+		if [ -n "$swapline" ]; then
+			stotal=$(echo "$swapline" | awk '{ print $2 }')
+			sused=$(echo "$swapline" | awk '{ print $3 }')
+			sfree=$((stotal - sused))
 		fi
-		[ -n "$stotal" -a -n "$sfree" ] && break;
-	done < /proc/meminfo
+	elif [ -r /proc/meminfo ]; then
+		while read name val unit; do
+			if [ "$name" = "SwapTotal:" ]; then
+				stotal="$val"
+			elif [ "$name" = "SwapFree:" ]; then
+				sfree="$val"
+			else
+				continue
+			fi
+			[ -n "$stotal" -a -n "$sfree" ] && break;
+		done < /proc/meminfo
+	fi
 	if [ "${stotal:-0}" = "0" ]; then
 		printf ""
 		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/swap"

--- a/usr/lib/byobu/uptime
+++ b/usr/lib/byobu/uptime
@@ -30,7 +30,7 @@ __uptime() {
 	if [ -r /proc/uptime ]; then
 		read u idle < /proc/uptime
 		u=${u%.*}
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: kern.boottime is epoch seconds directly
 		local bt
 		bt=$(sysctl -n kern.boottime)

--- a/usr/lib/byobu/uptime
+++ b/usr/lib/byobu/uptime
@@ -33,8 +33,8 @@ __uptime() {
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: kern.boottime is epoch seconds directly
 		local bt
-		bt=$(sysctl -n kern.boottime)
-		u=$(($(date +%s) - $bt))
+		bt=$(sysctl -n kern.boottime 2>/dev/null)
+		[ -n "$bt" ] && u=$(($(date +%s) - bt))
 	elif [ -x /usr/sbin/sysctl ]; then
 		# MacOS support
 		u=$(/usr/sbin/sysctl -n kern.boottime | cut -f4 -d' ' | cut -d',' -f1)

--- a/usr/lib/byobu/uptime
+++ b/usr/lib/byobu/uptime
@@ -30,6 +30,11 @@ __uptime() {
 	if [ -r /proc/uptime ]; then
 		read u idle < /proc/uptime
 		u=${u%.*}
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD: kern.boottime is epoch seconds directly
+		local bt
+		bt=$(sysctl -n kern.boottime)
+		u=$(($(date +%s) - $bt))
 	elif [ -x /usr/sbin/sysctl ]; then
 		# MacOS support
 		u=$(/usr/sbin/sysctl -n kern.boottime | cut -f4 -d' ' | cut -d',' -f1)

--- a/usr/lib/byobu/wifi_quality
+++ b/usr/lib/byobu/wifi_quality
@@ -23,7 +23,9 @@ ___get_dev_list() {
 	if [ -n "$MONITORED_NETWORK" ]; then
 		echo "$MONITORED_NETWORK"
 	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
-		# OpenBSD: list wireless interfaces
+		# OpenBSD: list wireless interfaces by known driver prefixes.
+		# Update this list when new wireless drivers are added to OpenBSD.
+		# See: man 4 iwx, man 4 iwm, etc. in the OpenBSD kernel source.
 		for _if in $(ifconfig 2>/dev/null | grep '^[a-z]' | cut -d: -f1); do
 			case "$_if" in
 				iwn*|iwm*|iwx*|athn*|ath*|rum*|run*|urtwn*|rtwn*) echo "$_if" ;;

--- a/usr/lib/byobu/wifi_quality
+++ b/usr/lib/byobu/wifi_quality
@@ -22,7 +22,7 @@
 ___get_dev_list() {
 	if [ -n "$MONITORED_NETWORK" ]; then
 		echo "$MONITORED_NETWORK"
-	elif [ "$(uname -s)" = "OpenBSD" ]; then
+	elif [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		# OpenBSD: list wireless interfaces
 		for _if in $(ifconfig 2>/dev/null | grep '^[a-z]' | cut -d: -f1); do
 			case "$_if" in
@@ -50,7 +50,7 @@ __wifi_quality_detail() {
 __wifi_quality() {
 	local out bitrate quality
 	# OpenBSD: parse ifconfig for signal strength
-	if [ "$(uname -s)" = "OpenBSD" ]; then
+	if [ "$BYOBU_OSTYPE" = "OpenBSD" ]; then
 		local dev sig
 		for dev in $(___get_dev_list); do
 			sig=$(ifconfig "$dev" 2>/dev/null | awk '/ [0-9-]+dBm/ { for(i=1;i<=NF;i++) if ($i ~ /dBm$/) { gsub(/dBm/,"",$i); print $i; exit } }')

--- a/usr/lib/byobu/wifi_quality
+++ b/usr/lib/byobu/wifi_quality
@@ -22,6 +22,13 @@
 ___get_dev_list() {
 	if [ -n "$MONITORED_NETWORK" ]; then
 		echo "$MONITORED_NETWORK"
+	elif [ "$(uname -s)" = "OpenBSD" ]; then
+		# OpenBSD: list wireless interfaces
+		for _if in $(ifconfig 2>/dev/null | grep '^[a-z]' | cut -d: -f1); do
+			case "$_if" in
+				iwn*|iwm*|iwx*|athn*|ath*|rum*|run*|urtwn*|rtwn*) echo "$_if" ;;
+			esac
+		done
 	else
 		iw dev | grep Interface | cut -f2 -d\ 
 	fi
@@ -42,7 +49,21 @@ __wifi_quality_detail() {
 
 __wifi_quality() {
 	local out bitrate quality
-	if eval $BYOBU_TEST iwconfig >/dev/null 2>&1; then
+	# OpenBSD: parse ifconfig for signal strength
+	if [ "$(uname -s)" = "OpenBSD" ]; then
+		local dev sig
+		for dev in $(___get_dev_list); do
+			sig=$(ifconfig "$dev" 2>/dev/null | awk '/ [0-9-]+dBm/ { for(i=1;i<=NF;i++) if ($i ~ /dBm$/) { gsub(/dBm/,"",$i); print $i; exit } }')
+			if [ -n "$sig" ]; then
+				# Convert dBm to quality percentage
+				quality=$(awk "BEGIN { a = 100 * ($sig + 110) / 70; if (a>100) a=100; if (a<0) a=0; printf \"%%.0f\", a }")
+				bitrate=$(ifconfig "$dev" 2>/dev/null | awk '/media:.*Mb/ { for(i=1;i<=NF;i++) if ($i ~ /Mb/) { gsub(/Mb.*/,"",$i); print $i; exit } }')
+				[ -n "$bitrate" ] || bitrate=0
+				break
+			fi
+		done
+	fi
+	if [ -z "$quality" ] && eval $BYOBU_TEST iwconfig >/dev/null 2>&1; then
 		# iwconfig is expected to output lines like:
 		#    Bit Rate=54 Mb/s   Tx-Power=15 dBm
 		#    Link Quality=60/70  Signal level=-50 dBm

--- a/usr/lib/byobu/wifi_quality
+++ b/usr/lib/byobu/wifi_quality
@@ -56,7 +56,7 @@ __wifi_quality() {
 			sig=$(ifconfig "$dev" 2>/dev/null | awk '/ [0-9-]+dBm/ { for(i=1;i<=NF;i++) if ($i ~ /dBm$/) { gsub(/dBm/,"",$i); print $i; exit } }')
 			if [ -n "$sig" ]; then
 				# Convert dBm to quality percentage
-				quality=$(awk "BEGIN { a = 100 * ($sig + 110) / 70; if (a>100) a=100; if (a<0) a=0; printf \"%%.0f\", a }")
+				quality=$(awk -v s="$sig" 'BEGIN { a = 100 * (s + 110) / 70; if (a>100) a=100; if (a<0) a=0; printf "%.0f", a }')
 				bitrate=$(ifconfig "$dev" 2>/dev/null | awk '/media:.*Mb/ { for(i=1;i<=NF;i++) if ($i ~ /Mb/) { gsub(/Mb.*/,"",$i); print $i; exit } }')
 				[ -n "$bitrate" ] || bitrate=0
 				break

--- a/usr/lib/byobu/wifi_quality
+++ b/usr/lib/byobu/wifi_quality
@@ -58,7 +58,9 @@ __wifi_quality() {
 			sig=$(ifconfig "$dev" 2>/dev/null | awk '/ [0-9-]+dBm/ { for(i=1;i<=NF;i++) if ($i ~ /dBm$/) { gsub(/dBm/,"",$i); print $i; exit } }')
 			if [ -n "$sig" ]; then
 				# Convert dBm to quality percentage
-				quality=$(awk -v s="$sig" 'BEGIN { a = 100 * (s + 110) / 70; if (a>100) a=100; if (a<0) a=0; printf "%.0f", a }')
+				quality=$(( (sig + 110) * 100 / 70 ))
+				[ "$quality" -gt 100 ] && quality=100
+				[ "$quality" -lt 0 ] && quality=0
 				bitrate=$(ifconfig "$dev" 2>/dev/null | awk '/media:.*Mb/ { for(i=1;i<=NF;i++) if ($i ~ /Mb/) { gsub(/Mb.*/,"",$i); print $i; exit } }')
 				[ -n "$bitrate" ] || bitrate=0
 				break


### PR DESCRIPTION
## Summary

Adds OpenBSD support across all status indicator scripts, building on #90.

**Core infrastructure:**
- Cache `BYOBU_OSTYPE` via `uname -s` to avoid repeated forks (`constants`)
- Add OpenBSD `kern.boottime` path in `get_now()` with boot time caching (`shutil`)
- Fix `route -n get default` for BSD interface detection (`shutil`)

**Hardware indicators:**
- CPU temperature via `hw.sensors` with coretemp/km/ksmn/inteldrm support (`cpu_temp`)
- CPU frequency via `hw.cpuspeed` in MHz (`cpu_freq`)
- CPU count via `sysctl -n hw.ncpuonline` (`cpu_count`)
- Fan speed via `hw.sensors` (`fan_speed`)
- Battery status via `apm(8)` (`battery`)

**System indicators:**
- Memory via `sysctl hw.physmem` + `vmstat -s` free/inactive pages (`memory`)
- Swap via `swapctl -sk` (`swap`)
- Load average via `sysctl -n vm.loadavg` (`load_average`)
- Process count with header line correction (`processes`)
- Uptime via `kern.boottime` (`uptime`)
- Entropy: no-op since OpenBSD uses `arc4random(3)` (`entropy`)
- RAID status via `bioctl softraid0` (`raid`)

**Network/storage indicators:**
- Network throughput via `netstat -ibn` with cached output (`network`)
- Disk I/O via `iostat -DI` (`disk_io`)
- Wifi quality via `ifconfig` signal strength with shell arithmetic dBm conversion (`wifi_quality`)