### PR TITLE
export BYOBU_SED_INLINE so child scripts inherit it

### DIFF
--- a/usr/lib/byobu/include/constants
+++ b/usr/lib/byobu/include/constants
@@ -59,7 +59,7 @@ eval $BYOBU_TEST "$BYOBU_EDITOR" >/dev/null 2>&1 || export BYOBU_EDITOR="vim"
 [ -z "$BYOBU_OSTYPE" ] && export BYOBU_OSTYPE=$(uname -s 2>/dev/null)
 
 # Check sed's follow-symlinks feature
-$BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || BYOBU_SED_INLINE="$BYOBU_SED -i"
+$BYOBU_SED --follow-symlinks "s///" /dev/null 2>/dev/null && export BYOBU_SED_INLINE="$BYOBU_SED -i --follow-symlinks" || export BYOBU_SED_INLINE="$BYOBU_SED -i"
 
 # Determine if we have ulimit support
 eval $BYOBU_TEST ulimit >/dev/null 2>&1 && export BYOBU_ULIMIT="ulimit" || export BYOBU_ULIMIT="false"


### PR DESCRIPTION
Commit 24eac3b ("Add OpenBSD support for status indicators") changed `cycle-status` and `toggle-utf8` to use `$BYOBU_SED_INLINE` instead of a hardcoded `sed -i`. Its message assumes those scripts "are sourced after include/constants" — but they are **forked as child processes**, not sourced:

- `byobu-janitor` runs `.../include/cycle-status` as a subprocess (the Wolfi `status` path)
- `f-keys.tmux` binds `cycle-status` and `toggle-utf8` via `new-window`/`run-shell`

`BYOBU_SED_INLINE` is assigned in `include/constants` **without `export`**, so the forked child sees it empty. The scripts then run `-e "s/..." ...`, and the shell tries to execute `-e`:

```
cycle-status: line 38: -e: command not found
```

which aborts status-bar setup and breaks the session. This one-liner exports the variable, matching the already-exported `BYOBU_SED` two lines above.

### Reproduction
On a Wolfi/Chainguard-based image, launching byobu triggers `byobu-janitor` → forked `cycle-status` → `-e: command not found` → `can't find session`, and the container exits non-zero.