### PR TITLE
trustmux: fix greedy OSC parser swallowing pane content after hyperlinks

### DIFF
--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -501,7 +501,7 @@ function ansiToHtml(text) {
       i++;
     }
   }
-  const TOK = /([^\x1b]+)|\x1b(?:\[([0-9;]*)([A-Za-z])|\][^\x07]*(?:\x07|\x1b\\)|(.))/g;
+  const TOK = /([^\x1b]+)|\x1b(?:\[([0-9;]*)([A-Za-z])|\][^\x07\x1b]*(?:\x07|\x1b\\)|(.))/g;
   for (const m of text.matchAll(TOK)) {
     if (m[1])              emit(m[1]);
     else if (m[3] === 'm') sgr(m[2] ? m[2].split(';').map(Number) : [0]);


### PR DESCRIPTION
## Summary

The client-side ANSI tokenizer in `mobile/trustmux/static/app.js` had a subtly wrong regex that made the PWA truncate pane content whenever an OSC-8 hyperlink (or any OSC sequence) appeared. The daemon-side stripper in `_daemon.py` already had the correct pattern; only the JS diverged.

## Symptom

In the PWA, a pane running Claude Code (or anything else that emits OSC-8 hyperlinks — `gh`, `git`, `less -R` with hyperlinked refs, etc.) would render only up to the first hyperlink, then cut off — often ending mid-line at something like \`. Update (\` (Claude's version-update footer, whose \`(v…)\` is a hyperlink). SSH to the same tmux session showed all the text correctly, so it was clearly a client-side rendering issue.

## Root cause

`app.js` used:
\`\`\`js
const TOK = /…|\x1b\][^\x07]*(?:\x07|\x1b\\)|…/g;
//                    ^^^^^^^^^
\`\`\`

`[^\x07]*` is greedy AND permits `\x1b` inside. Given real Claude Code output like:
\`\`\`
\x1b]8;id=abc;https://github.com/…\x1b\<label>\x1b[0m\x1b]8;;\x1b\
…lots more text…
\x1b]8;id=xyz;https://…\x1b\<label>\x1b]8;;\x1b\
\`\`\`
the OSC branch matches from the first `\x1b]` through the **last** `\x1b\` in the buffer, silently discarding thousands of characters of visible content in between.

Meanwhile `_daemon.py`'s `ANSI_RE` already used `[^\x07\x1b]*` — the correct exclusion. The client and server had diverged.

## Fix

One character:
\`\`\`diff
-const TOK = /([^\x1b]+)|\x1b(?:\[([0-9;]*)([A-Za-z])|\][^\x07]*(?:\x07|\x1b\\)|(.))/g;
+const TOK = /([^\x1b]+)|\x1b(?:\[([0-9;]*)([A-Za-z])|\][^\x07\x1b]*(?:\x07|\x1b\\)|(.))/g;
\`\`\`

Excluding `\x1b` from the OSC payload class makes the match stop at the ST terminator (`\x1b\`) instead of running off past it. Matches the daemon-side behavior. Standard OSC parsing.

## Test plan

Reproduced against a real 52,108-byte pane snapshot captured from a live Claude Code session with 19 OSC-8 hyperlinks:

- [x] Broken regex: 894 rendered chars (truncates at first hyperlink)
- [x] Fixed regex: 27,234 rendered chars (all text preserved; escape sequences correctly consumed)
- [x] Manual: reload PWA after patching \`/usr/share/trustmux/static/app.js\` → gpu pane now renders in full
- [x] No behavior change for panes without OSC sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)