### PR TITLE
trustmux: add --port/$TRUSTMUX_PORT to the CLI

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -71,6 +71,20 @@ trustmux pair           # generate a pairing code for a new device
 trustmux unpair         # list paired devices and remove them
 ```
 
+### A different port
+
+The daemon listens on 7432 by default. `--port` (or `$TRUSTMUX_PORT`) changes
+it for `setup`, `start`, `start-local`, `start-direct`, `stop`, `restart`,
+`status` and `enable`:
+
+```bash
+trustmux start --port 3389
+trustmux status              # finds it — no need to repeat --port
+```
+
+`stop`, `status` and `pair` ask the running daemon which port it is on, so only
+the start command needs the flag. `enable --port` records it in the login hook.
+
 ---
 
 ## Setup from source

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -10,11 +10,18 @@ _trustmux() {
         return
     fi
 
+    if [[ $prev == "--port" ]]; then
+        return
+    fi
+
     case "${words[1]}" in
         setup)
-            COMPREPLY=($(compgen -W "--quiet" -- "$cur"))
+            COMPREPLY=($(compgen -W "--quiet --port" -- "$cur"))
             ;;
-        start|start-local|start-direct|stop|restart|status|log|enable|disable|pair|unpair)
+        start|start-local|start-direct|stop|restart|status|enable)
+            COMPREPLY=($(compgen -W "--port" -- "$cur"))
+            ;;
+        log|disable|pair|unpair)
             ;;
     esac
 }

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -21,7 +21,8 @@ device pairing.
 .B setup
 One-time setup: verify Tailscale is installed and connected, then configure
 .B tailscale serve
-for HTTPS on port 7432.
+for HTTPS on the daemon port (7432 by default; see
+.BR \-\-port ).
 .TP
 .B start
 Start the daemon in HTTPS mode via
@@ -82,6 +83,44 @@ time) and offer an interactive menu to remove one or all of them.
 .TP
 .B setup \-\-quiet
 Suppress the "Next steps" output after a successful setup.
+.TP
+.BI \-\-port " PORT"
+TCP port the daemon listens on (default: 7432).
+Accepted by
+.BR setup ,
+.BR start ,
+.BR start\-local ,
+.BR start\-direct ,
+.BR stop ,
+.BR restart ,
+.B status
+and
+.BR enable .
+.IP
+Only the port changes; each mode binds the same address it always has.
+.B stop
+and
+.B status
+do not normally need the flag: they ask the running daemon over the admin
+socket which port it is on, so a daemon started on a non-default port is still
+found without repeating
+.BR \-\-port .
+The same answer gives
+.B pair
+the correct URL and QR code.
+.IP
+.B enable
+records the port in the login hook it writes, so a non-default port survives
+logout; re-running
+.B "enable \-\-port"
+rewrites an existing hook rather than leaving the old port in place.
+.SH ENVIRONMENT
+.TP
+.B TRUSTMUX_PORT
+Default port when
+.B \-\-port
+is not given, for users who always want a different port.
+An out-of-range or non-numeric value is an error, not a silent fallback.
 .SH FILES
 .TP
 .I ~/.config/trustmux/trustmux.log
@@ -119,6 +158,17 @@ Daily use:
 trustmux status
 trustmux restart
 trustmux log
+.fi
+.RE
+.PP
+Run on a different port; later commands find it without the flag:
+.PP
+.RS
+.nf
+trustmux start\-direct \-\-port 3389
+trustmux status
+trustmux pair
+trustmux stop
 .fi
 .RE
 .SH SECURITY

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -3,8 +3,10 @@
 import json
 import os
 import signal
+import socket
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -14,6 +16,20 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import trustmux._ctl as ctl
 import trustmux._enable as enable
 import trustmux._disable as disable
+
+_no_daemon = None
+
+
+def setUpModule():
+    # resolve_port() asks the running daemon which port it is on; without this
+    # the suite would pick up a real trustmux on the developer's machine.
+    global _no_daemon
+    _no_daemon = patch('trustmux._ctl.daemon_info', return_value=None)
+    _no_daemon.start()
+
+
+def tearDownModule():
+    _no_daemon.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +164,7 @@ class TestCheckTls(unittest.TestCase):
 class TestEnsureTsServe(unittest.TestCase):
 
     def test_already_configured(self):
-        port_str = f':{ctl.PORT}'
+        port_str = f':{ctl.DEFAULT_PORT}'
         with patch('trustmux._ctl.subprocess.check_output',
                    return_value=f'https/tcp/0:443 → {port_str}\n'):
             with patch('trustmux._ctl.subprocess.run') as mock_run:
@@ -383,7 +399,7 @@ class TestCmdStatus(unittest.TestCase):
         mock_print.assert_called_once_with('trustmux not running')
 
     def test_running_with_tailscale_serve(self):
-        port_str = f':{ctl.PORT}'
+        port_str = f':{ctl.DEFAULT_PORT}'
         with patch('trustmux._ctl._pid', return_value=1234):
             with patch('trustmux._ctl.subprocess.check_output',
                        return_value=f'something {port_str} here'):
@@ -394,16 +410,33 @@ class TestCmdStatus(unittest.TestCase):
         printed = ' '.join(str(c) for c in mock_print.call_args_list)
         self.assertIn('https://engawa.ts.net', printed)
 
-    def test_running_direct_http(self):
+    def test_running_direct_uses_daemon_reported_url(self):
         import subprocess as sp
-        with patch('trustmux._ctl._pid', return_value=1234):
-            with patch('trustmux._ctl.subprocess.check_output',
-                       side_effect=[sp.CalledProcessError(1, 'ts'), '100.64.0.1\n']):
-                with patch('builtins.print') as mock_print:
-                    result = ctl.cmd_status()
+        info = {'host': '0.0.0.0', 'port': 3389, 'scheme': 'https'}
+        with patch('trustmux._ctl.daemon_info', return_value=info):
+            with patch('trustmux._ctl._pid', return_value=1234):
+                with patch('trustmux._ctl._lan_ip', return_value='192.168.1.9'):
+                    with patch('trustmux._ctl.subprocess.check_output',
+                               side_effect=sp.CalledProcessError(1, 'ts')):
+                        with patch('builtins.print') as mock_print:
+                            result = ctl.cmd_status()
         self.assertEqual(result, 0)
         printed = ' '.join(str(c) for c in mock_print.call_args_list)
-        self.assertIn('direct HTTP', printed)
+        self.assertIn('https://192.168.1.9:3389/', printed)
+        self.assertIn('port 3389', printed)
+
+    def test_running_local_reports_loopback_http(self):
+        import subprocess as sp
+        info = {'host': '127.0.0.1', 'port': 3389, 'scheme': 'http'}
+        with patch('trustmux._ctl.daemon_info', return_value=info):
+            with patch('trustmux._ctl._pid', return_value=1234):
+                with patch('trustmux._ctl.subprocess.check_output',
+                           side_effect=sp.CalledProcessError(1, 'ts')):
+                    with patch('builtins.print') as mock_print:
+                        result = ctl.cmd_status()
+        self.assertEqual(result, 0)
+        printed = ' '.join(str(c) for c in mock_print.call_args_list)
+        self.assertIn('http://localhost:3389/', printed)
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +731,256 @@ class TestMainHelp(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 ctl.main()
             mock_print.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Port selection: --port / $TRUSTMUX_PORT / running daemon / default
+# ---------------------------------------------------------------------------
+
+class TestValidPort(unittest.TestCase):
+
+    def test_accepts_int_and_numeric_string(self):
+        self.assertEqual(ctl._valid_port(3389), 3389)
+        self.assertEqual(ctl._valid_port('3389'), 3389)
+
+    def test_rejects_out_of_range_and_junk(self):
+        for bad in (0, -1, 65536, 'abc', '', None, 3.5j):
+            self.assertIsNone(ctl._valid_port(bad), bad)
+
+
+class TestResolvePort(unittest.TestCase):
+
+    def setUp(self):
+        self.env = patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop(ctl.PORT_ENV, None)
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_default_when_nothing_set(self):
+        self.assertEqual(ctl.resolve_port(), ctl.DEFAULT_PORT)
+
+    def test_explicit_wins_over_env_and_daemon(self):
+        os.environ[ctl.PORT_ENV] = '4444'
+        with patch('trustmux._ctl.daemon_info', return_value={'port': 5555}):
+            self.assertEqual(ctl.resolve_port(3389), 3389)
+
+    def test_env_wins_over_daemon(self):
+        os.environ[ctl.PORT_ENV] = '4444'
+        with patch('trustmux._ctl.daemon_info', return_value={'port': 5555}):
+            self.assertEqual(ctl.resolve_port(), 4444)
+
+    def test_falls_back_to_running_daemon(self):
+        with patch('trustmux._ctl.daemon_info', return_value={'port': 5555}):
+            self.assertEqual(ctl.resolve_port(), 5555)
+
+    def test_ignores_nonsense_from_daemon(self):
+        with patch('trustmux._ctl.daemon_info', return_value={'port': 'wat'}):
+            self.assertEqual(ctl.resolve_port(), ctl.DEFAULT_PORT)
+
+    def test_blank_env_is_ignored(self):
+        os.environ[ctl.PORT_ENV] = '   '
+        self.assertEqual(ctl.resolve_port(), ctl.DEFAULT_PORT)
+
+    def test_invalid_env_exits_2(self):
+        os.environ[ctl.PORT_ENV] = '99999'
+        with patch('trustmux._ctl.sys.stderr'):
+            with self.assertRaises(SystemExit) as cm:
+                ctl.resolve_port()
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_invalid_explicit_exits_2(self):
+        with patch('trustmux._ctl.sys.stderr'):
+            with self.assertRaises(SystemExit) as cm:
+                ctl.resolve_port(0)
+        self.assertEqual(cm.exception.code, 2)
+
+
+class TestPortOpt(unittest.TestCase):
+
+    def test_empty_for_default(self):
+        self.assertEqual(ctl.port_opt(ctl.DEFAULT_PORT), '')
+
+    def test_flag_for_custom(self):
+        self.assertEqual(ctl.port_opt(3389), ' --port 3389')
+
+
+class TestDaemonInfo(unittest.TestCase):
+    """setUpModule stubs daemon_info out for the rest of the suite; these cases
+    exercise the real implementation against a real unix socket."""
+
+    def setUp(self):
+        _no_daemon.stop()
+        self.addCleanup(_no_daemon.start)
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.sock_path = Path(self.td.name) / 'trustmux.sock'
+
+    def _serve_once(self, reply: bytes) -> None:
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(str(self.sock_path))
+        srv.listen(1)
+        self.addCleanup(srv.close)
+
+        def handle():
+            conn, _ = srv.accept()
+            with conn:
+                conn.recv(4096)
+                conn.sendall(reply)
+
+        t = threading.Thread(target=handle, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+
+    def test_none_when_socket_absent(self):
+        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
+            self.assertIsNone(ctl.daemon_info())
+
+    def test_returns_listener_details(self):
+        self._serve_once(b'{"pid": 42, "host": "0.0.0.0", "port": 3389, "scheme": "https"}\n')
+        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
+            info = ctl.daemon_info()
+        self.assertEqual(info['port'], 3389)
+        self.assertEqual(info['scheme'], 'https')
+
+    def test_none_on_error_reply(self):
+        self._serve_once(b'{"error": "unknown action"}\n')
+        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
+            self.assertIsNone(ctl.daemon_info())
+
+    def test_none_on_garbage_reply(self):
+        self._serve_once(b'not json\n')
+        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
+            self.assertIsNone(ctl.daemon_info())
+
+
+class TestDirectUrl(unittest.TestCase):
+
+    def test_loopback_bind_is_localhost(self):
+        url = ctl.direct_url(3389, {'host': '127.0.0.1', 'scheme': 'http'})
+        self.assertEqual(url, 'http://localhost:3389/')
+
+    def test_wildcard_bind_uses_lan_ip(self):
+        with patch('trustmux._ctl._lan_ip', return_value='192.168.1.9'):
+            url = ctl.direct_url(3389, {'host': '0.0.0.0', 'scheme': 'https'})
+        self.assertEqual(url, 'https://192.168.1.9:3389/')
+
+    def test_defaults_to_https_when_daemon_silent(self):
+        with patch('trustmux._ctl._lan_ip', return_value='192.168.1.9'):
+            self.assertEqual(ctl.direct_url(7432, {}), 'https://192.168.1.9:7432/')
+
+    def test_live_daemon_port_wins_over_caller(self):
+        url = ctl.direct_url(4444, {'host': '127.0.0.1', 'port': 3389, 'scheme': 'http'})
+        self.assertEqual(url, 'http://localhost:3389/')
+
+
+class TestLaunchPort(unittest.TestCase):
+
+    def test_passes_resolved_port_to_daemon(self):
+        with patch('trustmux._ctl._ensure_dir'):
+            with patch('trustmux._ctl.LOGFILE'):
+                with patch('trustmux._ctl.PIDFILE'):
+                    with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
+                        with patch('trustmux._ctl.time.sleep'):
+                            with patch('trustmux._ctl._pid', return_value=4321):
+                                ctl._launch(3389, ['--host', '127.0.0.1'])
+        argv = mock_popen.call_args[0][0]
+        self.assertIn('--port', argv)
+        self.assertEqual(argv[argv.index('--port') + 1], '3389')
+        # Never handed to a shell.
+        self.assertNotIn('shell', mock_popen.call_args.kwargs)
+
+
+class TestEnsureTsServePort(unittest.TestCase):
+
+    def test_serves_the_requested_port(self):
+        with patch('trustmux._ctl.subprocess.check_output', return_value='nothing'):
+            with patch('trustmux._ctl.subprocess.run') as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                self.assertTrue(ctl._ensure_ts_serve(3389))
+        self.assertEqual(mock_run.call_args[0][0],
+                         ['tailscale', 'serve', '--bg', '3389'])
+
+
+class TestCmdStartPort(unittest.TestCase):
+
+    def test_start_local_launches_on_requested_port(self):
+        with patch('trustmux._ctl._pid', return_value=None):
+            with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
+                with patch('builtins.print'):
+                    self.assertEqual(ctl.cmd_start('start-local', 3389), 0)
+        self.assertEqual(mock_launch.call_args[0][0], 3389)
+
+    def test_refuses_when_something_already_owns_that_port(self):
+        with patch('trustmux._ctl._pid', return_value=999) as mock_pid:
+            with patch('builtins.print'):
+                self.assertEqual(ctl.cmd_start('start-local', 3389), 1)
+        mock_pid.assert_called_once_with(3389)
+
+
+class TestCmdStopPort(unittest.TestCase):
+
+    def test_stops_pid_found_on_requested_port(self):
+        with patch('trustmux._ctl._pid', return_value=1234) as mock_pid:
+            with patch('trustmux._ctl.PIDFILE') as mock_pidfile:
+                mock_pidfile.exists.return_value = False
+                with patch('trustmux._ctl.os.kill') as mock_kill:
+                    with patch('builtins.print'):
+                        self.assertEqual(ctl.cmd_stop(3389), 0)
+        mock_pid.assert_called_once_with(3389)
+        mock_kill.assert_called_once_with(1234, signal.SIGTERM)
+
+
+# ---------------------------------------------------------------------------
+# Login hook carries the port
+# ---------------------------------------------------------------------------
+
+class TestHookLine(unittest.TestCase):
+
+    def test_default_port_keeps_legacy_line(self):
+        self.assertEqual(enable.hook_line(ctl.DEFAULT_PORT), enable._HOOK)
+
+    def test_custom_port_is_carried(self):
+        self.assertEqual(enable.hook_line(3389),
+                         'trustmux start --port 3389 2>/dev/null || true\n')
+
+    def test_is_hook_line_matches_both_formats(self):
+        self.assertTrue(enable.is_hook_line('trustmux start 2>/dev/null || true'))
+        self.assertTrue(enable.is_hook_line('trustmux start --port 3389 2>/dev/null || true'))
+        self.assertTrue(enable.is_hook_line('trustmux-ctl start'))
+        self.assertFalse(enable.is_hook_line('# trustmux is great'))
+        self.assertFalse(enable.is_hook_line('alias tm="trustmux status"'))
+
+
+class TestInstallHookPort(unittest.TestCase):
+
+    def _profile(self, content):
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.profile', delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(Path(f.name).unlink)
+        return Path(f.name)
+
+    def test_appends_hook_with_port(self):
+        p = self._profile('# existing\n')
+        enable._install_hook(p, enable.hook_line(3389))
+        self.assertIn('trustmux start --port 3389 2>/dev/null', p.read_text())
+
+    def test_rewrites_existing_hook_with_new_port(self):
+        p = self._profile('# top\ntrustmux start 2>/dev/null || true\n# bottom\n')
+        enable._install_hook(p, enable.hook_line(3389))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 1)
+        self.assertIn('--port 3389', text)
+        self.assertIn('# top', text)
+        self.assertIn('# bottom', text)
+
+    def test_disable_removes_hook_with_port(self):
+        p = self._profile('# top\ntrustmux start --port 3389 2>/dev/null || true\n')
+        disable._remove_hook(p)
+        self.assertNotIn('trustmux start', p.read_text())
+        self.assertIn('# top', p.read_text())
 
 
 if __name__ == '__main__':

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -652,6 +652,29 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
         self.assertIn('expires_in', resp)
         self.assertTrue(bm._pair_code)
 
+    async def test_info_reports_listener(self):
+        with patch.object(bm, '_listen',
+                          {'host': '0.0.0.0', 'port': 3389, 'scheme': 'https'}):
+            resp = await self._call({'action': 'info'})
+        self.assertEqual(resp['host'], '0.0.0.0')
+        self.assertEqual(resp['port'], 3389)
+        self.assertEqual(resp['scheme'], 'https')
+        self.assertEqual(resp['pid'], os.getpid())
+
+    async def test_info_leaks_no_session_tokens(self):
+        _add_session('tok_secret_value')
+        with patch.object(bm, '_listen',
+                          {'host': '127.0.0.1', 'port': 7432, 'scheme': 'http'}):
+            resp = await self._call({'action': 'info'})
+        self.assertNotIn('tok_secret_value', json.dumps(resp))
+        self.assertEqual(set(resp), {'pid', 'host', 'port', 'scheme'})
+
+    async def test_info_before_listen_is_empty_not_an_error(self):
+        with patch.object(bm, '_listen', {}):
+            resp = await self._call({'action': 'info'})
+        self.assertEqual(resp['port'], 0)
+        self.assertNotIn('error', resp)
+
     async def test_sessions_list_empty(self):
         resp = await self._call({'action': 'sessions_list'})
         self.assertIsInstance(resp, list)

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,11 +11,13 @@ import sys
 import time
 from pathlib import Path
 
-PORT       = 7432
+DEFAULT_PORT = 7432
+PORT_ENV   = "TRUSTMUX_PORT"
 SERVE_PORT = 443  # tailscale serve terminates TLS on :443
 CONFIG_DIR = Path.home() / ".config" / "trustmux"
 LOGFILE    = CONFIG_DIR / "trustmux.log"
 PIDFILE    = CONFIG_DIR / "trustmux.pid"
+ADMIN_SOCK = CONFIG_DIR / "trustmux.sock"
 TOKENS_FILE = CONFIG_DIR / "tokens.json"
 
 
@@ -62,17 +64,118 @@ def _check_tls() -> bool:
         return False
 
 
+def _valid_port(value: object) -> int | None:
+    """Return value as a TCP port number, or None if it is not one."""
+    try:
+        port = int(value)   # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return port if 1 <= port <= 65535 else None
+
+
+def daemon_info() -> dict | None:
+    """Ask the running daemon what it is listening on.
+
+    Returns {"pid", "host", "port", "scheme"} or None if no daemon answers.
+    """
+    if not ADMIN_SOCK.exists():
+        return None
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(5)
+            s.connect(str(ADMIN_SOCK))
+            s.sendall(b'{"action": "info"}\n')
+            s.shutdown(socket.SHUT_WR)
+            chunks = []
+            while True:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        info = json.loads(b"".join(chunks))
+    except Exception:
+        return None
+    if not isinstance(info, dict) or "error" in info:
+        return None
+    return info
+
+
+def resolve_port(explicit: int | None = None) -> int:
+    """Return the port to operate on.
+
+    Precedence: --port, then $TRUSTMUX_PORT, then whatever the running daemon
+    reports, then the default.  Consulting the daemon is what lets stop/status/
+    pair find a daemon that was started on a non-default port without having to
+    repeat the flag.
+    """
+    if explicit is not None:
+        port = _valid_port(explicit)
+        if port is None:
+            print(f"Error: invalid port {explicit!r} — expected 1-65535.", file=sys.stderr)
+            sys.exit(2)
+        return port
+
+    env = os.environ.get(PORT_ENV, "").strip()
+    if env:
+        port = _valid_port(env)
+        if port is None:
+            print(f"Error: invalid {PORT_ENV}={env!r} — expected 1-65535.", file=sys.stderr)
+            sys.exit(2)
+        return port
+
+    info = daemon_info()
+    if info:
+        port = _valid_port(info.get("port"))
+        if port is not None:
+            return port
+
+    return DEFAULT_PORT
+
+
+def port_opt(port: int) -> str:
+    """' --port N' when port is not the default, else '' — for printed hints."""
+    return "" if port == DEFAULT_PORT else f" --port {port}"
+
+
+def _lan_ip() -> str:
+    """Best-effort primary LAN address, or 'localhost' if undeterminable."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "localhost"
+
+
+def direct_url(port: int, info: dict | None = None) -> str:
+    """URL for reaching the daemon directly (no tailscale serve in front).
+
+    Uses the daemon's own reported bind address and scheme when it is running,
+    so loopback-only and self-signed modes each print something usable.
+    """
+    if info is None:
+        info = daemon_info() or {}
+    # A live daemon's own port beats the caller's idea of it.
+    port = _valid_port(info.get("port")) or port
+    scheme = info.get("scheme") or "https"
+    host = info.get("host") or ""
+    hostname = "localhost" if host in ("127.0.0.1", "localhost", "::1") else _lan_ip()
+    return f"{scheme}://{hostname}:{port}/"
+
+
 def _ensure_dir() -> None:
     CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
     LOGFILE.touch()
     LOGFILE.chmod(0o600)
 
 
-def _pid() -> int | None:
-    """Return PID of process listening on PORT, or None."""
+def _pid(port: int = DEFAULT_PORT) -> int | None:
+    """Return PID of process listening on port, or None."""
     try:
         out = subprocess.check_output(
-            ["lsof", f"-ti:{PORT}"], stderr=subprocess.DEVNULL, text=True
+            ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
         ).strip()
         if out:
             return int(out.splitlines()[0])
@@ -183,23 +286,23 @@ def warn_if_peer_blocked(port: int = SERVE_PORT, stream=sys.stderr) -> None:
     print( "", file=stream)
 
 
-def _ensure_ts_serve() -> bool:
-    """Configure tailscale serve for PORT. Returns True on success."""
+def _ensure_ts_serve(port: int = DEFAULT_PORT) -> bool:
+    """Configure tailscale serve for port. Returns True on success."""
     try:
         out = subprocess.check_output(
             ["tailscale", "serve", "status"],
             stderr=subprocess.DEVNULL, text=True,
         )
-        if f":{PORT}" in out:
-            print(f"✓ tailscale serve already configured for port {PORT}")
+        if f":{port}" in out:
+            print(f"✓ tailscale serve already configured for port {port}")
             return True
     except Exception:
         pass
 
-    print(f"Enabling tailscale serve (HTTPS → localhost:{PORT})...")
+    print(f"Enabling tailscale serve (HTTPS → localhost:{port})...")
     try:
         subprocess.run(
-            ["tailscale", "serve", "--bg", str(PORT)],
+            ["tailscale", "serve", "--bg", str(port)],
             check=True, stderr=subprocess.DEVNULL,
         )
         print("✓ tailscale serve configured")
@@ -212,12 +315,12 @@ def _ensure_ts_serve() -> bool:
     print("Error: could not configure tailscale serve.", file=sys.stderr)
     print("Your user needs Tailscale operator permission (one-time setup). Run:", file=sys.stderr)
     print(f"  sudo tailscale set --operator={user}", file=sys.stderr)
-    print(f"  tailscale serve --bg {PORT}", file=sys.stderr)
+    print(f"  tailscale serve --bg {port}", file=sys.stderr)
     print("Then re-run: trustmux start", file=sys.stderr)
     return False
 
 
-def _launch(extra_args: list[str]) -> int | None:
+def _launch(port: int, extra_args: list[str]) -> int | None:
     """Launch daemon as a detached background process. Returns PID or None."""
     _ensure_dir()
     # Ensure the package directory is on the subprocess's Python path so that
@@ -229,7 +332,7 @@ def _launch(extra_args: list[str]) -> int | None:
     env["PYTHONPATH"] = f"{pkg_parent}:{existing}" if existing else pkg_parent
     with LOGFILE.open("a") as log:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "trustmux", "--port", str(PORT)] + extra_args,
+            [sys.executable, "-m", "trustmux", "--port", str(port)] + extra_args,
             stdout=log, stderr=log,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
@@ -237,10 +340,11 @@ def _launch(extra_args: list[str]) -> int | None:
         )
     PIDFILE.write_text(str(proc.pid))
     time.sleep(0.5)
-    return _pid()
+    return _pid(port)
 
 
-def cmd_setup(quiet: bool = False) -> int:
+def cmd_setup(quiet: bool = False, port: int | None = None) -> int:
+    port = resolve_port(port)
     print("=== trustmux setup ===\n")
 
     # Verify package is importable
@@ -268,21 +372,22 @@ def cmd_setup(quiet: bool = False) -> int:
         return 1
     print(f"✓ Tailscale connected as {ts_host}")
 
-    if not _ensure_ts_serve():
+    if not _ensure_ts_serve(port):
         return 1
 
     warn_if_peer_blocked()
 
     if not quiet:
         print("\nSetup complete. Next steps:\n")
-        print("  1. Start the daemon:      trustmux start")
+        print(f"  1. Start the daemon:      trustmux start{port_opt(port)}")
         print("  2. Generate pairing code: trustmux pair")
         print(f"  3. Open on your phone:    https://{ts_host}")
     return 0
 
 
-def cmd_start(mode: str = "serve") -> int:
-    p = _pid()
+def cmd_start(mode: str = "serve", port: int | None = None) -> int:
+    port = resolve_port(port)
+    p = _pid(port)
     if p:
         print(f"trustmux already running (pid {p})")
         return 1
@@ -304,10 +409,10 @@ def cmd_start(mode: str = "serve") -> int:
         if not ts_host:
             print("Error: cannot determine Tailscale hostname (is tailscale up?)", file=sys.stderr)
             return 1
-        if not _ensure_ts_serve():
+        if not _ensure_ts_serve(port):
             return 1
         print("Starting trustmux (HTTPS mode)...")
-        pid = _launch(["--host", "127.0.0.1", "--https"])
+        pid = _launch(port, ["--host", "127.0.0.1", "--https"])
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
@@ -315,13 +420,13 @@ def cmd_start(mode: str = "serve") -> int:
 
     elif mode == "start-local":
         print("Starting trustmux (loopback only — SSH tunnel access)...")
-        pid = _launch(["--host", "127.0.0.1"])
+        pid = _launch(port, ["--host", "127.0.0.1"])
         ok = pid is not None
         if ok:
             fqdn = socket.getfqdn()
             print(f"trustmux started (pid {pid})")
-            print(f"Access via SSH tunnel: ssh -L {PORT}:localhost:{PORT} user@{fqdn}")
-            print(f"Then open: http://localhost:{PORT}")
+            print(f"Access via SSH tunnel: ssh -L {port}:localhost:{port} user@{fqdn}")
+            print(f"Then open: http://localhost:{port}")
 
     elif mode == "start-direct":
         if not _check_tmux():
@@ -329,18 +434,11 @@ def cmd_start(mode: str = "serve") -> int:
         if not _check_tls():
             return 1
         print("Starting trustmux (direct HTTPS — self-signed cert)...")
-        pid = _launch(["--host", "0.0.0.0", "--self-signed"])
+        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"])
         ok = pid is not None
         if ok:
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.connect(("8.8.8.8", 80))
-                local_ip = s.getsockname()[0]
-                s.close()
-            except Exception:
-                local_ip = "localhost"
             print(f"trustmux started (pid {pid})")
-            print(f"Connect: https://{local_ip}:{PORT}")
+            print(f"Connect: https://{_lan_ip()}:{port}")
             print(f"  (browser will warn about self-signed cert — click through to proceed)")
 
     else:
@@ -353,8 +451,9 @@ def cmd_start(mode: str = "serve") -> int:
     return 0
 
 
-def cmd_stop() -> int:
-    p = _pid()
+def cmd_stop(port: int | None = None) -> int:
+    port = resolve_port(port)
+    p = _pid(port)
     if not p:
         print("trustmux not running")
         PIDFILE.unlink(missing_ok=True)
@@ -364,7 +463,7 @@ def cmd_stop() -> int:
         try:
             file_pid = int(PIDFILE.read_text().strip())
             if file_pid != p:
-                print(f"Error: pid {p} owns port {PORT} but PIDFILE contains {file_pid}.",
+                print(f"Error: pid {p} owns port {port} but PIDFILE contains {file_pid}.",
                       file=sys.stderr)
                 print(f"Refusing to kill. Remove {PIDFILE} manually if trustmux is truly stopped.",
                       file=sys.stderr)
@@ -378,32 +477,28 @@ def cmd_stop() -> int:
     return 0
 
 
-def cmd_status() -> int:
-    p = _pid()
+def cmd_status(port: int | None = None) -> int:
+    info = daemon_info()
+    port = resolve_port(port)
+    p = _pid(port)
     if not p:
         print("trustmux not running")
         return 0
 
-    print(f"trustmux running (pid {p}) — port {PORT}")
+    print(f"trustmux running (pid {p}) — port {port}")
     try:
         out = subprocess.check_output(
             ["tailscale", "serve", "status"],
             stderr=subprocess.DEVNULL, text=True,
         )
-        if f":{PORT}" in out:
+        if f":{port}" in out:
             ts_host = _ts_host()
             if ts_host:
                 print(f"Connect: https://{ts_host}")
             return 0
     except Exception:
         pass
-    try:
-        ts_ip = subprocess.check_output(
-            ["tailscale", "ip", "-4"], stderr=subprocess.DEVNULL, text=True,
-        ).strip()
-    except Exception:
-        ts_ip = "localhost"
-    print(f"Connect: http://{ts_ip}:{PORT}  (direct HTTP)")
+    print(f"Connect: {direct_url(port, info)}")
     return 0
 
 
@@ -448,18 +543,25 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
-    p_setup = sub.add_parser("setup", help="One-time setup: verify install, configure tailscale serve")
+    # Shared --port, attached to every subcommand that has to know which
+    # listener it is acting on.
+    port_opts = argparse.ArgumentParser(add_help=False)
+    port_opts.add_argument("--port", type=int, metavar="PORT",
+                           help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
+
+    p_setup = sub.add_parser("setup", parents=[port_opts],
+                             help="One-time setup: verify install, configure tailscale serve")
     p_setup.add_argument("--quiet", action="store_true", help="Suppress next-steps output")
 
-    sub.add_parser("start",        help="Start daemon via tailscale serve (HTTPS — default)")
-    sub.add_parser("serve",        help=argparse.SUPPRESS)   # alias
-    sub.add_parser("start-local",  help="Start daemon loopback-only for SSH tunnel access")
-    sub.add_parser("start-direct", help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
-    sub.add_parser("stop",         help="Stop daemon (tailscale serve config persists)")
-    sub.add_parser("restart",      help="Restart daemon")
-    sub.add_parser("status",       help="Show running status and URL")
+    sub.add_parser("start",        parents=[port_opts], help="Start daemon via tailscale serve (HTTPS — default)")
+    sub.add_parser("serve",        parents=[port_opts], help=argparse.SUPPRESS)   # alias
+    sub.add_parser("start-local",  parents=[port_opts], help="Start daemon loopback-only for SSH tunnel access")
+    sub.add_parser("start-direct", parents=[port_opts], help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
+    sub.add_parser("stop",         parents=[port_opts], help="Stop daemon (tailscale serve config persists)")
+    sub.add_parser("restart",      parents=[port_opts], help="Restart daemon")
+    sub.add_parser("status",       parents=[port_opts], help="Show running status and URL")
     sub.add_parser("log",          help="Tail the log file")
-    sub.add_parser("enable",       help="Start daemon and install login hook for automatic start")
+    sub.add_parser("enable",       parents=[port_opts], help="Start daemon and install login hook for automatic start")
     sub.add_parser("disable",      help="Stop daemon and remove login hook")
     sub.add_parser("pair",         help="Generate a one-time pairing code for a new device")
     sub.add_parser("unpair",       help="List paired devices and revoke tokens")
@@ -471,27 +573,31 @@ def main() -> None:
         sys.exit(0 if args.cmd == "help" else 1)
 
     cmd = args.cmd
+    # Resolve once: restart must reuse the running daemon's port after stopping
+    # it, by which point the daemon can no longer be asked.
+    port = resolve_port(args.port) if hasattr(args, "port") else DEFAULT_PORT
+
     if cmd == "setup":
-        sys.exit(cmd_setup(quiet=args.quiet))
+        sys.exit(cmd_setup(quiet=args.quiet, port=port))
     elif cmd in ("start", "serve"):
-        sys.exit(cmd_start("serve"))
+        sys.exit(cmd_start("serve", port))
     elif cmd == "start-local":
-        sys.exit(cmd_start("start-local"))
+        sys.exit(cmd_start("start-local", port))
     elif cmd == "start-direct":
-        sys.exit(cmd_start("start-direct"))
+        sys.exit(cmd_start("start-direct", port))
     elif cmd == "stop":
-        sys.exit(cmd_stop())
+        sys.exit(cmd_stop(port))
     elif cmd == "restart":
-        cmd_stop()
+        cmd_stop(port)
         time.sleep(0.5)
-        sys.exit(cmd_start("serve"))
+        sys.exit(cmd_start("serve", port))
     elif cmd == "status":
-        sys.exit(cmd_status())
+        sys.exit(cmd_status(port))
     elif cmd == "log":
         sys.exit(cmd_log())
     elif cmd == "enable":
         from trustmux._enable import main as _run_enable
-        _run_enable()
+        _run_enable(port)
     elif cmd == "disable":
         from trustmux._disable import main as _run_disable
         _run_disable()

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -61,6 +61,7 @@ _TOKEN_EXPIRY_DAYS: int = 90          # sessions expire after 90 days of inactiv
 _sessions: dict[str, dict] = {}      # token → {ip, paired_at, label, last_used}
 _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on unpair
 _https_mode: bool = False             # set by --https; enables Secure cookie
+_listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
 CONFIG_DIR    = Path.home() / ".config" / "trustmux"
 TOKENS_FILE   = CONFIG_DIR / "tokens.json"
@@ -1073,10 +1074,20 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
     try:
         action = cmd.get("action", "")
 
-        if action == "pair_generate":
+        if action == "info":
+            # Lets `trustmux stop/status/pair` discover the live listener
+            # instead of assuming the default port.
+            resp: object = {
+                "pid":    os.getpid(),
+                "host":   _listen.get("host", ""),
+                "port":   _listen.get("port", 0),
+                "scheme": _listen.get("scheme", ""),
+            }
+
+        elif action == "pair_generate":
             code = _generate_pair_code()
             _print_pair_code()
-            resp: object = {"code": f"{code[:3]}-{code[3:]}", "expires_in": _PAIR_CODE_TTL}
+            resp = {"code": f"{code[:3]}-{code[3:]}", "expires_in": _PAIR_CODE_TTL}
 
         elif action == "sessions_list":
             resp = [
@@ -1231,8 +1242,15 @@ def _ensure_self_signed_cert(lan_ip: str) -> tuple:
 
 
 async def _amain(host: str, port: int, https: bool, ssl_ctx=None) -> None:
-    global _https_mode
+    global _https_mode, _listen
     _https_mode = https or ssl_ctx is not None
+    _listen = {
+        "host":   host,
+        "port":   port,
+        # --https means tailscale serve terminates TLS in front of us, so the
+        # URL a client uses is https even though this socket is plain HTTP.
+        "scheme": "https" if _https_mode else "http",
+    }
     app = _make_app()
     # xheaders=True: trust X-Forwarded-For/Proto from tailscale serve proxy.
     # Only set in --https mode; in direct mode leave False to prevent spoofing.

--- a/mobile/trustmux/_disable.py
+++ b/mobile/trustmux/_disable.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from trustmux._ctl import cmd_stop
+from trustmux._enable import is_hook_line
 
 _LOGIN_FILES = [
     Path.home() / ".profile",
@@ -16,7 +17,7 @@ def _remove_hook(dest: Path) -> None:
     if not dest.exists() or not os.access(dest, os.W_OK):
         return
     lines = dest.read_text().splitlines(keepends=True)
-    filtered = [l for l in lines if "trustmux-ctl" not in l and "trustmux start 2>/dev/null" not in l]
+    filtered = [l for l in lines if not is_hook_line(l)]
     if len(filtered) < len(lines):
         dest.write_text("".join(filtered))
 

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 
-from trustmux._ctl import TOKENS_FILE, cmd_setup, cmd_start
+from trustmux._ctl import DEFAULT_PORT, TOKENS_FILE, cmd_setup, cmd_start, port_opt
 
 _HOOK = "trustmux start 2>/dev/null || true\n"
 
@@ -16,26 +16,43 @@ if "zsh" in os.environ.get("SHELL", ""):
     _LOGIN_FILES.append(Path.home() / ".zprofile")
 
 
-def _install_hook(dest: Path) -> None:
+def hook_line(port: int = DEFAULT_PORT) -> str:
+    """Login hook to install. Only carries --port when it is not the default,
+    so profiles written by older versions stay byte-identical."""
+    return f"trustmux start{port_opt(port)} 2>/dev/null || true\n"
+
+
+def is_hook_line(line: str) -> bool:
+    """True for a trustmux login hook in any version's format."""
+    return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
+
+
+def _install_hook(dest: Path, hook: str = _HOOK) -> None:
     if not dest.exists():
         return
-    text = dest.read_text()
-    if _HOOK in text or "trustmux-ctl" in text:
+    lines = dest.read_text().splitlines(keepends=True)
+    if any(is_hook_line(l) for l in lines):
+        # Rewrite in place so `enable --port N` updates a hook installed
+        # earlier with a different port instead of silently keeping the old one.
+        updated = [hook if is_hook_line(l) else l for l in lines]
+        if updated != lines:
+            dest.write_text("".join(updated))
         return
     with dest.open("a") as f:
-        f.write(f"\n{_HOOK}")
+        f.write(f"\n{hook}")
 
 
-def main() -> None:
-    if cmd_setup(quiet=True) != 0:
+def main(port: int = DEFAULT_PORT) -> None:
+    if cmd_setup(quiet=True, port=port) != 0:
         print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
-        print("  trustmux enable")
+        print(f"  trustmux enable{port_opt(port)}")
         sys.exit(1)
 
+    hook = hook_line(port)
     for f in _LOGIN_FILES:
-        _install_hook(f)
+        _install_hook(f, hook)
 
-    started = cmd_start("serve") == 0
+    started = cmd_start("serve", port) == 0
 
     print()
     if started:

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -9,7 +9,7 @@ import termios
 import tty
 from pathlib import Path
 
-from trustmux._ctl import warn_if_peer_blocked
+from trustmux._ctl import daemon_info, direct_url, resolve_port, warn_if_peer_blocked
 
 SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
 
@@ -60,16 +60,22 @@ def _ts_url() -> str:
     return ""
 
 
-def _direct_url(port: int = 7432) -> str:
-    """Return a best-effort LAN URL when Tailscale is unavailable."""
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-        s.close()
-        return f"https://{ip}:{port}/"
-    except Exception:
-        return f"https://localhost:{port}/"
+def _pair_url() -> str:
+    """Return the URL a phone should open to reach this daemon.
+
+    `tailscale serve` fronts the daemon only in the default start mode, which
+    the daemon reports as a loopback bind with an https scheme.  In start-local
+    and start-direct the tailnet name does not answer, so use the daemon's own
+    address and port instead.
+    """
+    info = daemon_info() or {}
+    served = info.get("host") in ("127.0.0.1", "localhost", "::1") \
+        and info.get("scheme") == "https"
+    if served or not info:
+        ts = _ts_url()
+        if ts:
+            return ts
+    return direct_url(resolve_port(), info)
 
 
 def _print_qr(url: str) -> None:
@@ -116,7 +122,7 @@ def main():
         sys.exit(1)
     code = data["code"]
     mins = data["expires_in"] // 60
-    url = _ts_url() or _direct_url()
+    url = _pair_url()
 
     pair_url = f"{url}#{code.replace('-', '')}"
     bar = "═" * 52


### PR DESCRIPTION
## Problem

`trustmuxd` has always accepted `--port`, but the `trustmux` wrapper hardcodes `PORT = 7432`. Running on another port therefore means bypassing the CLI:

```bash
nohup trustmuxd --port 3389 --host 0.0.0.0 --self-signed >> ~/.config/trustmux/trustmux.log 2>&1 &
```

and from there the rest of the tooling stops agreeing with reality:

- `trustmux status` / `stop` locate the process with `lsof -ti:7432`, so they report **"trustmux not running"** and you have to `pkill` by hand.
- `trustmux pair` prints a pairing URL and QR code built from `_direct_url(port=7432)` — wrong port, and always `https://` even for a loopback `start-local` daemon.

## What this does

Adds `--port PORT` to `setup`, `start`, `start-local`, `start-direct`, `stop`, `restart`, `status` and `enable`, with `$TRUSTMUX_PORT` as the fallback default. Only the port changes — each mode binds the same address it always did, so network exposure is unchanged.

So that only the *start* command needs the flag, the daemon now answers an `info` action on the existing owner-only admin socket with the host, port and scheme it actually bound. `stop`, `status` and `pair` ask it, which means:

```bash
trustmux start-direct --port 3389
trustmux status      # finds it — no flag needed
trustmux pair        # correct URL and QR
trustmux stop        # correct daemon
```

Two URLs that were already wrong before this change get fixed as a side effect, because the daemon is now the source of truth instead of a hardcoded constant:

| mode | old pairing/status URL | now |
|---|---|---|
| `start-local` (loopback, plain HTTP) | `https://<lan-ip>:7432/` | `http://localhost:<port>/` |
| `start-direct` (self-signed HTTPS) | `http://<tailscale-ip>:7432` from `status` | `https://<lan-ip>:<port>/` |

`enable` records a non-default port in the login hook it writes, and re-running `enable --port` rewrites an existing hook instead of leaving the old port behind. On the default port the hook line is byte-identical to before, so existing profiles do not churn.

## Notes for review

- No new state file: the admin socket is the source of truth, so there is nothing to go stale after a crash. When no daemon answers, resolution falls back to `$TRUSTMUX_PORT` then 7432.
- `restart` resolves the port *before* stopping the daemon, since the daemon can no longer be asked afterwards.
- `info` returns only `{pid, host, port, scheme}` — strictly less than `sessions_list`, which already returns full session tokens over the same 0600 socket.
- Port values are `argparse type=int` plus a 1–65535 range check; an invalid `$TRUSTMUX_PORT` is an error (exit 2), not a silent fallback. Ports only ever reach `subprocess` argv lists (never a shell) and the `~/.profile` hook line.
- `PORT` is now `DEFAULT_PORT` and is passed as a parameter rather than read as a module global.

## Testing

- `mobile/tests`: 215 → 250 tests, all passing. New coverage for the precedence chain, invalid `$TRUSTMUX_PORT`, `daemon_info()` against a real unix socket, the `info` action (including that it leaks no tokens), and enable/disable hook round-tripping with a port.
- Manually smoke-tested against an isolated `$HOME`: `start-local --port 3389`, `TRUSTMUX_PORT=3389 start-direct` (verified HTTP 200 over the self-signed listener), `status`/`pair`/`stop` with no flag, plus a default-port regression pass.
- Docs updated: `trustmux.1` (OPTIONS, new ENVIRONMENT section, example), bash completion, `mobile/README.md`.