### PR TITLE
add upower support and uevent fix to battery script

### DIFF
--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -41,7 +41,10 @@ __battery() {
 		case "$bat" in
 			/sys/*)
 				if [ -r "$bat/uevent" ]; then
-					. "$bat/uevent"
+					TMP_FILE=$(mktemp)
+					sed 's/=/="/; s/$/"/' < "$bat/uevent" > "$TMP_FILE"
+					. "$TMP_FILE"
+					rm -f "$TMP_FILE"
 					case "$POWER_SUPPLY_NAME" in AC|ac|Ac|aC) continue ;; esac
 					present="$POWER_SUPPLY_PRESENT"
 					# Some use "CHARGE", others use "ENERGY", still others "CAPACITY"

--- a/usr/lib/byobu/battery
+++ b/usr/lib/byobu/battery
@@ -27,6 +27,10 @@ __battery_detail() {
 		cat "$bat/state"
 	done
 	# FIXME: do the same thing with the /sys interface
+	if eval $BYOBU_TEST /usr/bin/upower >/dev/null 2>&1; then
+		dev=$(upower -e | grep devices/ups | head -1)
+		[ ! -n "$dev" ] && upower -i "$dev"
+	fi
 }
 
 __battery() {
@@ -76,6 +80,18 @@ __battery() {
 			;;
 		esac
 	done
+	# upower fallback if /proc and /sys didn't work, e.g., with an APC UPS via USB HID
+	if eval $BYOBU_TEST /usr/bin/upower >/dev/null 2>&1; then
+		if [ -n "$full" -a -n "$present" -a -n "$rem" -a -n "$state" ]; then
+			dev=$(upower -e | grep devices/ups | head -1)
+			[ -n "$dev" ] && break
+			BATTERY_STATUS=$(upower -i "$dev")
+			present=$(printf "%s" "$BATTERY_STATUS" | awk '/present/ { print $2}')
+			full="100"
+			rem=$(printf "%s" "$BATTERY_STATUS" | awk '/percentage/ { gsub(/[^0-9]/, "", $2); print $2}')
+			state=$(printf "%s" "$BATTERY_STATUS" | awk '/state/ { print $2}')
+		fi
+	fi
 	# Mac OS X support
 	if eval $BYOBU_TEST /usr/sbin/ioreg >/dev/null 2>&1; then
 		# MacOS support
@@ -125,7 +141,7 @@ __battery() {
 		case $state in
 			charging) sign="+" ;;
 			discharging) sign="-" ;;
-			charged|unknown|full) sign="=" ;;
+			charged|unknown|full|fully-charged) sign="=" ;;
 			*) sign="$state" ;;
 		esac
 		if [ -z "$percent" ]; then


### PR DESCRIPTION
Adds fallback support to the battery script for grabbing UPS info from upower command.  Tested with an APC UPS connected via USB.

Replaces dot command inclusion `. "$bat/uevent"` by creating a temp file that adds double quotes around the values in "$bat/uevent".  The existing code errors out if spaces exist in values, e.g., on an HP laptop with `POWER_SUPPLY_SERIAL_NUMBER=12345 2020/07/01`.