### PR TITLE
build: install trustmux via autotools, add --disable-trustmux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,9 @@
+if ENABLE_TRUSTMUX
+TRUSTMUX_SUBDIR = mobile
+else
+TRUSTMUX_SUBDIR =
+endif
+
 SUBDIRS = etc/byobu \
 	etc/profile.d \
 	usr/share/byobu/desktop \
@@ -14,7 +20,12 @@ SUBDIRS = etc/byobu \
 	usr/lib/byobu/include \
 	usr/share/man/man1 \
 	usr/share/sounds/byobu \
-	usr/bin
+	usr/bin \
+	$(TRUSTMUX_SUBDIR)
+
+# mobile/ is also distributed by AM_CONDITIONAL=no users, so DIST_SUBDIRS
+# always includes it — keeps `make dist` complete regardless of --enable.
+DIST_SUBDIRS = $(SUBDIRS) mobile
 
 distclean-local:
 	rm -rf mobile/build mobile/dist mobile/trustmux.egg-info

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,18 @@ AC_PROG_LN_S
 
 # Checks for library functions.
 
+# Trustmux — mobile companion daemon. Enabled by default; pass
+# --disable-trustmux to skip installing the daemon, CLIs, and PWA assets
+# (e.g. for a minimal byobu install without a Python tornado runtime dep).
+AC_ARG_ENABLE([trustmux],
+  [AS_HELP_STRING([--disable-trustmux],
+    [do not install the Trustmux mobile companion daemon @<:@default=enabled@:>@])],
+  [enable_trustmux=$enableval],
+  [enable_trustmux=yes])
+AM_CONDITIONAL([ENABLE_TRUSTMUX], [test "x$enable_trustmux" = "xyes"])
+
 AC_OUTPUT(Makefile \
+	mobile/Makefile \
 	etc/byobu/Makefile \
 	etc/profile.d/Makefile \
 	etc/profile.d/Z97-byobu.sh \

--- a/debian/byobu.dirs
+++ b/debian/byobu.dirs
@@ -1,3 +1,1 @@
 usr/bin
-usr/lib/trustmux
-usr/share/trustmux/static/icons

--- a/debian/byobu.install
+++ b/debian/byobu.install
@@ -1,26 +1,5 @@
-# Extra placements not handled by autotools make install
+# Extra placements not handled by autotools make install.
+# Trustmux files are now installed by autotools via mobile/Makefile.am.
 usr/share/byobu/pixmaps/byobu.svg             usr/share/icons/hicolor/scalable/apps/
 usr/share/byobu/pixmaps/highcontrast/byobu.svg usr/share/icons/HighContrast/scalable/apps/
 debian/source_byobu.py                         usr/share/apport/package-hooks
-
-# Trustmux (mobile companion daemon) — folded into byobu package
-mobile/trustmux/__init__.py             usr/lib/trustmux/trustmux/
-mobile/trustmux/__main__.py             usr/lib/trustmux/trustmux/
-mobile/trustmux/_daemon.py              usr/lib/trustmux/trustmux/
-mobile/trustmux/_ctl.py                 usr/lib/trustmux/trustmux/
-mobile/trustmux/_pair.py                usr/lib/trustmux/trustmux/
-mobile/trustmux/_unpair.py              usr/lib/trustmux/trustmux/
-mobile/trustmux/_enable.py              usr/lib/trustmux/trustmux/
-mobile/trustmux/_disable.py             usr/lib/trustmux/trustmux/
-mobile/trustmux-ctl                     usr/bin/
-mobile/trustmux-pair                    usr/bin/
-mobile/trustmux-unpair                  usr/bin/
-mobile/trustmux-enable                  usr/bin/
-mobile/trustmux-disable                 usr/bin/
-mobile/trustmux/static/index.html           usr/share/trustmux/static/
-mobile/trustmux/static/app.js               usr/share/trustmux/static/
-mobile/trustmux/static/trustmux.svg         usr/share/trustmux/static/
-mobile/trustmux/static/trustmux-logo.svg    usr/share/trustmux/static/
-mobile/trustmux/static/sw.js                usr/share/trustmux/static/
-mobile/trustmux/static/icons/icon-192.png   usr/share/trustmux/static/icons/
-mobile/trustmux/static/icons/icon-512.png   usr/share/trustmux/static/icons/

--- a/debian/byobu.manpages
+++ b/debian/byobu.manpages
@@ -1,6 +1,0 @@
-mobile/man/man1/trustmux.1
-mobile/man/man1/trustmux-ctl.1
-mobile/man/man1/trustmux-pair.1
-mobile/man/man1/trustmux-unpair.1
-mobile/man/man1/trustmux-enable.1
-mobile/man/man1/trustmux-disable.1

--- a/debian/rules
+++ b/debian/rules
@@ -19,10 +19,6 @@ override_dh_auto_test:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/byobu
 
-override_dh_install:
-	dh_install
-	install -Dm755 mobile/trustmux-daemon debian/byobu/usr/bin/trustmux
-
 override_dh_perl:
 	dh_perl -d
 

--- a/mobile/Makefile.am
+++ b/mobile/Makefile.am
@@ -1,0 +1,102 @@
+# Trustmux — mobile companion daemon for byobu/tmux.
+#
+# The wrappers in $(bindir) import the trustmux Python package from a fixed
+# location (trustmuxpydir), so we install the modules to a flat directory
+# tree rather than into Python's site-packages.  This keeps autotools-based
+# installs decoupled from any system Python's site-packages layout, and
+# matches what downstream distro packaging has historically done.
+#
+# A parallel pip/PyPI distribution is built from this same source via
+# pyproject.toml; the two installation paths are independent.
+
+# Use $(prefix)/lib explicitly rather than $(libdir) so that Debian
+# multiarch builds (libdir=/usr/lib/x86_64-linux-gnu) still land Python
+# modules in the arch-independent /usr/lib/trustmux that the wrappers
+# expect — matching the historical Debian layout.
+trustmuxpydir = $(prefix)/lib/trustmux
+trustmuxmoddir = $(trustmuxpydir)/trustmux
+dist_trustmuxmod_DATA = \
+	trustmux/__init__.py \
+	trustmux/__main__.py \
+	trustmux/_daemon.py \
+	trustmux/_ctl.py \
+	trustmux/_pair.py \
+	trustmux/_unpair.py \
+	trustmux/_enable.py \
+	trustmux/_disable.py
+
+trustmuxstaticdir = $(datadir)/trustmux/static
+dist_trustmuxstatic_DATA = \
+	trustmux/static/index.html \
+	trustmux/static/app.js \
+	trustmux/static/sw.js \
+	trustmux/static/trustmux.svg \
+	trustmux/static/trustmux-logo.svg
+
+trustmuxiconsdir = $(datadir)/trustmux/static/icons
+dist_trustmuxicons_DATA = \
+	trustmux/static/icons/icon-192.png \
+	trustmux/static/icons/icon-512.png
+
+dist_man1_MANS = \
+	man/man1/trustmux.1 \
+	man/man1/trustmux-ctl.1 \
+	man/man1/trustmux-pair.1 \
+	man/man1/trustmux-unpair.1 \
+	man/man1/trustmux-enable.1 \
+	man/man1/trustmux-disable.1
+
+# Generated wrappers — sed-substitute @trustmuxpydir@ at build time so
+# the path resolves to the actual configure --prefix.  Using Make rules
+# rather than AC_CONFIG_FILES because $(libdir) is only fully expanded
+# at Make time, not configure time.
+WRAPPERS = \
+	trustmux-ctl \
+	trustmux-pair \
+	trustmux-unpair \
+	trustmux-enable \
+	trustmux-disable \
+	trustmux-daemon
+
+bin_SCRIPTS = $(WRAPPERS:%=%.gen)
+
+EXTRA_DIST = \
+	trustmux-ctl.in \
+	trustmux-pair.in \
+	trustmux-unpair.in \
+	trustmux-enable.in \
+	trustmux-disable.in \
+	trustmux-daemon.in \
+	pyproject.toml \
+	requirements.txt \
+	uv.lock \
+	README.md \
+	generate_screenshots.py \
+	tests/__init__.py \
+	tests/test_ctl.py \
+	tests/test_daemon.py \
+	tests/test_daemon_extended.py
+
+CLEANFILES = $(WRAPPERS:%=%.gen)
+
+do_subst = sed -e 's|@trustmuxpydir[@]|$(trustmuxpydir)|g'
+
+%.gen: %.in Makefile
+	$(do_subst) < $(srcdir)/$*.in > $@
+	chmod +x $@
+
+# Install with the right names (strip the .gen suffix) and rename
+# trustmux-daemon → trustmux to match Debian's historical layout, where
+# /usr/bin/trustmux is the user-facing entry point for the daemon.
+install-exec-hook:
+	cd $(DESTDIR)$(bindir) && \
+	  for w in trustmux-ctl trustmux-pair trustmux-unpair \
+	           trustmux-enable trustmux-disable; do \
+	    mv $$w.gen $$w; \
+	  done && \
+	  mv trustmux-daemon.gen trustmux
+
+uninstall-hook:
+	cd $(DESTDIR)$(bindir) && rm -f \
+	  trustmux trustmux-ctl trustmux-pair trustmux-unpair \
+	  trustmux-enable trustmux-disable

--- a/mobile/trustmux-ctl.in
+++ b/mobile/trustmux-ctl.in
@@ -3,11 +3,13 @@
 import sys
 import os
 
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._ctl import main
 

--- a/mobile/trustmux-daemon.in
+++ b/mobile/trustmux-daemon.in
@@ -3,11 +3,13 @@
 import sys
 import os
 
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._daemon import main
 

--- a/mobile/trustmux-disable.in
+++ b/mobile/trustmux-disable.in
@@ -3,11 +3,13 @@
 import sys
 import os
 
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._disable import main
 

--- a/mobile/trustmux-enable.in
+++ b/mobile/trustmux-enable.in
@@ -3,11 +3,13 @@
 import sys
 import os
 
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._enable import main
 

--- a/mobile/trustmux-pair.in
+++ b/mobile/trustmux-pair.in
@@ -3,13 +3,13 @@
 import sys
 import os
 
-# When run from the dev tree or Debian install (not via pip), the package may
-# not be on sys.path — add the directory that contains the trustmux/ package.
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._pair import main
 

--- a/mobile/trustmux-unpair.in
+++ b/mobile/trustmux-unpair.in
@@ -3,11 +3,13 @@
 import sys
 import os
 
+# When run from the dev tree, the package is in a sibling trustmux/ dir.
+# When installed by autotools, fall back to the configure-time trustmuxpydir.
 _here = os.path.dirname(os.path.abspath(__file__))
 if os.path.isdir(os.path.join(_here, "trustmux")):
     sys.path.insert(0, _here)
 else:
-    sys.path.insert(0, "/usr/lib/trustmux")
+    sys.path.insert(0, "@trustmuxpydir@")
 
 from trustmux._unpair import main
 


### PR DESCRIPTION
## Summary

The trustmux mobile companion (Python daemon, CLIs, PWA assets, man pages) was previously installed only by downstream distro packaging (`debian/byobu.install` + an extra line in `debian/rules`). As a result, non-Debian packagers — Wolfi/Chainguard apk, Homebrew bottling, RPM specs, plain `make install` from source — silently shipped byobu without trustmux even though the source tree contained it.

This PR folds the install into autotools so every consumer of `make install` gets the same layout Debian has historically produced.

## Layout (unchanged from Debian today)

```
/usr/bin/trustmux                 (was mobile/trustmux-daemon)
/usr/bin/trustmux-{ctl,pair,unpair,enable,disable}
/usr/lib/trustmux/trustmux/*.py
/usr/share/trustmux/static/{index.html,app.js,sw.js,*.svg,icons/*}
/usr/share/man/man1/trustmux*.1
```

## Implementation notes

- **`mobile/Makefile.am`** installs the Python package, static assets, icons, and man pages via `*_DATA` / `dist_man1_MANS` rules. Uses `$(prefix)/lib/trustmux` rather than `$(libdir)/trustmux` so Debian multiarch builds (`libdir=/usr/lib/<triplet>`) still land Python modules in the arch-independent path the wrappers expect.
- **Wrappers converted to `.in` templates** with `@trustmuxpydir@` substituted at build time via `sed`. This fixes a latent bug where `--prefix=/usr/local` or `--prefix=$HOME` would install wrappers that still hardcoded `/usr/lib/trustmux` — now Homebrew, source installs, and other non-`/usr` prefixes work correctly.
- **`install-exec-hook`** strips the `.gen` suffix and renames `trustmux-daemon` → `trustmux` to match Debian's bin layout.
- **`--enable-trustmux` / `--disable-trustmux`** (default enabled) for minimal byobu installs that don't want a Python tornado runtime dep.
- **`DIST_SUBDIRS`** unconditionally includes `mobile/` so `make dist` is independent of the configure-time choice.

## Parallel distribution paths preserved

- **pip / PyPI** (`mobile/pyproject.toml`) — unchanged. Installs through setuptools `[project.scripts]` entry points into site-packages, independent of autotools.
- **Homebrew bottle** — unchanged source layout; bottle can keep using its existing recipe.

## Debian packaging simplified

- `debian/byobu.install` — drop the 20 lines of trustmux file map.
- `debian/rules` — drop the `override_dh_install` rule that installed `mobile/trustmux-daemon` manually.
- `debian/byobu.manpages` — removed; man pages ship via autotools.
- `debian/byobu.dirs` — drop `/usr/lib/trustmux` and `/usr/share/trustmux` pre-created dirs; autotools creates them.

## Test plan

- [x] `./configure --prefix=/usr && make && make install DESTDIR=/tmp/install` produces the expected layout on `ubuntu:devel`
- [x] Installed wrappers run: `trustmux --help`, `trustmux-ctl --help`, `trustmux-enable --help` all import tornado and execute
- [x] `./configure --prefix=/usr --disable-trustmux && make install DESTDIR=/tmp/install2` installs zero trustmux files while byobu itself still installs
- [x] `make dist` tarball includes all `mobile/` files (Makefile.am, .in templates, Python package, static assets, man pages, pyproject.toml, tests) regardless of configure-time choice
- [x] `dpkg-buildpackage -us -uc -b` on `ubuntu:devel` produces a `byobu_*.deb` with the same trustmux file list as before this change
- [ ] CI: verify on other prefixes (Homebrew `/usr/local`, `/opt/homebrew`) — not tested locally; the templated path makes this should-work-by-construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)