### PR TITLE
trustmux: warn on tailnet ACL that blocks the serve port

### DIFF
--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -479,5 +479,131 @@ class TestDisableMain(unittest.TestCase):
                 disable.main()   # should not raise
 
 
+# ---------------------------------------------------------------------------
+# _peer_acl_allows_tcp() — tailnet ACL preflight
+# ---------------------------------------------------------------------------
+
+def _netmap(rules, self_addrs=("100.93.98.28/32",)):
+    """Build a minimal netmap JSON blob for the ACL preflight tests."""
+    nm = {"PacketFilter": rules}
+    if self_addrs is not None:
+        nm["SelfNode"] = {"Addresses": list(self_addrs)}
+    return json.dumps(nm)
+
+
+class TestPeerAclAllowsTcp(unittest.TestCase):
+
+    def _patch_netmap(self, output):
+        return patch('trustmux._ctl.subprocess.check_output', return_value=output)
+
+    def test_rule_allows_port_and_proto(self):
+        rules = [{
+            "IPProto": [6],
+            "Dsts": [{"Net": "100.93.98.28/32", "Ports": {"First": 443, "Last": 443}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertTrue(ctl._peer_acl_allows_tcp(443))
+
+    def test_rule_allows_port_range(self):
+        rules = [{
+            "IPProto": [6],
+            "Dsts": [{"Net": "100.93.98.28/32", "Ports": {"First": 1, "Last": 65535}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertTrue(ctl._peer_acl_allows_tcp(443))
+
+    def test_empty_iproto_means_all_protocols(self):
+        rules = [{
+            "IPProto": [],
+            "Dsts": [{"Net": "100.93.98.28/32", "Ports": {"First": 443, "Last": 443}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertTrue(ctl._peer_acl_allows_tcp(443))
+
+    def test_no_rule_covers_port(self):
+        rules = [{
+            "IPProto": [6],
+            "Dsts": [{"Net": "100.93.98.28/32", "Ports": {"First": 22, "Last": 22}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertFalse(ctl._peer_acl_allows_tcp(443))
+
+    def test_wrong_protocol_rejected(self):
+        rules = [{
+            "IPProto": [17],  # UDP only
+            "Dsts": [{"Net": "100.93.98.28/32", "Ports": {"First": 443, "Last": 443}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertFalse(ctl._peer_acl_allows_tcp(443))
+
+    def test_rule_for_different_device_rejected(self):
+        rules = [{
+            "IPProto": [6],
+            "Dsts": [{"Net": "100.64.0.99/32", "Ports": {"First": 443, "Last": 443}}],
+        }]
+        with self._patch_netmap(_netmap(rules)):
+            self.assertFalse(ctl._peer_acl_allows_tcp(443))
+
+    def test_accepts_match_when_self_ips_unknown(self):
+        # If SelfNode.Addresses is absent, fall back to "any net" matching so
+        # we don't false-positive a warning.
+        rules = [{
+            "IPProto": [6],
+            "Dsts": [{"Net": "100.64.0.99/32", "Ports": {"First": 443, "Last": 443}}],
+        }]
+        nm = json.dumps({"PacketFilter": rules})
+        with patch('trustmux._ctl.subprocess.check_output', return_value=nm):
+            self.assertTrue(ctl._peer_acl_allows_tcp(443))
+
+    def test_tailscale_missing_returns_none(self):
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=FileNotFoundError):
+            self.assertIsNone(ctl._peer_acl_allows_tcp(443))
+
+    def test_malformed_json_returns_none(self):
+        with patch('trustmux._ctl.subprocess.check_output',
+                   return_value='not json'):
+            self.assertIsNone(ctl._peer_acl_allows_tcp(443))
+
+    def test_missing_packet_filter_returns_none(self):
+        with patch('trustmux._ctl.subprocess.check_output',
+                   return_value='{}'):
+            self.assertIsNone(ctl._peer_acl_allows_tcp(443))
+
+
+# ---------------------------------------------------------------------------
+# warn_if_peer_blocked()
+# ---------------------------------------------------------------------------
+
+class TestWarnIfPeerBlocked(unittest.TestCase):
+
+    def test_silent_when_reachable(self):
+        import io
+        buf = io.StringIO()
+        with patch('trustmux._ctl._peer_acl_allows_tcp', return_value=True):
+            ctl.warn_if_peer_blocked(443, stream=buf)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_silent_when_unknown(self):
+        import io
+        buf = io.StringIO()
+        with patch('trustmux._ctl._peer_acl_allows_tcp', return_value=None):
+            ctl.warn_if_peer_blocked(443, stream=buf)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_warns_when_blocked(self):
+        import io
+        buf = io.StringIO()
+        with patch('trustmux._ctl._peer_acl_allows_tcp', return_value=False):
+            ctl.warn_if_peer_blocked(443, stream=buf)
+        msg = buf.getvalue()
+        self.assertIn("warning", msg)
+        self.assertIn("tcp:443", msg)
+        self.assertIn("ERR_NETWORK_CHANGED", msg)
+        # Mentions both ACL formats so users on either can self-serve.
+        self.assertIn("grants", msg)
+        self.assertIn("acls", msg)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 PORT       = 7432
+SERVE_PORT = 443  # tailscale serve terminates TLS on :443
 CONFIG_DIR = Path.home() / ".config" / "trustmux"
 LOGFILE    = CONFIG_DIR / "trustmux.log"
 PIDFILE    = Path("/tmp/trustmux.pid")
@@ -54,6 +55,85 @@ def _ts_host() -> str:
         return json.loads(out).get("Self", {}).get("DNSName", "").rstrip(".")
     except Exception:
         return ""
+
+
+def _peer_acl_allows_tcp(port: int = SERVE_PORT) -> bool | None:
+    """Check whether the current tailnet ACL permits peer devices to reach this
+    node on tcp:<port>.
+
+    Returns True if at least one packet-filter rule allows it, False if no rule
+    does, or None if the check could not be performed (no tailscale binary,
+    unexpected netmap shape, etc.) — callers should treat None as "no warning."
+    """
+    try:
+        out = subprocess.check_output(
+            ["tailscale", "debug", "netmap"],
+            stderr=subprocess.DEVNULL, timeout=3, text=True,
+        )
+        nm = json.loads(out)
+    except Exception:
+        return None
+
+    self_ips: set[str] = set()
+    for cidr in (nm.get("SelfNode") or {}).get("Addresses") or []:
+        self_ips.add(cidr.split("/")[0])
+
+    rules = nm.get("PacketFilter")
+    if not rules:
+        return None
+
+    for r in rules:
+        protos = r.get("IPProto") or []
+        # Empty IPProto means "any protocol" in Tailscale's filter format.
+        if protos and 6 not in protos:
+            continue
+        for dst in r.get("Dsts") or []:
+            ports = dst.get("Ports") or {}
+            first, last = ports.get("First"), ports.get("Last")
+            if first is None or last is None:
+                continue
+            if not (first <= port <= last):
+                continue
+            if self_ips:
+                base = dst.get("Net", "").split("/")[0]
+                if base not in self_ips:
+                    continue
+            return True
+    return False
+
+
+def warn_if_peer_blocked(port: int = SERVE_PORT, stream=sys.stderr) -> None:
+    """Print an actionable warning if peer access to tcp:<port> appears to be
+    blocked by the tailnet ACL. Silent when the check passes or cannot run.
+
+    Without this warning, an ACL that omits the serve port produces a confusing
+    failure mode: the daemon and `tailscale serve` are healthy, `curl` from the
+    same host succeeds (loopback bypasses ACL evaluation), but peer browsers
+    see ERR_NETWORK_CHANGED or "Site cannot be reached" because tailscaled
+    silently drops the incoming TCP with no RST.
+    """
+    if _peer_acl_allows_tcp(port) is not False:
+        return
+    print("", file=stream)
+    print(f"warning: your tailnet ACL does not appear to allow tcp:{port} to this device.", file=stream)
+    print( "         Peer devices will silently fail to connect; browsers show", file=stream)
+    print( "         ERR_NETWORK_CHANGED or 'site cannot be reached.'", file=stream)
+    print( "", file=stream)
+    print( "         Edit your tailnet policy at:", file=stream)
+    print( "           https://login.tailscale.com/admin/acls/file", file=stream)
+    print( "", file=stream)
+    print( "         For the newer 'grants' format, add:", file=stream)
+    print( "", file=stream)
+    print( '             { "src": ["autogroup:member"],', file=stream)
+    print( '               "dst": ["<this-device-or-tag>"],', file=stream)
+    print(f'               "ip":  ["tcp:{port}"] }}', file=stream)
+    print( "", file=stream)
+    print( "         For the legacy 'acls' format, add:", file=stream)
+    print( "", file=stream)
+    print( '             { "action": "accept",', file=stream)
+    print( '               "src":    ["autogroup:member"],', file=stream)
+    print(f'               "dst":    ["<this-device-or-tag>:{port}"] }}', file=stream)
+    print( "", file=stream)
 
 
 def _ensure_ts_serve() -> bool:
@@ -143,6 +223,8 @@ def cmd_setup(quiet: bool = False) -> int:
 
     if not _ensure_ts_serve():
         return 1
+
+    warn_if_peer_blocked()
 
     if not quiet:
         print("\nSetup complete. Next steps:\n")

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -9,6 +9,8 @@ import termios
 import tty
 from pathlib import Path
 
+from trustmux._ctl import warn_if_peer_blocked
+
 SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
 
 
@@ -122,6 +124,8 @@ def main():
     print(f"  Trustmux pairing code:  {code}  (valid {mins} min)")
     print(f"  Connect:                {pair_url}")
     print(f"{bar}\n")
+
+    warn_if_peer_blocked()
 
     _print_qr(pair_url)
     print()


### PR DESCRIPTION
## Summary

- Adds an ACL preflight (`_peer_acl_allows_tcp` / `warn_if_peer_blocked`) that queries `tailscale debug netmap` and warns when no rule allows `tcp:443` to this device.
- Wires the warning into `cmd_setup()` (called by `trustmux-enable`) and `_pair.main()` (called by `trustmux-pair`), so users see it at the two moments when they can act on it.
- Warning text includes the exact stanzas for both the newer `grants` ACL format and the legacy `acls` format.

Fixes #98.

## Why

Without this preflight, an ACL that omits the trustmux serve port produces a famously confusing failure mode: the daemon, `tailscale serve`, and same-host `curl` all look healthy, but peer devices see `ERR_NETWORK_CHANGED` / "site cannot be reached" because `tailscaled` silently drops the inbound TCP — `Drop: TCP{... > self:443} ... no rules matched` in `journalctl -u tailscaled`. Same-host loopback bypasses ACL evaluation, so local probes don't reproduce the problem.

I hit this on a fresh setup and lost an hour to it. A heads-up at install/pair time would have saved that.

## Safety

Strictly additive. Every failure mode of the check returns `None` (no warning):

- `tailscale` binary missing → exception, suppressed
- `tailscale debug netmap` malformed/different version → JSON parse failure, suppressed
- Empty or missing `PacketFilter` → suppressed (unknown intent)
- `SelfNode.Addresses` missing → falls back to net-agnostic port match (still conservative)

The function can only return `False` (and warn) when a netmap was parsed and no rule covers `tcp:<port>`. It cannot regress a working install. No new dependencies.

## Tests

13 new unit tests in `mobile/tests/test_ctl.py` matching the existing `unittest.TestCase` + `unittest.mock.patch` style:

- `TestPeerAclAllowsTcp` — rule allows port & proto, port range, empty `IPProto` = all protos, no covering rule, wrong protocol, different device's IP, self-IPs unknown fallback, subprocess error, malformed JSON, missing `PacketFilter`.
- `TestWarnIfPeerBlocked` — silent on reachable, silent on unknown, warns on blocked (verifies the warning mentions `tcp:<port>`, `ERR_NETWORK_CHANGED`, and both ACL formats).

Full suite (`python3 -m unittest tests.test_ctl`): **60 passing, 0 failures.**

Also validated end-to-end on a real tailnet: `_peer_acl_allows_tcp(443)` returns `True` on a host whose ACL was just corrected to allow `tcp:443`, confirming the netmap-shape assumptions against a live Tailscale daemon.

## Test plan

- [x] `python3 -m unittest tests.test_ctl` — all 60 pass
- [x] `_peer_acl_allows_tcp(443)` returns `True` against a real netmap where the ACL allows it
- [x] Diff applies cleanly against `master` (byte-identical baseline verified)
- [ ] (Maintainer) Verify warning text reads well in your terminal

## Out of scope (happy to do in follow-ups)

- `trustmux-ctl doctor` subcommand aggregating daemon health / serve config / cert status / recent `Drop:` lines.
- `trustmux(1)` man page REQUIREMENTS section documenting the ACL stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)