### PR TITLE
trustmux: add --instance for running several daemons at once

### DIFF
--- a/mobile/Makefile.am
+++ b/mobile/Makefile.am
@@ -20,6 +20,7 @@ dist_trustmuxmod_DATA = \
 	trustmux/__main__.py \
 	trustmux/_daemon.py \
 	trustmux/_ctl.py \
+	trustmux/_paths.py \
 	trustmux/_pair.py \
 	trustmux/_unpair.py \
 	trustmux/_enable.py \
@@ -66,6 +67,7 @@ EXTRA_DIST = \
 	generate_screenshots.py \
 	tests/__init__.py \
 	tests/test_ctl.py \
+	tests/test_paths.py \
 	tests/test_daemon.py \
 	tests/test_daemon_extended.py
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -88,6 +88,29 @@ trustmux status              # finds it — no need to repeat --port
 `stop`, `status` and `pair` ask the running daemon which port it is on, so only
 the start command needs the flag. `enable --port` records it in the login hook.
 
+### Several daemons at once
+
+`--instance NAME` (or `$TRUSTMUX_INSTANCE`) gives a daemon its own pid file,
+admin socket, log, session tokens and TLS certificate, so more than one can run
+side by side — on different ports, or on the same port at different addresses:
+
+```bash
+trustmux start-direct --instance work --port 3389
+trustmux pair  --instance work
+trustmux list
+trustmux stop  --instance work
+```
+
+The unnamed instance is called `default`; it is not special-cased, and lives
+under `instances/default/` like any other.
+
+Only `default` can use `tailscale serve` mode, because `serve` publishes on the
+tailnet's port 443 and only one daemon can own it — a second would silently
+take over the mapping. Named instances use `start-direct` or `start-local`;
+`setup`, `start`, `restart` and `enable` refuse them with a message saying so.
+Note `--port` does not lift this: it moves the loopback backend that
+`tailscale serve` proxies to, not the tailnet-facing port.
+
 ---
 
 ## Setup from source
@@ -113,16 +136,17 @@ export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
 
 ## Files
 
-Trustmux follows the XDG base directory spec.
+Trustmux follows the XDG base directory spec, with one subdirectory per
+instance. `<I>` below is the `--instance` name, or `default`.
 
 | Path | Purpose |
 |---|---|
-| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector — the only user-authored file |
-| `$XDG_STATE_HOME/trustmux/instances/default/tokens.json` | Paired device session tokens (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.log` | Daemon log (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.sock` | Admin Unix socket (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.pid` | PID file |
+| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector. Shared by all instances — the only user-authored file |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/tokens.json` | Paired device session tokens (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.log` | Daemon log (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.sock` | Admin Unix socket (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.pid` | PID file |
 
 Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
 write by hand; everything the daemon owns lives together under state, as it
@@ -151,8 +175,8 @@ precedence over the XDG variables.
 
 **Upgrading:** earlier versions kept everything directly in
 `~/.config/trustmux`. On first run `tokens.json`, `cert.pem`, `key.pem` and
-`trustmux.log` are moved into the state directory above with their modes
-preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
+`trustmux.log` are moved into the `default` instance's state directory with
+their modes preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
 case a daemon predating the upgrade is still serving on it.
 
 ---

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -14,7 +14,10 @@ Two tiers:
 
 - tmux (byobu optional but recommended)
 - Python 3.10+
-- [Tailscale](https://tailscale.com) installed, running, and connected
+- [Tailscale](https://tailscale.com) — only for the default `start` mode, which
+  serves over your tailnet. `start-direct` (self-signed HTTPS, binds **all**
+  interfaces — reachable from anywhere the host is) and `start-local` (loopback
+  only, reached through an SSH tunnel) need no Tailscale at all
 
 ---
 
@@ -93,20 +96,49 @@ the start command needs the flag. `enable --port` records it in the login hook.
 cd mobile/
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
-trustmux enable
-trustmux pair
+.venv/bin/python trustmux.in --help
+```
+
+`trustmux.in` and `trustmuxd.in` find the package in the sibling `trustmux/`
+directory, so no install step is needed. To run a throwaway daemon that leaves
+your real one untouched, point both base directories at a scratch tree:
+
+```bash
+export TRUSTMUX_CONFIG_DIR=$(mktemp -d)
+export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
+.venv/bin/python trustmux.in start-local --port 3389
 ```
 
 ---
 
-## Configuration
+## Files
+
+Trustmux follows the XDG base directory spec.
 
 | Path | Purpose |
 |---|---|
-| `~/.config/trustmux/tokens.json` | Paired device session tokens (mode 0600) |
-| `~/.config/trustmux/trustmux.sock` | Admin Unix socket (mode 0600) |
-| `~/.config/trustmux/trustmux.log` | Daemon log (mode 0600) |
-| `~/.config/trustmux/machines.json` | Optional: sibling machines for the machine selector |
+| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector — the only user-authored file |
+| `$XDG_STATE_HOME/trustmux/instances/default/tokens.json` | Paired device session tokens (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.log` | Daemon log (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.sock` | Admin Unix socket (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.pid` | PID file |
+
+Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
+write by hand; everything the daemon owns lives together under state, as it
+always has — just no longer mixed in with configuration.
+
+The socket and pid file stay here rather than in `$XDG_RUNTIME_DIR`, where the
+spec would put them. systemd-logind deletes `/run/user/$UID` when your last
+login session ends unless `loginctl enable-linger` is set, which would strand a
+still-running daemon with no socket to reach it by — and being started and then
+reached later is the whole point of trustmux. That directory also doesn't exist
+on macOS or in most containers. Leftovers are detected instead of swept away: a
+socket refuses connections once its daemon is gone, and a recorded pid is only
+believed when it's confirmed to hold the port in question.
+
+`TRUSTMUX_CONFIG_DIR` and `TRUSTMUX_STATE_DIR` override each base, taking
+precedence over the XDG variables.
 
 ### Multiple machines
 
@@ -117,11 +149,17 @@ trustmux pair
 ]
 ```
 
+**Upgrading:** earlier versions kept everything directly in
+`~/.config/trustmux`. On first run `tokens.json`, `cert.pem`, `key.pem` and
+`trustmux.log` are moved into the state directory above with their modes
+preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
+case a daemon predating the upgrade is still serving on it.
+
 ---
 
 ## Security
 
-- Daemon binds to `127.0.0.1:7432` only — not reachable from the network
+- In the default mode the daemon binds to `127.0.0.1` only — not reachable from the network
 - All traffic encrypted by Tailscale WireGuard; HTTPS via `tailscale serve`
 - No relay server — terminal data never leaves your Tailscale mesh
 - Pairing codes: 6-digit, 5-minute TTL, single-use, max 10 attempts
@@ -133,8 +171,12 @@ trustmux pair
 
 ```bash
 cd mobile/
-python3 -m unittest tests.test_daemon -v
+python3 -m unittest discover -s tests -t .
 ```
+
+Needs `tornado` and `cryptography` (`pip install -r requirements.txt`). The
+suite points `TRUSTMUX_CONFIG_DIR`/`TRUSTMUX_STATE_DIR` at a temporary tree, so it never
+reads or writes your real trustmux state.
 
 ---
 

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -1,4 +1,5 @@
 # bash completion for trustmux(1)
+
 _trustmux() {
     local cur prev words cword
     _init_completion || return

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -1,28 +1,45 @@
 # bash completion for trustmux(1)
 
+# Names of instances that have a state directory, for --instance.
+_trustmux_instances() {
+    local base="${TRUSTMUX_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/trustmux}"
+    local d
+    for d in "$base"/instances/*/; do
+        [[ -d $d ]] || continue
+        d=${d%/}
+        printf '%s\n' "${d##*/}"
+    done
+}
+
 _trustmux() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="setup start start-local start-direct stop restart status log enable disable pair unpair"
+    local subcommands="setup start start-local start-direct stop restart status log list enable disable pair unpair"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
         return
     fi
 
-    if [[ $prev == "--port" ]]; then
-        return
-    fi
+    case "$prev" in
+        --port)      return ;;                                     # freeform
+        --instance)  COMPREPLY=($(compgen -W "$(_trustmux_instances)" -- "$cur"))
+                     return ;;
+    esac
 
+    # `list` acts on every instance, so it takes neither flag.
     case "${words[1]}" in
         setup)
-            COMPREPLY=($(compgen -W "--quiet --port" -- "$cur"))
+            COMPREPLY=($(compgen -W "--quiet --port --instance" -- "$cur"))
             ;;
         start|start-local|start-direct|stop|restart|status|enable)
-            COMPREPLY=($(compgen -W "--port" -- "$cur"))
+            COMPREPLY=($(compgen -W "--port --instance" -- "$cur"))
             ;;
         log|disable|pair|unpair)
+            COMPREPLY=($(compgen -W "--instance" -- "$cur"))
+            ;;
+        list)
             ;;
     esac
 }

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -48,8 +48,8 @@ Stop then start the daemon in HTTPS mode.
 Show whether the daemon is running and the URL to connect to.
 .TP
 .B log
-Tail the daemon log at
-.IR ~/.config/trustmux/trustmux.log .
+Tail the daemon log (see
+.BR FILES ).
 .SS "Login hook"
 .TP
 .B enable
@@ -121,25 +121,87 @@ Default port when
 .B \-\-port
 is not given, for users who always want a different port.
 An out-of-range or non-numeric value is an error, not a silent fallback.
+.TP
+.B TRUSTMUX_CONFIG_DIR
+.TQ
+.B TRUSTMUX_STATE_DIR
+Override the configuration and state base directories individually.
+Each takes precedence over the corresponding XDG variable.
+Pointing both at a scratch directory is the supported way to run a throwaway
+daemon — from a development tree, for instance — without touching the real
+one.
 .SH FILES
+Files live in the XDG base directories:
+.I $XDG_CONFIG_HOME
+(default
+.IR ~/.config )
+holds the one file the user writes by hand, and
+.I $XDG_STATE_HOME
+(default
+.IR ~/.local/state )
+holds everything the daemon owns.
+.SS Configuration
 .TP
-.I ~/.config/trustmux/trustmux.log
-Daemon log file.
+.I $XDG_CONFIG_HOME/trustmux/machines.json
+Optional: sibling machine list for the in-app machine selector.
+The only user-authored file here.
+.SS State
 .TP
-.I ~/.config/trustmux/trustmux.pid
-PID file written at daemon startup.
-.TP
-.I ~/.config/trustmux/trustmux.sock
-Admin Unix socket used by
-.B pair
-and
-.BR unpair .
-.TP
-.I ~/.config/trustmux/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
 Paired device session tokens (mode 0600).
 .TP
-.I ~/.config/trustmux/machines.json
-Optional: sibling machine list for the in-app machine selector.
+.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.TQ
+.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+Self-signed TLS keypair used by
+.BR start\-direct .
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.log
+Daemon log file, tailed by
+.BR "trustmux log" .
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+Admin Unix socket (mode 0600) used by
+.BR pair ,
+.B unpair
+and by
+.B stop
+and
+.B status
+to ask the daemon which port it is on.
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.pid
+PID file written at daemon startup.
+.PP
+The socket and pid file are deliberately kept here rather than under
+.IR $XDG_RUNTIME_DIR ,
+where the spec would put them: systemd-logind deletes
+.I /run/user/$UID
+when a user's last login session ends unless
+.B loginctl enable-linger
+is set, which would strand a still-running daemon with no socket to reach it
+by — and trustmux exists precisely to be started and then reached later.
+That directory also does not exist on macOS or in most containers.
+A socket or pid file left behind by a killed daemon is therefore detected
+rather than swept away: the socket refuses connections once its daemon is
+gone, and a recorded pid is only believed when it is confirmed to hold the
+port in question.
+.SS Migration
+Earlier versions kept everything directly in
+.IR ~/.config/trustmux .
+On first run,
+.IR tokens.json ,
+.IR cert.pem ,
+.I key.pem
+and
+.I trustmux.log
+are moved from there into the state directory above, preserving their modes.
+Any stale
+.I trustmux.pid
+and
+.I trustmux.sock
+are deliberately left in place, since a daemon predating the upgrade may still
+be serving on that socket.
 .SH EXAMPLES
 Typical first-time setup:
 .PP
@@ -171,6 +233,16 @@ trustmux pair
 trustmux stop
 .fi
 .RE
+.PP
+A throwaway daemon that touches none of the above:
+.PP
+.RS
+.nf
+export TRUSTMUX_CONFIG_DIR=$(mktemp \-d)
+export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
+trustmux start\-local \-\-port 3389
+.fi
+.RE
 .SH SECURITY
 .SS "Pairing code"
 The one-time pairing code is a 6-digit decimal value drawn from
@@ -190,8 +262,10 @@ An incorrect guess also incurs a 0.5-second artificial delay.
 After a successful pairing the daemon issues a 256-bit URL-safe session token
 .RB ( secrets.token_urlsafe (32))
 stored in
-.I ~/.config/trustmux/tokens.json
-(mode 0600) and delivered to the browser as an
+.I tokens.json
+(mode 0600; see
+.BR FILES )
+and delivered to the browser as an
 .BR httponly ,
 .B SameSite=Strict
 cookie.

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -48,8 +48,13 @@ Stop then start the daemon in HTTPS mode.
 Show whether the daemon is running and the URL to connect to.
 .TP
 .B log
-Tail the daemon log (see
+Tail this instance's daemon log (see
 .BR FILES ).
+.TP
+.B list
+List every instance that has a state directory, with the port, scheme and pid
+of any that are running.
+Instances whose daemon is stopped are shown with dashes.
 .SS "Login hook"
 .TP
 .B enable
@@ -60,10 +65,18 @@ user's shell login file
 or
 .IR ~/.zprofile )
 so the daemon starts automatically on each login.
+Only available for the
+.B default
+instance, since it starts the daemon in
+.B tailscale serve
+mode; see
+.BR \-\-instance .
 .TP
 .B disable
 Stop the running daemon and remove the login hook so the daemon no longer
 starts automatically.
+Only this instance's hook is removed, so disabling one leaves any others in
+place.
 Paired device tokens are preserved.
 .SS "Device pairing"
 .TP
@@ -114,6 +127,46 @@ records the port in the login hook it writes, so a non-default port survives
 logout; re-running
 .B "enable \-\-port"
 rewrites an existing hook rather than leaving the old port in place.
+.TP
+.BI \-\-instance " NAME"
+Act on the named instance instead of
+.BR default .
+Accepted by every subcommand.
+Each instance keeps its own pid file, admin socket, log, session tokens and
+TLS certificate, so several daemons can run at once — on different ports,
+or on the same port at different bind addresses.
+.IP
+.I NAME
+must match
+.RB ` [A-Za-z0-9][A-Za-z0-9._-]{0,31} ':
+it becomes a directory name and is written into the login hook, so separators,
+leading dots and shell metacharacters are rejected rather than sanitised.
+.IP
+Only the
+.B default
+instance can use
+.B tailscale serve
+mode.
+.B serve
+publishes on the tailnet's port 443, which just one daemon can own — a
+second would silently take over the mapping and leave the first running but
+unreachable.
+Named instances therefore use
+.B start\-direct
+or
+.BR start\-local ,
+and
+.BR setup ,
+.BR start ,
+.B restart
+and
+.B enable
+refuse them with a message pointing at those modes.
+Note that
+.B \-\-port
+does not lift this restriction: it moves only the loopback backend that
+.B tailscale serve
+proxies to, not the tailnet-facing port.
 .SH ENVIRONMENT
 .TP
 .B TRUSTMUX_PORT
@@ -121,6 +174,12 @@ Default port when
 .B \-\-port
 is not given, for users who always want a different port.
 An out-of-range or non-numeric value is an error, not a silent fallback.
+.TP
+.B TRUSTMUX_INSTANCE
+Default instance when
+.B \-\-instance
+is not given.
+An invalid name is an error, not a silent fallback.
 .TP
 .B TRUSTMUX_CONFIG_DIR
 .TQ
@@ -131,7 +190,7 @@ Pointing both at a scratch directory is the supported way to run a throwaway
 daemon — from a development tree, for instance — without touching the real
 one.
 .SH FILES
-Files live in the XDG base directories:
+Files live in the XDG base directories, with one subdirectory per instance:
 .I $XDG_CONFIG_HOME
 (default
 .IR ~/.config )
@@ -140,27 +199,35 @@ holds the one file the user writes by hand, and
 (default
 .IR ~/.local/state )
 holds everything the daemon owns.
+.PP
+Below,
+.I INSTANCE
+is the
+.B \-\-instance
+name, or
+.B default
+when unset.
 .SS Configuration
 .TP
 .I $XDG_CONFIG_HOME/trustmux/machines.json
 Optional: sibling machine list for the in-app machine selector.
-The only user-authored file here.
+Shared by every instance, being the only user-authored file here.
 .SS State
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
 Paired device session tokens (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/cert.pem
 .TQ
-.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/key.pem
 Self-signed TLS keypair used by
 .BR start\-direct .
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.log
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.log
 Daemon log file, tailed by
 .BR "trustmux log" .
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR pair ,
 .B unpair
@@ -170,7 +237,7 @@ and
 .B status
 to ask the daemon which port it is on.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.pid
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.pid
 PID file written at daemon startup.
 .PP
 The socket and pid file are deliberately kept here rather than under
@@ -195,7 +262,9 @@ On first run,
 .I key.pem
 and
 .I trustmux.log
-are moved from there into the state directory above, preserving their modes.
+are moved from there into the
+.B default
+instance's state directory, preserving their modes.
 Any stale
 .I trustmux.pid
 and
@@ -234,6 +303,17 @@ trustmux stop
 .fi
 .RE
 .PP
+A second daemon alongside the first, with its own tokens and log:
+.PP
+.RS
+.nf
+trustmux start\-direct \-\-instance work \-\-port 3389
+trustmux pair \-\-instance work
+trustmux list
+trustmux stop \-\-instance work
+.fi
+.RE
+.PP
 A throwaway daemon that touches none of the above:
 .PP
 .RS
@@ -261,7 +341,7 @@ An incorrect guess also incurs a 0.5-second artificial delay.
 .SS "Session tokens"
 After a successful pairing the daemon issues a 256-bit URL-safe session token
 .RB ( secrets.token_urlsafe (32))
-stored in
+stored in this instance's
 .I tokens.json
 (mode 0600; see
 .BR FILES )

--- a/mobile/man/man1/trustmuxd.1
+++ b/mobile/man/man1/trustmuxd.1
@@ -5,6 +5,7 @@ trustmuxd \- Trustmux daemon (mobile companion for tmux/Byobu sessions)
 .B trustmuxd
 [\fB\-\-host\fP \fIADDR\fP]
 [\fB\-\-port\fP \fIPORT\fP]
+[\fB\-\-instance\fP \fINAME\fP]
 [\fB\-\-https\fP]
 [\fB\-\-self\-signed\fP]
 [\fB\-\-version\fP]
@@ -22,8 +23,8 @@ a self-signed ECDSA certificate and binds directly on the network interface.
 .PP
 Authentication uses 6-digit one-time pairing codes (generated with
 .BR trustmux\-pair (1))
-and permanent per-device session tokens stored as described under
-.BR FILES .
+and permanent per-device session tokens stored per instance (see
+.BR FILES ).
 .PP
 In normal use, the daemon is managed via
 .BR trustmux (1)
@@ -44,26 +45,38 @@ Use with \fBtailscale serve\fP.
 Generate a self-signed ECDSA P-256 TLS certificate for direct
 HTTPS access without Tailscale.
 .TP
+.BI \-\-instance " NAME"
+Which instance's state and runtime files to use (default:
+.BR default ).
+Each instance has its own tokens, TLS keypair, log, admin socket and pid file,
+so several daemons can run side by side.
+.B trustmux (1)
+passes this through when it starts a daemon.
+.TP
 .B \-\-version
 Print version and exit.
 .SH FILES
-Paths follow the XDG base directories.
+Paths follow the XDG base directories, one subdirectory per instance;
+.I INSTANCE
+below is the
+.B \-\-instance
+name.
 .B trustmux (1)
 documents the full layout, the fallbacks and the
 .B TRUSTMUX_*_DIR
 overrides.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
 Persistent session tokens (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/cert.pem
 Self-signed TLS certificate (mode 0644), created on first
 \fB\-\-self\-signed\fP start.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/key.pem
 TLS private key (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR trustmux\-pair (1)
 and

--- a/mobile/man/man1/trustmuxd.1
+++ b/mobile/man/man1/trustmuxd.1
@@ -22,8 +22,8 @@ a self-signed ECDSA certificate and binds directly on the network interface.
 .PP
 Authentication uses 6-digit one-time pairing codes (generated with
 .BR trustmux\-pair (1))
-and permanent per-device session tokens stored in
-.IR ~/.config/trustmux/tokens.json .
+and permanent per-device session tokens stored as described under
+.BR FILES .
 .PP
 In normal use, the daemon is managed via
 .BR trustmux (1)
@@ -47,22 +47,27 @@ HTTPS access without Tailscale.
 .B \-\-version
 Print version and exit.
 .SH FILES
+Paths follow the XDG base directories.
+.B trustmux (1)
+documents the full layout, the fallbacks and the
+.B TRUSTMUX_*_DIR
+overrides.
 .TP
-.I ~/.config/trustmux/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
 Persistent session tokens (mode 0600).
 .TP
-.I ~/.config/trustmux/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+Self-signed TLS certificate (mode 0644), created on first
+\fB\-\-self\-signed\fP start.
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+TLS private key (mode 0600).
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR trustmux\-pair (1)
 and
 .BR trustmux\-unpair (1).
-.TP
-.I ~/.config/trustmux/cert.pem
-Self-signed TLS certificate (mode 0644), created on first
-\fB\-\-self\-signed\fP start.
-.TP
-.I ~/.config/trustmux/key.pem
-TLS private key (mode 0600).
 .SH SEE ALSO
 .BR trustmux (1),
 .BR trustmux\-pair (1),

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -150,6 +150,41 @@ class TestPid(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Two instances, one port: attribution must not be a coin flip
+# ---------------------------------------------------------------------------
+
+class TestPidInstanceAttribution(unittest.TestCase):
+    """Two daemons may share a port on different addresses (127.0.0.1:7432 and
+    192.168.1.5:7432), so lsof reports both pids. The instance's own pid file
+    says which of them is ours -- but only ever to *choose among* processes
+    already known to hold the port, never to invent one."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('attrib')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def test_prefers_own_pid_over_whichever_lsof_listed_first(self):
+        write_pid(self.inst, 5678)
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+
+    def test_another_instances_daemon_on_our_port_is_not_ours(self):
+        # Our pid file names a live daemon, but it is not the one holding this
+        # port -- so this instance is not running on it.
+        write_pid(self.inst, 5678)
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertIsNone(ctl._pid(7432, self.inst))
+
+    def test_admin_socket_attributes_when_the_pidfile_is_gone(self):
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
+            with patch('trustmux._ctl.daemon_info', return_value={'pid': 5678}):
+                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+
+
+# ---------------------------------------------------------------------------
 # Regression: _pid(port) must never return an unrelated daemon's pid for a
 # port nothing is listening on (verified live: this previously let
 # `trustmux stop --port <unrelated port>` kill an unrelated running daemon).
@@ -1037,6 +1072,11 @@ class TestLaunchPort(unittest.TestCase):
         # Never handed to a shell.
         self.assertNotIn('shell', mock_popen.call_args.kwargs)
 
+    def test_passes_instance_to_daemon(self):
+        mock_popen = self._launch(3389, self.inst)
+        argv = mock_popen.call_args[0][0]
+        self.assertEqual(argv[argv.index('--instance') + 1], 'launchtest')
+
     def test_writes_pid_to_this_instance(self):
         self._launch(3389, self.inst)
         self.assertTrue(self.inst.pid_file.exists())
@@ -1143,6 +1183,228 @@ class TestInstallHookPort(unittest.TestCase):
         disable._remove_hook(p)
         self.assertNotIn('trustmux start', p.read_text())
         self.assertIn('# top', p.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Instances: isolation, listing, per-instance login hooks
+# ---------------------------------------------------------------------------
+
+class TestInstanceIsolation(unittest.TestCase):
+
+    def test_resolve_port_asks_the_named_instance(self):
+        work = ctl.Instance('work')
+        with patch('trustmux._ctl.daemon_info') as info:
+            info.return_value = {'port': 3389}
+            self.assertEqual(ctl.resolve_port(inst=work), 3389)
+        info.assert_called_once_with(work)
+
+    def test_status_and_stop_address_the_named_instance(self):
+        work = ctl.Instance('work')
+        work.ensure_dirs()
+        self.addCleanup(shutil.rmtree, work.state, True)
+        with patch('trustmux._ctl._pid', return_value=None) as mock_pid:
+            with patch('builtins.print'):
+                ctl.cmd_status(3389, work)
+        self.assertEqual(mock_pid.call_args[0][1], work)
+
+
+class TestCmdList(unittest.TestCase):
+
+    def setUp(self):
+        self.made = []
+        for name in ('default', 'work'):
+            inst = ctl.Instance(name)
+            inst.ensure_dirs()
+            self.made.append(inst)
+            self.addCleanup(shutil.rmtree, inst.state, True)
+
+    def _run(self):
+        with patch('builtins.print') as mock_print:
+            rc = ctl.cmd_list()
+        return rc, ' '.join(str(c) for c in mock_print.call_args_list)
+
+    def test_lists_every_instance(self):
+        rc, out = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn('default', out)
+        self.assertIn('work', out)
+
+    def test_reports_a_running_instance_with_its_port(self):
+        def fake_info(inst):
+            return {'port': 3389, 'scheme': 'https'} if inst.name == 'work' else None
+        with patch('trustmux._ctl.daemon_info', side_effect=fake_info):
+            with patch('trustmux._ctl._pid', return_value=4321):
+                rc, out = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn('3389', out)
+        self.assertIn('running (pid 4321)', out)
+
+    def test_reports_stopped_instances(self):
+        with patch('trustmux._ctl._recorded_pid', return_value=None):
+            rc, out = self._run()
+        self.assertIn('stopped', out)
+
+
+class TestPerInstanceHooks(unittest.TestCase):
+
+    def _profile(self, content=''):
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.profile', delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(Path(f.name).unlink, True)
+        return Path(f.name)
+
+    def test_hook_line_carries_instance_and_port(self):
+        line = enable.hook_line(3389, ctl.Instance('work'))
+        self.assertEqual(line,
+                         'trustmux start --instance work --port 3389 2>/dev/null || true\n')
+
+    def test_default_instance_keeps_the_legacy_line(self):
+        self.assertEqual(enable.hook_line(ctl.DEFAULT_PORT, ctl.Instance()), enable._HOOK)
+
+    def test_second_instance_appends_rather_than_replacing(self):
+        p = self._profile('# top\n')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 2)
+        self.assertIn('--instance work', text)
+
+    def test_reenabling_one_instance_rewrites_only_its_line(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        enable._install_hook(p, enable.hook_line(9999, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 2)
+        self.assertIn('--port 9999', text)
+        self.assertNotIn('--port 3389', text)
+
+    def test_disable_removes_only_that_instance(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        disable._remove_hook(p, ctl.Instance('work'))
+        text = p.read_text()
+        self.assertNotIn('--instance work', text)
+        self.assertIn('trustmux start 2>/dev/null', text)
+
+    def test_disabling_default_leaves_named_instances(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        disable._remove_hook(p, ctl.Instance())
+        text = p.read_text()
+        self.assertIn('--instance work', text)
+        self.assertNotIn('trustmux start 2>/dev/null', text)
+
+
+# ---------------------------------------------------------------------------
+# serve mode is singular: only one daemon can own the tailnet's :443
+# ---------------------------------------------------------------------------
+
+class TestServeModeGuard(unittest.TestCase):
+    """`tailscale serve` publishes on the tailnet's port 443. A second
+    `tailscale serve --bg` silently replaces the first mapping, so a named
+    instance must not be allowed into serve mode at all. --port does not help:
+    it moves only the loopback backend, not the tailnet-facing port."""
+
+    def _stderr(self):
+        import io
+        return io.StringIO()
+
+    def test_default_instance_may_use_serve(self):
+        self.assertTrue(ctl.can_use_serve(ctl.Instance(), self._stderr()))
+
+    def test_named_instance_may_not(self):
+        buf = self._stderr()
+        self.assertFalse(ctl.can_use_serve(ctl.Instance('work'), buf))
+        msg = buf.getvalue()
+        self.assertIn('work', msg)
+        self.assertIn('443', msg)
+        # Points at the modes that actually work for a second instance.
+        self.assertIn('start-direct --instance work', msg)
+        self.assertIn('start-local --instance work', msg)
+
+    def test_cmd_start_serve_refuses_named_instance(self):
+        with patch('trustmux._ctl._launch') as mock_launch:
+            with patch('trustmux._ctl._ensure_ts_serve') as mock_serve:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    rc = ctl.cmd_start('serve', 7432, ctl.Instance('work'))
+        self.assertEqual(rc, 1)
+        mock_launch.assert_not_called()
+        # Crucially, the existing serve mapping is never touched.
+        mock_serve.assert_not_called()
+
+    def test_refusal_happens_before_any_probing(self):
+        # The refusal is certain, so it must not first query a daemon or
+        # fork lsof.
+        with patch('trustmux._ctl._pid') as mock_pid:
+            with patch('trustmux._ctl.daemon_info') as mock_info:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    ctl.cmd_start('serve', None, ctl.Instance('work'))
+        mock_pid.assert_not_called()
+        mock_info.assert_not_called()
+
+    def test_named_instance_may_still_use_direct_and_local(self):
+        for mode in ('start-direct', 'start-local'):
+            with self.subTest(mode=mode):
+                with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
+                    with patch('trustmux._ctl._check_tmux', return_value=True):
+                        with patch('trustmux._ctl._check_tls', return_value=True):
+                            with patch('trustmux._ctl._pid', return_value=None):
+                                with patch('builtins.print'):
+                                    rc = ctl.cmd_start(mode, 3389, ctl.Instance('work'))
+                self.assertEqual(rc, 0)
+                mock_launch.assert_called_once()
+
+    def test_restart_refuses_before_stopping_anything(self):
+        # restart brings the daemon back in serve mode; refusing only at the
+        # start step would leave a running named instance stopped.
+        with patch('trustmux._ctl._refuse_root'), \
+             patch('trustmux._ctl.sys.argv',
+                   ['trustmux', 'restart', '--instance', 'work']), \
+             patch('trustmux._ctl.cmd_stop') as mock_stop, \
+             patch('trustmux._ctl.cmd_start') as mock_start, \
+             patch('trustmux._ctl.sys.stderr', self._stderr()):
+            with self.assertRaises(SystemExit) as cm:
+                ctl.main()
+        self.assertEqual(cm.exception.code, 1)
+        mock_stop.assert_not_called()
+        mock_start.assert_not_called()
+
+    def test_cmd_setup_refuses_named_instance(self):
+        with patch('trustmux._ctl._ensure_ts_serve') as mock_serve:
+            with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                rc = ctl.cmd_setup(inst=ctl.Instance('work'))
+        self.assertEqual(rc, 1)
+        mock_serve.assert_not_called()
+
+    def test_enable_refuses_named_instance_without_looping(self):
+        with patch('trustmux._enable.cmd_setup') as mock_setup:
+            with patch('trustmux._enable._install_hook') as mock_hook:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    with patch('sys.stderr', self._stderr()):
+                        with self.assertRaises(SystemExit) as cm:
+                            enable.main(3389, ctl.Instance('work'))
+        self.assertEqual(cm.exception.code, 1)
+        # Refused up front: no setup attempt, no hook written.
+        mock_setup.assert_not_called()
+        mock_hook.assert_not_called()
+
+    def test_enable_still_works_for_the_default_instance(self):
+        with patch('trustmux._enable.cmd_setup', return_value=0) as mock_setup:
+            with patch('trustmux._enable.cmd_start', return_value=0):
+                with patch('trustmux._enable._install_hook'):
+                    with patch('trustmux._paths.Instance.tokens_file'):
+                        with patch('builtins.print'):
+                            enable.main(ctl.DEFAULT_PORT, ctl.Instance())
+        mock_setup.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import signal
 import socket
 import sys
@@ -18,18 +19,38 @@ import trustmux._enable as enable
 import trustmux._disable as disable
 
 _no_daemon = None
+_tmp_root = None
+_tmp_env = None
 
 
 def setUpModule():
+    # Root every base directory in a temp tree so the suite can never read or
+    # write the developer's real trustmux state.
+    global _no_daemon, _tmp_root, _tmp_env
+    _tmp_root = tempfile.TemporaryDirectory()
+    root = Path(_tmp_root.name)
+    _tmp_env = patch.dict(os.environ, {
+        'TRUSTMUX_CONFIG_DIR': str(root / 'config'),
+        'TRUSTMUX_STATE_DIR':  str(root / 'state'),
+    })
+    _tmp_env.start()
     # resolve_port() asks the running daemon which port it is on; without this
     # the suite would pick up a real trustmux on the developer's machine.
-    global _no_daemon
     _no_daemon = patch('trustmux._ctl.daemon_info', return_value=None)
     _no_daemon.start()
 
 
 def tearDownModule():
     _no_daemon.stop()
+    _tmp_env.stop()
+    _tmp_root.cleanup()
+
+
+def write_pid(inst, pid):
+    """Give inst a pid file containing pid."""
+    inst.ensure_dirs()
+    inst.pid_file.write_text(str(pid))
+    return inst.pid_file
 
 
 # ---------------------------------------------------------------------------
@@ -49,19 +70,24 @@ class TestPid(unittest.TestCase):
     nothing was listening on, and in turn let `trustmux stop --port <wrong>`
     kill the wrong daemon (see TestPidCrossPortRegression below)."""
 
+    def setUp(self):
+        self.inst = ctl.Instance('pidtest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
     def test_lsof_returns_pid(self):
         with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
-            self.assertEqual(ctl._pid(3389), 1234)
+            self.assertEqual(ctl._pid(3389, self.inst), 1234)
 
-    def test_lsof_multiple_lines_uses_first(self):
+    def test_lsof_first_pid_when_this_instance_has_no_claim(self):
         with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
-            self.assertEqual(ctl._pid(3389), 1234)
+            self.assertEqual(ctl._pid(3389, self.inst), 1234)
 
     def test_lsof_empty_output_is_definitive_none(self):
         # lsof ran fine, found nothing: no fallback, no daemon_info() call.
         with patch('trustmux._ctl.subprocess.check_output', return_value=''):
             with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
         mock_info.assert_not_called()
 
     def test_lsof_called_process_error_is_definitive_none(self):
@@ -71,15 +97,25 @@ class TestPid(unittest.TestCase):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=subprocess.CalledProcessError(1, 'lsof')):
             with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
         mock_info.assert_not_called()
+
+    def test_a_live_pidfile_cannot_conjure_a_pid_for_an_idle_port(self):
+        # Same invariant as above, with this instance's pid file naming a
+        # genuinely live process: still None, because nothing holds the port.
+        import subprocess
+        write_pid(self.inst, 9999)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=subprocess.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_falls_back_to_daemon_info_matching_port(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 4321, 'port': 3389}):
-                self.assertEqual(ctl._pid(3389), 4321)
+                self.assertEqual(ctl._pid(3389, self.inst), 4321)
 
     def test_lsof_missing_and_daemon_info_reports_different_port(self):
         # The exact regression this class exists to prevent: a live daemon
@@ -88,20 +124,29 @@ class TestPid(unittest.TestCase):
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 4321, 'port': 7432}):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_and_no_daemon_answers(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info', return_value=None):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_and_daemon_info_reports_junk_pid(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 'not-a-pid', 'port': 3389}):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
+
+    def test_lsof_full_listing_is_treated_as_unusable_not_as_a_pid(self):
+        # An lsof that does not understand -ti:<port> prints a whole table
+        # instead of failing; its columns must not be misread as pids.
+        listing = '1084\t/usr/lib/systemd/systemd\t0\t/dev/null\n'
+        with patch('trustmux._ctl.subprocess.check_output', return_value=listing):
+            with patch('trustmux._ctl.daemon_info', return_value=None) as mock_info:
+                self.assertIsNone(ctl._pid(3389, self.inst))
+        mock_info.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -112,30 +157,51 @@ class TestPid(unittest.TestCase):
 
 class TestPidCrossPortRegression(unittest.TestCase):
 
-    def _mock_pidfile(self, exists=False, content=''):
-        m = MagicMock()
-        m.exists.return_value = exists
-        m.read_text.return_value = content
-        return m
+    def setUp(self):
+        self.inst = ctl.Instance('crossport')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
 
     def test_stop_on_unrelated_port_does_not_kill_the_real_daemon(self):
         import subprocess as sp
-        # Real daemon is on 3389 (PIDFILE reflects it, and is genuinely
-        # alive); lsof is queried for 4444, where nothing listens, and
-        # genuinely finds nothing. Must never send SIGTERM to the pid
-        # PIDFILE names -- only cmd_stop's own liveness *probe* (signal 0,
-        # harmless) is expected, to decide whether to also clean PIDFILE up.
+        # Real daemon is on 3389 (the pid file reflects it, and it is
+        # genuinely alive); lsof is queried for 4444, where nothing listens,
+        # and genuinely finds nothing. Must never send SIGTERM to the pid the
+        # pid file names -- only the harmless liveness probe (signal 0), used
+        # to decide whether to also clean the pid file up.
+        write_pid(self.inst, 3141)
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=sp.CalledProcessError(1, 'lsof')):
             with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl.PIDFILE',
-                           self._mock_pidfile(exists=True, content='3141\n')):
-                    with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
-                        with patch('builtins.print'):
-                            result = ctl.cmd_stop(4444)
-        mock_kill.assert_called_once_with(3141, 0)  # liveness probe only
+                with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+                    with patch('builtins.print'):
+                        result = ctl.cmd_stop(4444, self.inst)
         self.assertNotIn(call(3141, signal.SIGTERM), mock_kill.call_args_list)
+        for c in mock_kill.call_args_list:
+            self.assertEqual(c, call(3141, 0))   # liveness probes only
         self.assertEqual(result, 0)
+
+    def test_live_pidfile_survives_a_stop_on_a_different_port(self):
+        import subprocess as sp
+        write_pid(self.inst, 3141)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=sp.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.daemon_info', return_value=None):
+                with patch('trustmux._ctl.os.kill', return_value=None):
+                    with patch('builtins.print'):
+                        ctl.cmd_stop(4444, self.inst)
+        self.assertTrue(self.inst.pid_file.exists())
+
+    def test_dead_pidfile_is_cleaned_up(self):
+        import subprocess as sp
+        write_pid(self.inst, 3141)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=sp.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.daemon_info', return_value=None):
+                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+                    with patch('builtins.print'):
+                        ctl.cmd_stop(4444, self.inst)
+        self.assertFalse(self.inst.pid_file.exists())
 
     def test_start_on_unrelated_port_is_not_falsely_refused(self):
         import subprocess as sp
@@ -144,10 +210,9 @@ class TestPidCrossPortRegression(unittest.TestCase):
             with patch('trustmux._ctl.daemon_info', return_value=None):
                 with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
                     with patch('builtins.print'):
-                        result = ctl.cmd_start('start-local', 4444)
+                        result = ctl.cmd_start('start-local', 4444, self.inst)
         mock_launch.assert_called_once()
         self.assertEqual(result, 0)
-
 
 # ---------------------------------------------------------------------------
 # _ts_host()
@@ -405,67 +470,61 @@ class TestCmdStart(unittest.TestCase):
 
 class TestCmdStop(unittest.TestCase):
 
-    def _mock_pidfile(self, exists=False, content=''):
-        m = MagicMock()
-        m.exists.return_value = exists
-        m.read_text.return_value = content
-        return m
+    def setUp(self):
+        self.inst = ctl.Instance('stoptest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
 
     def test_not_running_returns_0(self):
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', self._mock_pidfile(exists=False)):
-                self.assertEqual(ctl.cmd_stop(), 0)
+            self.assertEqual(ctl.cmd_stop(inst=self.inst), 0)
 
     def test_kills_process_and_removes_pidfile(self):
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE',
-                       self._mock_pidfile(exists=True, content='4321')):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, signal.SIGTERM)
+        self.assertFalse(self.inst.pid_file.exists())
 
     def test_pidfile_mismatch_refuses_to_kill(self):
+        write_pid(self.inst, 9999)
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE',
-                       self._mock_pidfile(exists=True, content='9999')):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 1)
         mock_kill.assert_not_called()
 
     def test_no_pidfile_still_kills(self):
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE', self._mock_pidfile(exists=False)):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, signal.SIGTERM)
 
     def test_not_found_on_this_port_preserves_pidfile_of_live_other_daemon(self):
-        # Nothing is on the requested port, but PIDFILE tracks a genuinely
-        # alive daemon on some other port -- must not be deleted just
-        # because the wrong port was asked about (regression: previously
+        # Nothing is on the requested port, but the pid file tracks a
+        # genuinely alive daemon on some other port -- must not be deleted
+        # just because the wrong port was asked about (regression: previously
         # unconditional, which threw away bookkeeping for a live daemon).
-        pidfile = self._mock_pidfile(exists=True, content='4321')
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', pidfile):
-                with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
-                    result = ctl.cmd_stop(4444)
+            with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+                result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, 0)  # liveness probe, not a real kill
-        pidfile.unlink.assert_not_called()
+        self.assertTrue(self.inst.pid_file.exists())
 
     def test_not_found_on_this_port_cleans_up_genuinely_dead_pidfile(self):
-        # Same "not found" case, but PIDFILE's own pid is dead: this is the
-        # genuinely-stale case, and should still be cleaned up as before.
-        pidfile = self._mock_pidfile(exists=True, content='4321')
+        # Same "not found" case, but the pid file's own pid is dead: this is
+        # the genuinely-stale case, and should still be cleaned up as before.
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', pidfile):
-                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
-                    result = ctl.cmd_stop(4444)
+            with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+                result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
-        pidfile.unlink.assert_called_once_with(missing_ok=True)
+        self.assertFalse(self.inst.pid_file.exists())
 
 
 # ---------------------------------------------------------------------------
@@ -627,7 +686,7 @@ class TestEnableMain(unittest.TestCase):
         with patch('trustmux._enable.cmd_setup', return_value=0):
             with patch('trustmux._enable.cmd_start', return_value=0):
                 with patch('trustmux._enable._LOGIN_FILES', []):
-                    with patch('trustmux._enable.TOKENS_FILE') as tf:
+                    with patch('trustmux._paths.Instance.tokens_file') as tf:
                         tf.exists.return_value = True
                         tf.stat.return_value = MagicMock(st_size=100)
                         enable.main()   # should not raise
@@ -896,9 +955,10 @@ class TestDaemonInfo(unittest.TestCase):
     def setUp(self):
         _no_daemon.stop()
         self.addCleanup(_no_daemon.start)
-        self.td = tempfile.TemporaryDirectory()
-        self.addCleanup(self.td.cleanup)
-        self.sock_path = Path(self.td.name) / 'trustmux.sock'
+        self.inst = ctl.Instance('infotest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+        self.sock_path = self.inst.sock
 
     def _serve_once(self, reply: bytes) -> None:
         srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -917,25 +977,21 @@ class TestDaemonInfo(unittest.TestCase):
         self.addCleanup(t.join, 5)
 
     def test_none_when_socket_absent(self):
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
     def test_returns_listener_details(self):
         self._serve_once(b'{"pid": 42, "host": "0.0.0.0", "port": 3389, "scheme": "https"}\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            info = ctl.daemon_info()
+        info = ctl.daemon_info(self.inst)
         self.assertEqual(info['port'], 3389)
         self.assertEqual(info['scheme'], 'https')
 
     def test_none_on_error_reply(self):
         self._serve_once(b'{"error": "unknown action"}\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
     def test_none_on_garbage_reply(self):
         self._serve_once(b'not json\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
 
 class TestDirectUrl(unittest.TestCase):
@@ -960,19 +1016,41 @@ class TestDirectUrl(unittest.TestCase):
 
 class TestLaunchPort(unittest.TestCase):
 
+    def setUp(self):
+        self.inst = ctl.Instance('launchtest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def _launch(self, port, inst):
+        with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
+            mock_popen.return_value.poll.return_value = None   # still alive
+            with patch('trustmux._ctl.time.sleep'):
+                with patch('trustmux._ctl._pid', return_value=4321):
+                    ctl._launch(port, ['--host', '127.0.0.1'], inst)
+        return mock_popen
+
     def test_passes_resolved_port_to_daemon(self):
-        with patch('trustmux._ctl._ensure_dir'):
-            with patch('trustmux._ctl.LOGFILE'):
-                with patch('trustmux._ctl.PIDFILE'):
-                    with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
-                        with patch('trustmux._ctl.time.sleep'):
-                            with patch('trustmux._ctl._pid', return_value=4321):
-                                ctl._launch(3389, ['--host', '127.0.0.1'])
+        mock_popen = self._launch(3389, self.inst)
         argv = mock_popen.call_args[0][0]
         self.assertIn('--port', argv)
         self.assertEqual(argv[argv.index('--port') + 1], '3389')
         # Never handed to a shell.
         self.assertNotIn('shell', mock_popen.call_args.kwargs)
+
+    def test_writes_pid_to_this_instance(self):
+        self._launch(3389, self.inst)
+        self.assertTrue(self.inst.pid_file.exists())
+
+    def test_reports_failure_when_the_daemon_dies_on_startup(self):
+        # Port conflicts are easy to hit once several instances are in play;
+        # a child that has already exited must not be reported as started.
+        with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
+            mock_popen.return_value.poll.return_value = 1   # already exited
+            with patch('trustmux._ctl.time.sleep'):
+                with patch('trustmux._ctl._pid', return_value=4321):
+                    result = ctl._launch(3389, ['--host', '127.0.0.1'], self.inst)
+        self.assertIsNone(result)
+        self.assertFalse(self.inst.pid_file.exists())
 
 
 class TestEnsureTsServePort(unittest.TestCase):
@@ -999,19 +1077,20 @@ class TestCmdStartPort(unittest.TestCase):
         with patch('trustmux._ctl._pid', return_value=999) as mock_pid:
             with patch('builtins.print'):
                 self.assertEqual(ctl.cmd_start('start-local', 3389), 1)
-        mock_pid.assert_called_once_with(3389)
+        mock_pid.assert_called_once_with(3389, ctl.Instance())
 
 
 class TestCmdStopPort(unittest.TestCase):
 
     def test_stops_pid_found_on_requested_port(self):
+        inst = ctl.Instance('stopport')
+        inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, inst.state, True)
         with patch('trustmux._ctl._pid', return_value=1234) as mock_pid:
-            with patch('trustmux._ctl.PIDFILE') as mock_pidfile:
-                mock_pidfile.exists.return_value = False
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    with patch('builtins.print'):
-                        self.assertEqual(ctl.cmd_stop(3389), 0)
-        mock_pid.assert_called_once_with(3389)
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                with patch('builtins.print'):
+                    self.assertEqual(ctl.cmd_stop(3389, inst), 0)
+        mock_pid.assert_called_once_with(3389, inst)
         mock_kill.assert_called_once_with(1234, signal.SIGTERM)
 
 

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -41,6 +41,42 @@ def _clear_sessions():
 
 
 # ---------------------------------------------------------------------------
+# Stale admin socket
+# ---------------------------------------------------------------------------
+
+class TestStaleSocket(unittest.TestCase):
+    """The state directory persists across logout and reboot, so a socket left
+    behind by a killed daemon stays on disk. Connecting is what distinguishes
+    it from one a live daemon is serving -- unlinking blindly would let a
+    second daemon steal a live socket, leaving the first unreachable."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.path = Path(self.td.name) / 'trustmux.sock'
+
+    def test_leftover_socket_file_is_stale(self):
+        import socket as _socket
+        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        s.bind(str(self.path))
+        s.listen(1)
+        s.close()                       # daemon died without unlinking
+        self.assertTrue(self.path.exists())
+        self.assertTrue(bm._socket_is_stale(self.path))
+
+    def test_live_socket_is_not_stale(self):
+        import socket as _socket
+        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        s.bind(str(self.path))
+        s.listen(1)
+        self.addCleanup(s.close)
+        self.assertFalse(bm._socket_is_stale(self.path))
+
+    def test_missing_socket_is_stale(self):
+        self.assertTrue(bm._socket_is_stale(self.path))
+
+
+# ---------------------------------------------------------------------------
 # Token persistence
 # ---------------------------------------------------------------------------
 
@@ -48,19 +84,19 @@ class TestTokenPersistence(unittest.TestCase):
     def setUp(self):
         _clear_sessions()
         self._tmpdir = tempfile.TemporaryDirectory()
-        self._orig_config = bm.CONFIG_DIR
+        self._orig_state = bm.STATE_DIR
         self._orig_tokens = bm.TOKENS_FILE
-        bm.CONFIG_DIR = Path(self._tmpdir.name) / 'trustmux'
-        bm.TOKENS_FILE = bm.CONFIG_DIR / 'tokens.json'
+        bm.STATE_DIR = Path(self._tmpdir.name) / 'trustmux'
+        bm.TOKENS_FILE = bm.STATE_DIR / 'tokens.json'
 
     def tearDown(self):
         _clear_sessions()
-        bm.CONFIG_DIR = self._orig_config
+        bm.STATE_DIR = self._orig_state
         bm.TOKENS_FILE = self._orig_tokens
         self._tmpdir.cleanup()
 
     def _write_tokens(self, data):
-        bm.CONFIG_DIR.mkdir(parents=True)
+        bm.STATE_DIR.mkdir(parents=True)
         bm.TOKENS_FILE.write_text(json.dumps(data))
 
     def test_load_missing_file_is_no_op(self):
@@ -85,7 +121,7 @@ class TestTokenPersistence(unittest.TestCase):
         self.assertNotIn('bad_missing', bm._sessions)
 
     def test_load_corrupt_json_does_not_raise(self):
-        bm.CONFIG_DIR.mkdir(parents=True)
+        bm.STATE_DIR.mkdir(parents=True)
         bm.TOKENS_FILE.write_text('not json!!!')
         bm._load_tokens()
         self.assertEqual(bm._sessions, {})
@@ -651,6 +687,14 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(resp['code']), 7)  # XXX-XXX
         self.assertIn('expires_in', resp)
         self.assertTrue(bm._pair_code)
+
+    async def test_info_pid_identifies_which_daemon_answered(self):
+        # Two daemons each own their instance's socket, so the pid in the
+        # reply is how a caller tells them apart.
+        with patch.object(bm, '_listen',
+                          {'host': '127.0.0.1', 'port': 7432, 'scheme': 'https'}):
+            resp = await self._call({'action': 'info'})
+        self.assertEqual(resp['pid'], os.getpid())
 
     async def test_info_reports_listener(self):
         with patch.object(bm, '_listen',

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -75,6 +75,47 @@ class TestStaleSocket(unittest.TestCase):
     def test_missing_socket_is_stale(self):
         self.assertTrue(bm._socket_is_stale(self.path))
 
+# ---------------------------------------------------------------------------
+# Instance selection
+# ---------------------------------------------------------------------------
+
+class TestSetInstance(unittest.TestCase):
+    """--instance repoints every path the daemon owns."""
+
+    def setUp(self):
+        self._orig = (bm.INSTANCE, bm.STATE_DIR, bm.TOKENS_FILE,
+                      bm.ADMIN_SOCK, bm.CERT_FILE, bm.KEY_FILE)
+
+    def tearDown(self):
+        (bm.INSTANCE, bm.STATE_DIR, bm.TOKENS_FILE,
+         bm.ADMIN_SOCK, bm.CERT_FILE, bm.KEY_FILE) = self._orig
+
+    def test_repoints_state_and_runtime(self):
+        from trustmux._paths import Instance
+        work = Instance('work')
+        bm._set_instance(work)
+        self.assertEqual(bm.TOKENS_FILE, work.tokens_file)
+        self.assertEqual(bm.ADMIN_SOCK, work.sock)
+        self.assertEqual(bm.CERT_FILE, work.cert_file)
+        self.assertEqual(bm.KEY_FILE, work.key_file)
+        self.assertEqual(bm.STATE_DIR, work.state)
+
+    def test_two_instances_never_collide(self):
+        from trustmux._paths import Instance
+        bm._set_instance(Instance('a'))
+        a = (bm.TOKENS_FILE, bm.ADMIN_SOCK, bm.CERT_FILE)
+        bm._set_instance(Instance('b'))
+        b = (bm.TOKENS_FILE, bm.ADMIN_SOCK, bm.CERT_FILE)
+        for x, y in zip(a, b):
+            self.assertNotEqual(x, y)
+
+    def test_machines_file_stays_shared(self):
+        from trustmux._paths import Instance, machines_file
+        before = bm.MACHINES_FILE
+        bm._set_instance(Instance('work'))
+        self.assertEqual(bm.MACHINES_FILE, before)
+        self.assertEqual(bm.MACHINES_FILE, machines_file())
+
 
 # ---------------------------------------------------------------------------
 # Token persistence

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -15,8 +15,8 @@ import trustmux._paths as paths
 class BaseDirs(unittest.TestCase):
     """Give each test a clean, fully-overridden environment."""
 
-    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR",
-           "XDG_CONFIG_HOME", "XDG_STATE_HOME")
+    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR", "TRUSTMUX_INSTANCE",
+           "XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_RUNTIME_DIR")
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -109,8 +109,80 @@ class TestInstancePaths(BaseDirs):
         inst.ensure_dirs()
         inst.ensure_dirs()   # must not raise
 
+    def test_label_only_set_for_non_default(self):
+        self.assertEqual(paths.Instance().label(), "")
+        self.assertEqual(paths.Instance("work").label(), " --instance work")
 
 
+class TestResolveInstance(BaseDirs):
+
+    def test_default_when_nothing_set(self):
+        self.assertEqual(paths.resolve_instance().name, "default")
+
+    def test_explicit_wins_over_env(self):
+        os.environ["TRUSTMUX_INSTANCE"] = "fromenv"
+        self.assertEqual(paths.resolve_instance("fromflag").name, "fromflag")
+
+    def test_env_used_when_no_flag(self):
+        os.environ["TRUSTMUX_INSTANCE"] = "fromenv"
+        self.assertEqual(paths.resolve_instance().name, "fromenv")
+
+    def test_accepts_reasonable_names(self):
+        for name in ("work", "a", "A1", "my-box", "my_box", "v1.2", "x" * 32):
+            self.assertEqual(paths.resolve_instance(name).name, name)
+
+    def test_rejects_traversal_and_separators(self):
+        for bad in ("..", ".", "../..", "a/b", "a/../b", "/abs", "a\\b",
+                    ".hidden", "", "x" * 33, "sp ace", "semi;colon",
+                    "$(id)", "`id`", "quo'te", "new\nline"):
+            with self.subTest(name=bad):
+                with patch("trustmux._paths.sys.stderr"):
+                    with self.assertRaises(SystemExit) as cm:
+                        paths.resolve_instance(bad)
+                self.assertEqual(cm.exception.code, 2)
+
+    def test_a_rejected_name_never_reaches_the_filesystem(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        with patch("trustmux._paths.sys.stderr"):
+            with self.assertRaises(SystemExit):
+                paths.resolve_instance("../escape")
+        self.assertEqual(list(self.root.rglob("escape")), [])
+
+
+class TestSockPathLength(BaseDirs):
+
+    def test_ok_for_a_normal_path(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "/home/u/.local/state/trustmux"
+        self.assertTrue(paths.check_sock_path(paths.Instance("work")))
+
+    def test_rejects_an_overlong_path(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "/" + "d" * 120
+        import io
+        buf = io.StringIO()
+        self.assertFalse(paths.check_sock_path(paths.Instance("work"), buf))
+        self.assertIn("unix socket", buf.getvalue())
+
+
+class TestKnownInstances(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        os.environ["TRUSTMUX_RUN_DIR"] = str(self.root / "run")
+
+    def test_empty_before_anything_exists(self):
+        self.assertEqual(paths.known_instances(), [])
+
+    def test_lists_default_first_then_alphabetical(self):
+        for name in ("zulu", "default", "alpha"):
+            paths.Instance(name).ensure_dirs()
+        self.assertEqual([i.name for i in paths.known_instances()],
+                         ["default", "alpha", "zulu"])
+
+    def test_ignores_stray_files(self):
+        paths.Instance("real").ensure_dirs()
+        (self.root / "state" / "instances" / "a-file").write_text("x")
+        self.assertEqual([i.name for i in paths.known_instances()], ["real"])
 
 
 class TestMigration(BaseDirs):

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -1,0 +1,329 @@
+"""Tests for trustmux._paths — XDG base directories and instance isolation."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import trustmux._paths as paths
+
+
+class BaseDirs(unittest.TestCase):
+    """Give each test a clean, fully-overridden environment."""
+
+    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR",
+           "XDG_CONFIG_HOME", "XDG_STATE_HOME")
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.root = Path(self.td.name)
+        self._env = patch.dict(os.environ, {}, clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        for name in self.ENV:
+            os.environ.pop(name, None)
+
+    def home(self, *parts) -> Path:
+        return Path.home().joinpath(*parts)
+
+
+class TestXdgDefaults(BaseDirs):
+
+    def test_defaults_follow_the_spec(self):
+        self.assertEqual(paths.config_dir(), self.home(".config", "trustmux"))
+        self.assertEqual(paths.state_dir(), self.home(".local", "state", "trustmux"))
+
+    def test_xdg_vars_are_honoured(self):
+        os.environ["XDG_CONFIG_HOME"] = str(self.root / "c")
+        os.environ["XDG_STATE_HOME"] = str(self.root / "s")
+        self.assertEqual(paths.config_dir(), self.root / "c" / "trustmux")
+        self.assertEqual(paths.state_dir(), self.root / "s" / "trustmux")
+
+    def test_trustmux_vars_win_over_xdg(self):
+        os.environ["XDG_STATE_HOME"] = str(self.root / "ignored")
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "wins")
+        self.assertEqual(paths.state_dir(), self.root / "wins")
+
+    def test_xdg_runtime_dir_is_deliberately_not_used(self):
+        # systemd-logind removes /run/user/$UID at last logout without
+        # linger, which would strand a running daemon's socket.
+        os.environ["XDG_RUNTIME_DIR"] = str(self.root / "runtime")
+        inst = paths.Instance()
+        for pth in (inst.sock, inst.pid_file):
+            self.assertNotIn("runtime", str(pth))
+
+    def test_machines_file_is_shared_config_not_per_instance(self):
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.root / "c")
+        self.assertEqual(paths.machines_file(), self.root / "c" / "machines.json")
+
+    def test_blank_env_var_is_ignored(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "   "
+        self.assertEqual(paths.state_dir(), self.home(".local", "state", "trustmux"))
+
+
+class TestInstancePaths(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+
+    def test_default_instance_is_not_special_cased(self):
+        inst = paths.Instance()
+        self.assertEqual(inst.name, "default")
+        self.assertEqual(inst.state, self.root / "state" / "instances" / "default")
+
+    def test_every_daemon_owned_file_lives_in_the_state_dir(self):
+        inst = paths.Instance("work")
+        for attr in ("tokens_file", "cert_file", "key_file", "log_file",
+                     "sock", "pid_file"):
+            self.assertEqual(getattr(inst, attr).parent, inst.state, attr)
+
+    def test_nothing_the_daemon_writes_lands_in_the_config_dir(self):
+        # The whole point of the change: config holds only machines.json.
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.root / "config")
+        inst = paths.Instance()
+        for attr in ("tokens_file", "cert_file", "key_file", "log_file",
+                     "sock", "pid_file"):
+            self.assertFalse(
+                str(getattr(inst, attr)).startswith(str(self.root / "config")), attr)
+
+    def test_two_instances_share_nothing(self):
+        a, b = paths.Instance("a"), paths.Instance("b")
+        for attr in ("sock", "pid_file", "tokens_file", "log_file",
+                     "cert_file", "key_file"):
+            self.assertNotEqual(getattr(a, attr), getattr(b, attr), attr)
+
+    def test_ensure_dirs_is_private(self):
+        inst = paths.Instance("perms")
+        inst.ensure_dirs()
+        self.assertTrue(inst.state.is_dir())
+        self.assertEqual(inst.state.stat().st_mode & 0o777, 0o700)
+
+    def test_ensure_dirs_is_idempotent(self):
+        inst = paths.Instance("twice")
+        inst.ensure_dirs()
+        inst.ensure_dirs()   # must not raise
+
+
+
+
+
+class TestMigration(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        self.legacy = self.root / "legacy"
+        self.legacy.mkdir()
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.legacy)
+
+    def _legacy_file(self, name, content="x", mode=0o600):
+        p = self.legacy / name
+        p.write_text(content)
+        p.chmod(mode)
+        return p
+
+    def test_no_op_when_nothing_to_migrate(self):
+        self.assertFalse(paths.migrate_legacy_layout(stream=None))
+
+    def test_moves_state_files_into_default_instance(self):
+        self._legacy_file("tokens.json", '{"tok": {}}')
+        self._legacy_file("cert.pem", "cert", 0o644)
+        self._legacy_file("key.pem", "key")
+        self._legacy_file("trustmux.log", "log")
+        import io
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        target = paths.Instance().state
+        self.assertEqual((target / "tokens.json").read_text(), '{"tok": {}}')
+        self.assertEqual((target / "key.pem").read_text(), "key")
+        self.assertEqual((target / "trustmux.log").read_text(), "log")
+
+    def test_leaves_no_copy_behind(self):
+        self._legacy_file("tokens.json")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertFalse((self.legacy / "tokens.json").exists())
+
+    def test_preserves_0600_on_secrets(self):
+        self._legacy_file("tokens.json", '{}', 0o600)
+        self._legacy_file("key.pem", "key", 0o600)
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        target = paths.Instance().state
+        for name in ("tokens.json", "key.pem"):
+            self.assertEqual((target / name).stat().st_mode & 0o777, 0o600, name)
+
+    def test_target_directory_is_private(self):
+        self._legacy_file("tokens.json")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertEqual(paths.Instance().state.stat().st_mode & 0o777, 0o700)
+
+    def test_idempotent_second_run_does_nothing(self):
+        self._legacy_file("tokens.json")
+        import io
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        self.assertFalse(paths.migrate_legacy_layout(stream=io.StringIO()))
+
+    def test_does_not_clobber_an_existing_instance(self):
+        target = paths.Instance().state
+        target.mkdir(parents=True)
+        (target / "tokens.json").write_text("new")
+        self._legacy_file("tokens.json", "old")
+        self.assertFalse(paths.migrate_legacy_layout(stream=None))
+        self.assertEqual((target / "tokens.json").read_text(), "new")
+
+    def test_isolated_by_config_dir_override(self):
+        # The legacy location follows $TRUSTMUX_CONFIG_DIR, so an overridden
+        # run never reaches into the real ~/.config/trustmux.
+        self.assertEqual(paths.legacy_dir(), self.legacy)
+
+    def test_survives_a_cross_filesystem_move(self):
+        # os.replace raises EXDEV when state lives on another filesystem.
+        import errno, io
+        self._legacy_file("tokens.json", "secret", 0o600)
+        real_replace = os.replace
+
+        def fake_replace(src, dst, *a, **kw):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        with patch("trustmux._paths.os.replace", side_effect=fake_replace):
+            self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        target = paths.Instance().state / "tokens.json"
+        self.assertEqual(target.read_text(), "secret")
+        self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+        self.assertFalse((self.legacy / "tokens.json").exists())
+
+    def test_a_failed_move_does_not_raise(self):
+        import io
+        self._legacy_file("tokens.json")
+        buf = io.StringIO()
+        with patch("trustmux._paths._move_preserving_mode",
+                   side_effect=OSError("boom")):
+            self.assertFalse(paths.migrate_legacy_layout(stream=buf))
+        self.assertIn("could not move", buf.getvalue())
+        # Left in place for a retry rather than lost.
+        self.assertTrue((self.legacy / "tokens.json").exists())
+
+    def test_retries_only_what_is_still_pending(self):
+        import io
+        self._legacy_file("tokens.json", "tok")
+        self._legacy_file("key.pem", "key")
+        target = paths.Instance().state
+        target.mkdir(parents=True)
+        (target / "tokens.json").write_text("already there")
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        self.assertEqual((target / "tokens.json").read_text(), "already there")
+        self.assertEqual((target / "key.pem").read_text(), "key")
+
+    def test_leaves_legacy_socket_and_pidfile_alone(self):
+        # A pre-upgrade daemon may still be serving on that socket.
+        self._legacy_file("tokens.json")
+        self._legacy_file("trustmux.sock")
+        self._legacy_file("trustmux.pid", "123")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertTrue((self.legacy / "trustmux.sock").exists())
+        self.assertTrue((self.legacy / "trustmux.pid").exists())
+
+
+
+class TestMigrationHardening(BaseDirs):
+    """Directory-migration code has a history of breaking long-time byobu
+    users (LP #674217), so exercise the ugly cases, not just the happy path."""
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        self.legacy = self.root / "legacy"
+        self.legacy.mkdir()
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.legacy)
+
+    def _migrate(self):
+        import io
+        buf = io.StringIO()
+        return paths.migrate_legacy_layout(stream=buf), buf.getvalue()
+
+    def test_tokens_survive_byte_for_byte(self):
+        # Losing a token means every paired phone silently stops working.
+        blob = '{"tok_%s": {"ip": "10.0.0.1", "paired_at": 1.5}}' % ("x" * 300)
+        (self.legacy / "tokens.json").write_text(blob)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(), blob)
+
+    def test_binary_keypair_survives_unchanged(self):
+        blob = bytes(range(256)) * 4
+        (self.legacy / "key.pem").write_bytes(blob)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "key.pem").read_bytes(), blob)
+
+    def test_unreadable_legacy_file_is_reported_not_fatal(self):
+        (self.legacy / "tokens.json").write_text("secret")
+        (self.legacy / "cert.pem").write_text("cert")
+        with patch("trustmux._paths._move_preserving_mode",
+                   side_effect=[None, OSError("permission denied")]):
+            moved, msg = self._migrate()
+        self.assertIn("could not move", msg)
+
+    def test_unwritable_target_parent_is_reported_not_fatal(self):
+        (self.legacy / "tokens.json").write_text("secret")
+        with patch("trustmux._paths.Path.mkdir", side_effect=PermissionError("nope")):
+            moved, msg = self._migrate()
+        self.assertFalse(moved)
+        self.assertIn("cannot create", msg)
+        # The original is untouched, so a fixed-up retry still works.
+        self.assertEqual((self.legacy / "tokens.json").read_text(), "secret")
+
+    def test_a_legacy_symlink_is_followed_to_its_content(self):
+        real = self.root / "elsewhere.json"
+        real.write_text("via symlink")
+        (self.legacy / "tokens.json").symlink_to(real)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(),
+                         "via symlink")
+
+    def test_partial_migration_completes_on_the_next_run(self):
+        (self.legacy / "tokens.json").write_text("tok")
+        (self.legacy / "key.pem").write_text("key")
+        calls = {"n": 0}
+        real = paths._move_preserving_mode
+
+        def flaky(src, dst):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("transient")
+            real(src, dst)
+
+        with patch("trustmux._paths._move_preserving_mode", side_effect=flaky):
+            self._migrate()
+        self._migrate()                      # retry picks up what was left
+        state = paths.Instance().state
+        self.assertEqual((state / "tokens.json").read_text(), "tok")
+        self.assertEqual((state / "key.pem").read_text(), "key")
+
+    def test_nothing_is_moved_twice_over_a_repeated_run(self):
+        (self.legacy / "tokens.json").write_text("first")
+        self._migrate()
+        # A daemon writes new tokens after the upgrade...
+        (paths.Instance().state / "tokens.json").write_text("second")
+        # ...and a stray legacy file reappears somehow.
+        (self.legacy / "tokens.json").write_text("resurrected")
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(),
+                         "second")
+
+    def test_config_only_install_migrates_nothing(self):
+        # machines.json is config and must stay exactly where it is.
+        (self.legacy / "machines.json").write_text("[]")
+        moved, _ = self._migrate()
+        self.assertFalse(moved)
+        self.assertTrue((self.legacy / "machines.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,14 +11,11 @@ import sys
 import time
 from pathlib import Path
 
+from trustmux._paths import Instance, migrate_legacy_layout
+
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
 SERVE_PORT = 443  # tailscale serve terminates TLS on :443
-CONFIG_DIR = Path.home() / ".config" / "trustmux"
-LOGFILE    = CONFIG_DIR / "trustmux.log"
-PIDFILE    = CONFIG_DIR / "trustmux.pid"
-ADMIN_SOCK = CONFIG_DIR / "trustmux.sock"
-TOKENS_FILE = CONFIG_DIR / "tokens.json"
 
 
 def _check_tmux() -> bool:
@@ -73,12 +70,13 @@ def _valid_port(value: object) -> int | None:
     return port if 1 <= port <= 65535 else None
 
 
-def daemon_info() -> dict | None:
-    """Ask the running daemon what it is listening on.
+def daemon_info(inst: Instance | None = None) -> dict | None:
+    """Ask this instance's running daemon what it is listening on.
 
     Returns {"pid", "host", "port", "scheme"} or None if no daemon answers.
     """
-    if not ADMIN_SOCK.exists():
+    inst = inst or Instance()
+    if not inst.sock.exists():
         return None
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
@@ -90,7 +88,7 @@ def daemon_info() -> dict | None:
             # turns ordinary commands into a multi-second hang instead of an
             # instant response.
             s.settimeout(1.5)
-            s.connect(str(ADMIN_SOCK))
+            s.connect(str(inst.sock))
             s.sendall(b'{"action": "info"}\n')
             s.shutdown(socket.SHUT_WR)
             chunks = []
@@ -107,13 +105,13 @@ def daemon_info() -> dict | None:
     return info
 
 
-def resolve_port(explicit: int | None = None) -> int:
+def resolve_port(explicit: int | None = None, inst: Instance | None = None) -> int:
     """Return the port to operate on.
 
-    Precedence: --port, then $TRUSTMUX_PORT, then whatever the running daemon
-    reports, then the default.  Consulting the daemon is what lets stop/status/
-    pair find a daemon that was started on a non-default port without having to
-    repeat the flag.
+    Precedence: --port, then $TRUSTMUX_PORT, then whatever this instance's
+    running daemon reports, then the default.  Consulting the daemon is what
+    lets stop/status/pair find a daemon that was started on a non-default port
+    without having to repeat the flag.
     """
     if explicit is not None:
         port = _valid_port(explicit)
@@ -130,7 +128,7 @@ def resolve_port(explicit: int | None = None) -> int:
             sys.exit(2)
         return port
 
-    info = daemon_info()
+    info = daemon_info(inst)
     if info:
         port = _valid_port(info.get("port"))
         if port is not None:
@@ -172,13 +170,14 @@ def direct_url(port: int, info: dict | None = None) -> str:
     return f"{scheme}://{hostname}:{port}/"
 
 
-def _ensure_dir() -> None:
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    LOGFILE.touch()
-    LOGFILE.chmod(0o600)
+def _ensure_dir(inst: Instance | None = None) -> None:
+    inst = inst or Instance()
+    inst.ensure_dirs()
+    inst.log_file.touch()
+    inst.log_file.chmod(0o600)
 
 
-def _pid(port: int = DEFAULT_PORT) -> int | None:
+def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
     """Return the PID of the trustmux daemon listening on `port`, or None.
 
     lsof directly observes what is bound to `port`; when it can run, its
@@ -188,14 +187,13 @@ def _pid(port: int = DEFAULT_PORT) -> int | None:
     which is still port-scoped and authoritative since it is self-reported
     by the live process rather than inferred.
 
-    There is deliberately no further fallback to "PIDFILE's pid is alive,"
-    which cannot say anything about *which* port that pid owns: with a
-    single global PORT constant (pre-multi-port) that was an adequate proxy
-    for "is trustmux running," but once callers can ask about an arbitrary
-    port, trusting it blindly means a query for a port nothing is listening
-    on can return some *other*, unrelated daemon's pid -- which previously
-    let `trustmux stop --port <port nothing is on>` kill the wrong daemon.
+    There is deliberately no further fallback to "the pid file's pid is
+    alive," which cannot say anything about *which* port that pid owns:
+    trusting it blindly means a query for a port nothing is listening on can
+    return some other, unrelated daemon's pid -- which previously let
+    `trustmux stop --port <port nothing is on>` kill the wrong daemon.
     """
+    inst = inst or Instance()
     try:
         out = subprocess.check_output(
             ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
@@ -207,7 +205,7 @@ def _pid(port: int = DEFAULT_PORT) -> int | None:
     except (FileNotFoundError, ValueError):
         pass  # lsof unusable; fall through to the daemon's own account.
 
-    info = daemon_info()
+    info = daemon_info(inst)
     if info and _valid_port(info.get("port")) == port:
         pid = info.get("pid")
         if isinstance(pid, int) and pid > 0:
@@ -343,9 +341,10 @@ def _ensure_ts_serve(port: int = DEFAULT_PORT) -> bool:
     return False
 
 
-def _launch(port: int, extra_args: list[str]) -> int | None:
+def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> int | None:
     """Launch daemon as a detached background process. Returns PID or None."""
-    _ensure_dir()
+    inst = inst or Instance()
+    _ensure_dir(inst)
     # Ensure the package directory is on the subprocess's Python path so that
     # `python3 -m trustmux` resolves correctly regardless of how Python was
     # invoked (e.g. bare /usr/bin/python3 from a .deb shim).
@@ -353,7 +352,7 @@ def _launch(port: int, extra_args: list[str]) -> int | None:
     env = os.environ.copy()
     existing = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = f"{pkg_parent}:{existing}" if existing else pkg_parent
-    with LOGFILE.open("a") as log:
+    with inst.log_file.open("a") as log:
         proc = subprocess.Popen(
             [sys.executable, "-m", "trustmux", "--port", str(port)] + extra_args,
             stdout=log, stderr=log,
@@ -361,13 +360,21 @@ def _launch(port: int, extra_args: list[str]) -> int | None:
             start_new_session=True,
             env=env,
         )
-    PIDFILE.write_text(str(proc.pid))
+    inst.pid_file.write_text(str(proc.pid))
     time.sleep(0.5)
-    return _pid(port)
+    if proc.poll() is not None:
+        # Died on startup — usually the port is taken, which is easy to hit
+        # once more than one instance is in play.  Without this the pid file
+        # still names the (zombie) child and the caller reports success.
+        inst.pid_file.unlink(missing_ok=True)
+        return None
+    return _pid(port, inst)
 
 
-def cmd_setup(quiet: bool = False, port: int | None = None) -> int:
-    port = resolve_port(port)
+def cmd_setup(quiet: bool = False, port: int | None = None,
+              inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
     print("=== trustmux setup ===\n")
 
     # Verify package is importable
@@ -408,9 +415,11 @@ def cmd_setup(quiet: bool = False, port: int | None = None) -> int:
     return 0
 
 
-def cmd_start(mode: str = "serve", port: int | None = None) -> int:
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_start(mode: str = "serve", port: int | None = None,
+              inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if p:
         print(f"trustmux already running (pid {p})")
         return 1
@@ -435,7 +444,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         if not _ensure_ts_serve(port):
             return 1
         print("Starting trustmux (HTTPS mode)...")
-        pid = _launch(port, ["--host", "127.0.0.1", "--https"])
+        pid = _launch(port, ["--host", "127.0.0.1", "--https"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
@@ -443,7 +452,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
 
     elif mode == "start-local":
         print("Starting trustmux (loopback only — SSH tunnel access)...")
-        pid = _launch(port, ["--host", "127.0.0.1"])
+        pid = _launch(port, ["--host", "127.0.0.1"], inst)
         ok = pid is not None
         if ok:
             fqdn = socket.getfqdn()
@@ -457,7 +466,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         if not _check_tls():
             return 1
         print("Starting trustmux (direct HTTPS — self-signed cert)...")
-        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"])
+        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
@@ -469,35 +478,35 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         return 1
 
     if not ok:
-        print(f"trustmux failed to start — check {LOGFILE}")
+        print(f"trustmux failed to start — check {inst.log_file}")
         return 1
     return 0
 
 
-def cmd_stop(port: int | None = None) -> int:
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if not p:
         print("trustmux not running")
-        # "Nothing found on *this* port" does not mean PIDFILE is globally
-        # stale -- it may correctly be tracking a different, still-alive
-        # daemon on another port. Only clean it up when its own recorded pid
-        # is actually dead, same condition that made it stale pre-multi-port.
-        if PIDFILE.exists():
+        # "Nothing found on *this* port" does not mean the pid file is stale
+        # -- it may correctly be tracking this instance's daemon on another
+        # port. Only clean it up when its own recorded pid is actually dead.
+        if inst.pid_file.exists():
             try:
-                file_pid = int(PIDFILE.read_text().strip())
+                file_pid = int(inst.pid_file.read_text().strip())
                 os.kill(file_pid, 0)
             except (ValueError, ProcessLookupError, PermissionError, OSError):
-                PIDFILE.unlink(missing_ok=True)
+                inst.pid_file.unlink(missing_ok=True)
         return 0
 
-    if PIDFILE.exists():
+    if inst.pid_file.exists():
         try:
-            file_pid = int(PIDFILE.read_text().strip())
+            file_pid = int(inst.pid_file.read_text().strip())
             if file_pid != p:
-                print(f"Error: pid {p} owns port {port} but PIDFILE contains {file_pid}.",
+                print(f"Error: pid {p} owns port {port} but {inst.pid_file} contains {file_pid}.",
                       file=sys.stderr)
-                print(f"Refusing to kill. Remove {PIDFILE} manually if trustmux is truly stopped.",
+                print(f"Refusing to kill. Remove {inst.pid_file} manually if trustmux is truly stopped.",
                       file=sys.stderr)
                 return 1
         except ValueError:
@@ -505,14 +514,15 @@ def cmd_stop(port: int | None = None) -> int:
 
     os.kill(p, signal.SIGTERM)
     print(f"trustmux stopped (pid {p})")
-    PIDFILE.unlink(missing_ok=True)
+    inst.pid_file.unlink(missing_ok=True)
     return 0
 
 
-def cmd_status(port: int | None = None) -> int:
-    info = daemon_info()
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_status(port: int | None = None, inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    info = daemon_info(inst)
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if not p:
         print("trustmux not running")
         return 0
@@ -534,10 +544,12 @@ def cmd_status(port: int | None = None) -> int:
     return 0
 
 
-def cmd_log() -> int:
-    _ensure_dir()
+
+def cmd_log(inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    _ensure_dir(inst)
     try:
-        subprocess.run(["tail", "-f", str(LOGFILE)])
+        subprocess.run(["tail", "-f", str(inst.log_file)])
     except KeyboardInterrupt:
         pass
     return 0
@@ -547,9 +559,9 @@ def _refuse_root() -> None:
     """Abort if running as root (e.g. via sudo).
 
     Running as root causes three distinct failure modes:
-      1. Path.home() resolves to /root/, so PIDFILE/CONFIG_DIR point to root's
-         home; the PID-mismatch safety check in cmd_stop() is silently bypassed
-         because the user's PIDFILE is invisible to root.
+      1. Path.home() resolves to /root/, so the state and runtime directories
+         point at root's home; the PID-mismatch safety check in cmd_stop() is
+         silently bypassed because the user's pid file is invisible to root.
       2. `tailscale serve` runs as root and creates a conflicting serve config,
          clobbering the user-level config and wedging tailscale.
       3. The daemon relaunches owned by root, creating a privilege-escalation
@@ -575,8 +587,6 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
-    # Shared --port, attached to every subcommand that has to know which
-    # listener it is acting on.
     port_opts = argparse.ArgumentParser(add_help=False)
     port_opts.add_argument("--port", type=int, metavar="PORT",
                            help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
@@ -592,8 +602,8 @@ def main() -> None:
     sub.add_parser("stop",         parents=[port_opts], help="Stop daemon (tailscale serve config persists)")
     sub.add_parser("restart",      parents=[port_opts], help="Restart daemon")
     sub.add_parser("status",       parents=[port_opts], help="Show running status and URL")
-    sub.add_parser("log",          help="Tail the log file")
     sub.add_parser("enable",       parents=[port_opts], help="Start daemon and install login hook for automatic start")
+    sub.add_parser("log",          help="Tail the log file")
     sub.add_parser("disable",      help="Stop daemon and remove login hook")
     sub.add_parser("pair",         help="Generate a one-time pairing code for a new device")
     sub.add_parser("unpair",       help="List paired devices and revoke tokens")
@@ -604,41 +614,44 @@ def main() -> None:
         parser.print_help()
         sys.exit(0 if args.cmd == "help" else 1)
 
+    migrate_legacy_layout()
+
     cmd = args.cmd
+    inst = Instance()
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
-    port = resolve_port(args.port) if hasattr(args, "port") else DEFAULT_PORT
+    port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT
 
     if cmd == "setup":
-        sys.exit(cmd_setup(quiet=args.quiet, port=port))
+        sys.exit(cmd_setup(quiet=args.quiet, port=port, inst=inst))
     elif cmd in ("start", "serve"):
-        sys.exit(cmd_start("serve", port))
+        sys.exit(cmd_start("serve", port, inst))
     elif cmd == "start-local":
-        sys.exit(cmd_start("start-local", port))
+        sys.exit(cmd_start("start-local", port, inst))
     elif cmd == "start-direct":
-        sys.exit(cmd_start("start-direct", port))
+        sys.exit(cmd_start("start-direct", port, inst))
     elif cmd == "stop":
-        sys.exit(cmd_stop(port))
+        sys.exit(cmd_stop(port, inst))
     elif cmd == "restart":
-        cmd_stop(port)
+        cmd_stop(port, inst)
         time.sleep(0.5)
-        sys.exit(cmd_start("serve", port))
+        sys.exit(cmd_start("serve", port, inst))
     elif cmd == "status":
-        sys.exit(cmd_status(port))
+        sys.exit(cmd_status(port, inst))
     elif cmd == "log":
-        sys.exit(cmd_log())
+        sys.exit(cmd_log(inst))
     elif cmd == "enable":
         from trustmux._enable import main as _run_enable
-        _run_enable(port)
+        _run_enable(port, inst)
     elif cmd == "disable":
         from trustmux._disable import main as _run_disable
-        _run_disable()
+        _run_disable(inst)
     elif cmd == "pair":
         from trustmux._pair import main as _run_pair
-        _run_pair()
+        _run_pair(inst)
     elif cmd == "unpair":
         from trustmux._unpair import main as _run_unpair
-        _run_unpair()
+        _run_unpair(inst)
 
 
 if __name__ == "__main__":

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,7 +11,10 @@ import sys
 import time
 from pathlib import Path
 
-from trustmux._paths import Instance, migrate_legacy_layout
+from trustmux._paths import (DEFAULT_INSTANCE, INSTANCE_ENV, Instance,
+                             check_sock_path, known_instances,
+                             migrate_legacy_layout, resolve_instance,
+                             state_dir)
 
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
@@ -177,40 +180,87 @@ def _ensure_dir(inst: Instance | None = None) -> None:
     inst.log_file.chmod(0o600)
 
 
-def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
-    """Return the PID of the trustmux daemon listening on `port`, or None.
+def _pids_on_port(port: int) -> list[int] | None:
+    """PIDs listening on port, per lsof.
 
-    lsof directly observes what is bound to `port`; when it can run, its
-    answer -- found or not -- is authoritative and final. Only when lsof
-    itself is unusable (e.g. not installed) does this fall back to asking
-    the running daemon what port *it* is bound to over the admin socket,
-    which is still port-scoped and authoritative since it is self-reported
-    by the live process rather than inferred.
-
-    There is deliberately no further fallback to "the pid file's pid is
-    alive," which cannot say anything about *which* port that pid owns:
-    trusting it blindly means a query for a port nothing is listening on can
-    return some other, unrelated daemon's pid -- which previously let
-    `trustmux stop --port <port nothing is on>` kill the wrong daemon.
+    Empty list means lsof ran and genuinely found nothing -- a definitive
+    answer.  None means lsof could not answer at all (not installed, or output
+    this does not understand), which is the only case where a caller may fall
+    back to guessing.
     """
-    inst = inst or Instance()
     try:
         out = subprocess.check_output(
             ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
-        ).strip()
-        return int(out.splitlines()[0]) if out else None
+        )
     except subprocess.CalledProcessError:
-        # lsof ran fine and found nothing bound to this port -- definitive.
+        return []          # ran fine, nothing bound to this port
+    except FileNotFoundError:
+        return None        # lsof unusable
+    lines = [x.strip() for x in out.splitlines() if x.strip()]
+    pids = [int(l) for l in lines if l.isdigit()]
+    if lines and not pids:
+        # An lsof that does not understand -ti:<port> prints a full listing
+        # rather than failing; its columns must not be misread as pids.
         return None
-    except (FileNotFoundError, ValueError):
-        pass  # lsof unusable; fall through to the daemon's own account.
+    return pids
 
-    info = daemon_info(inst)
-    if info and _valid_port(info.get("port")) == port:
-        pid = info.get("pid")
-        if isinstance(pid, int) and pid > 0:
-            return pid
-    return None
+
+def _recorded_pid(inst: Instance) -> int | None:
+    """Live PID from this instance's pid file, or None.
+
+    Says nothing about which port that pid owns -- only ever used to attribute
+    a pid that is already known to hold the port in question.
+    """
+    if not inst.pid_file.exists():
+        return None
+    try:
+        pid = int(inst.pid_file.read_text().strip())
+        os.kill(pid, 0)
+        return pid
+    except (ValueError, ProcessLookupError, PermissionError, OSError):
+        return None
+
+
+def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
+    """Return the PID of this instance's daemon listening on `port`, or None.
+
+    lsof directly observes what is bound to `port`; when it can run, its
+    answer -- found or not -- is authoritative and final.  Only when lsof
+    itself is unusable does this fall back to asking the daemon what port *it*
+    is bound to over the admin socket, and only trust the reply when the
+    reported port matches the one being asked about.
+
+    Nothing here may return a pid without confirming it owns the *requested*
+    port: doing so is what previously let `trustmux stop --port <port nothing
+    is on>` kill an unrelated daemon.  The pid file is therefore only ever
+    used to decide *which* of the processes already known to hold the port is
+    ours -- never to conjure one up when the port is idle.
+    """
+    inst = inst or Instance()
+    listening = _pids_on_port(port)
+
+    if listening is None:
+        info = daemon_info(inst)
+        if info and _valid_port(info.get("port")) == port:
+            pid = info.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                return pid
+        return None
+
+    if not listening:
+        return None
+
+    # Something holds the port. Attribute it: with two instances bound to the
+    # same port on different addresses, "whichever pid lsof printed first" is
+    # a coin flip, so prefer this instance's own claim when it has one.
+    claimed = _recorded_pid(inst)
+    if claimed is None:
+        info = daemon_info(inst)
+        reported = info.get("pid") if info else None
+        claimed = reported if isinstance(reported, int) and reported > 0 else None
+    if claimed is not None:
+        return claimed if claimed in listening else None
+    return listening[0]
 
 
 def _ts_host() -> str:
@@ -354,7 +404,8 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
     env["PYTHONPATH"] = f"{pkg_parent}:{existing}" if existing else pkg_parent
     with inst.log_file.open("a") as log:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "trustmux", "--port", str(port)] + extra_args,
+            [sys.executable, "-m", "trustmux",
+             "--port", str(port), "--instance", inst.name] + extra_args,
             stdout=log, stderr=log,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
@@ -371,9 +422,35 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
     return _pid(port, inst)
 
 
+def can_use_serve(inst: Instance, stream=sys.stderr) -> bool:
+    """False (with a message) if this instance must not use serve mode.
+
+    `tailscale serve` publishes on the tailnet's port 443, which only one
+    daemon can own: a second `tailscale serve --bg` silently replaces the
+    first instance's mapping, leaving it running but unreachable.  Per-instance
+    --port does not help, since that only moves the loopback backend the proxy
+    forwards to, not the tailnet-facing port.
+    """
+    if inst.name == DEFAULT_INSTANCE:
+        return True
+    print(f"Error: instance {inst.name!r} cannot use tailscale serve mode.", file=stream)
+    print("  `tailscale serve` publishes on the tailnet's port 443, which only one",
+          file=stream)
+    print("  daemon can own — a second one would silently take over the mapping.",
+          file=stream)
+    print("  Use a mode that binds its own port instead:", file=stream)
+    print(f"    trustmux start-direct{inst.label()} --port <port>", file=stream)
+    print(f"    trustmux start-local{inst.label()} --port <port>", file=stream)
+    return False
+
+
 def cmd_setup(quiet: bool = False, port: int | None = None,
               inst: Instance | None = None) -> int:
     inst = inst or Instance()
+    # setup exists to configure tailscale serve, so there is nothing it can
+    # usefully do for an instance that is not allowed to use it.
+    if not can_use_serve(inst):
+        return 1
     port = resolve_port(port, inst)
     print("=== trustmux setup ===\n")
 
@@ -408,9 +485,10 @@ def cmd_setup(quiet: bool = False, port: int | None = None,
     warn_if_peer_blocked()
 
     if not quiet:
+        opts = f"{inst.label()}{port_opt(port)}"
         print("\nSetup complete. Next steps:\n")
-        print(f"  1. Start the daemon:      trustmux start{port_opt(port)}")
-        print("  2. Generate pairing code: trustmux pair")
+        print(f"  1. Start the daemon:      trustmux start{opts}")
+        print(f"  2. Generate pairing code: trustmux pair{inst.label()}")
         print(f"  3. Open on your phone:    https://{ts_host}")
     return 0
 
@@ -418,6 +496,10 @@ def cmd_setup(quiet: bool = False, port: int | None = None,
 def cmd_start(mode: str = "serve", port: int | None = None,
               inst: Instance | None = None) -> int:
     inst = inst or Instance()
+    if mode == "serve" and not can_use_serve(inst):
+        return 1
+    if not check_sock_path(inst):
+        return 1
     port = resolve_port(port, inst)
     p = _pid(port, inst)
     if p:
@@ -492,12 +574,8 @@ def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
         # "Nothing found on *this* port" does not mean the pid file is stale
         # -- it may correctly be tracking this instance's daemon on another
         # port. Only clean it up when its own recorded pid is actually dead.
-        if inst.pid_file.exists():
-            try:
-                file_pid = int(inst.pid_file.read_text().strip())
-                os.kill(file_pid, 0)
-            except (ValueError, ProcessLookupError, PermissionError, OSError):
-                inst.pid_file.unlink(missing_ok=True)
+        if inst.pid_file.exists() and _recorded_pid(inst) is None:
+            inst.pid_file.unlink(missing_ok=True)
         return 0
 
     if inst.pid_file.exists():
@@ -544,6 +622,20 @@ def cmd_status(port: int | None = None, inst: Instance | None = None) -> int:
     return 0
 
 
+def cmd_list() -> int:
+    instances = known_instances()
+    if not instances:
+        print("no trustmux instances yet")
+        return 0
+    print(f"{'INSTANCE':<16} {'PORT':>5}  {'SCHEME':<6} STATUS")
+    for inst in instances:
+        info = daemon_info(inst) or {}
+        port = _valid_port(info.get("port"))
+        p = _pid(port or DEFAULT_PORT, inst) if info else _recorded_pid(inst)
+        status = f"running (pid {p})" if p else "stopped"
+        print(f"{inst.name:<16} {port or '-':>5}  {info.get('scheme', '-'):<6} {status}")
+    return 0
+
 
 def cmd_log(inst: Instance | None = None) -> int:
     inst = inst or Instance()
@@ -587,26 +679,36 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
+    # --instance selects which daemon's state directory to act on and so is
+    # accepted everywhere; --port only matters to commands that address a
+    # listener.
+    inst_opts = argparse.ArgumentParser(add_help=False)
+    inst_opts.add_argument("--instance", metavar="NAME",
+                           help=f"Instance name (default: {DEFAULT_INSTANCE}, or ${INSTANCE_ENV})")
+
     port_opts = argparse.ArgumentParser(add_help=False)
     port_opts.add_argument("--port", type=int, metavar="PORT",
                            help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
 
-    p_setup = sub.add_parser("setup", parents=[port_opts],
+    both = [inst_opts, port_opts]
+
+    p_setup = sub.add_parser("setup", parents=both,
                              help="One-time setup: verify install, configure tailscale serve")
     p_setup.add_argument("--quiet", action="store_true", help="Suppress next-steps output")
 
-    sub.add_parser("start",        parents=[port_opts], help="Start daemon via tailscale serve (HTTPS — default)")
-    sub.add_parser("serve",        parents=[port_opts], help=argparse.SUPPRESS)   # alias
-    sub.add_parser("start-local",  parents=[port_opts], help="Start daemon loopback-only for SSH tunnel access")
-    sub.add_parser("start-direct", parents=[port_opts], help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
-    sub.add_parser("stop",         parents=[port_opts], help="Stop daemon (tailscale serve config persists)")
-    sub.add_parser("restart",      parents=[port_opts], help="Restart daemon")
-    sub.add_parser("status",       parents=[port_opts], help="Show running status and URL")
-    sub.add_parser("enable",       parents=[port_opts], help="Start daemon and install login hook for automatic start")
-    sub.add_parser("log",          help="Tail the log file")
-    sub.add_parser("disable",      help="Stop daemon and remove login hook")
-    sub.add_parser("pair",         help="Generate a one-time pairing code for a new device")
-    sub.add_parser("unpair",       help="List paired devices and revoke tokens")
+    sub.add_parser("start",        parents=both, help="Start daemon via tailscale serve (HTTPS — default)")
+    sub.add_parser("serve",        parents=both, help=argparse.SUPPRESS)   # alias
+    sub.add_parser("start-local",  parents=both, help="Start daemon loopback-only for SSH tunnel access")
+    sub.add_parser("start-direct", parents=both, help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
+    sub.add_parser("stop",         parents=both, help="Stop daemon (tailscale serve config persists)")
+    sub.add_parser("restart",      parents=both, help="Restart daemon")
+    sub.add_parser("status",       parents=both, help="Show running status and URL")
+    sub.add_parser("enable",       parents=both, help="Start daemon and install login hook for automatic start")
+    sub.add_parser("log",          parents=[inst_opts], help="Tail the log file")
+    sub.add_parser("disable",      parents=[inst_opts], help="Stop daemon and remove login hook")
+    sub.add_parser("pair",         parents=[inst_opts], help="Generate a one-time pairing code for a new device")
+    sub.add_parser("unpair",       parents=[inst_opts], help="List paired devices and revoke tokens")
+    sub.add_parser("list",         help="List instances and their listeners")
     sub.add_parser("help",         help=argparse.SUPPRESS)  # alias for -h/--help
 
     args = parser.parse_args()
@@ -617,7 +719,7 @@ def main() -> None:
     migrate_legacy_layout()
 
     cmd = args.cmd
-    inst = Instance()
+    inst = resolve_instance(getattr(args, "instance", None))
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
     port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT
@@ -633,11 +735,18 @@ def main() -> None:
     elif cmd == "stop":
         sys.exit(cmd_stop(port, inst))
     elif cmd == "restart":
+        # restart brings the daemon back in serve mode, so check the serve
+        # restriction before stopping anything -- otherwise a named instance
+        # gets stopped and then refused, leaving it down.
+        if not can_use_serve(inst):
+            sys.exit(1)
         cmd_stop(port, inst)
         time.sleep(0.5)
         sys.exit(cmd_start("serve", port, inst))
     elif cmd == "status":
         sys.exit(cmd_status(port, inst))
+    elif cmd == "list":
+        sys.exit(cmd_list())
     elif cmd == "log":
         sys.exit(cmd_log(inst))
     elif cmd == "enable":

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -22,6 +22,8 @@ import tornado.httpserver
 import tornado.web
 import tornado.websocket
 
+from trustmux._paths import Instance, machines_file, migrate_legacy_layout
+
 def _resolve_version() -> str:
     import subprocess as _sp
     # Prefer the full Debian package version (e.g. 7.14-1~local1) when
@@ -63,10 +65,17 @@ _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on un
 _https_mode: bool = False             # set by --https; enables Secure cookie
 _listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
-CONFIG_DIR    = Path.home() / ".config" / "trustmux"
-TOKENS_FILE   = CONFIG_DIR / "tokens.json"
-ADMIN_SOCK    = CONFIG_DIR / "trustmux.sock"
-MACHINES_FILE = CONFIG_DIR / "machines.json"
+# Which instance's files this daemon owns.
+INSTANCE      = Instance()
+STATE_DIR     = INSTANCE.state
+TOKENS_FILE   = INSTANCE.tokens_file
+ADMIN_SOCK    = INSTANCE.sock
+CERT_FILE     = INSTANCE.cert_file
+KEY_FILE      = INSTANCE.key_file
+MACHINES_FILE = machines_file()   # shared by every instance
+
+
+
 _INSTALLED_STATIC = Path("/usr/share/trustmux/static")
 _DEV_STATIC       = Path(__file__).parent / "static"
 STATIC            = _INSTALLED_STATIC if _INSTALLED_STATIC.is_dir() else _DEV_STATIC
@@ -110,8 +119,8 @@ def _load_tokens() -> None:
         print(f"Warning: could not load {TOKENS_FILE}: {e} — all sessions lost", flush=True)
 
 def _save_tokens() -> None:
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-    CONFIG_DIR.chmod(0o700)
+    STATE_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    STATE_DIR.chmod(0o700)
     tmp = TOKENS_FILE.with_suffix(".tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
@@ -1136,8 +1145,30 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
         await writer.wait_closed()
 
 
+def _socket_is_stale(path: Path) -> bool:
+    """True if path is a socket file with nothing listening on it.
+
+    The state directory persists across logout and reboot, so a socket left
+    behind by a killed daemon stays on disk.  Connecting is the only way to
+    tell that apart from one a live daemon is serving: a leftover file refuses
+    the connection, a live one accepts it.
+    """
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(1.5)
+    try:
+        probe.connect(str(path))
+    except OSError:
+        return True
+    finally:
+        probe.close()
+    return False
+
+
 async def _run_admin_server() -> None:
-    if ADMIN_SOCK.exists():
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Only ever remove a socket nothing is serving; main() has already refused
+    # to start if a live one was there.
+    if ADMIN_SOCK.exists() and _socket_is_stale(ADMIN_SOCK):
         ADMIN_SOCK.unlink()
     old_mask = os.umask(0o177)  # socket created with mode 0o600
     try:
@@ -1186,9 +1217,9 @@ def _ensure_self_signed_cert(lan_ip: str) -> tuple:
     from cryptography.hazmat.primitives import hashes as _hashes, serialization as _ser
     from cryptography.hazmat.primitives.asymmetric import ec as _ec
 
-    cert = CONFIG_DIR / "cert.pem"
-    key  = CONFIG_DIR / "key.pem"
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    cert = CERT_FILE
+    key  = KEY_FILE
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
     san_parts = [f"IP:{lan_ip}", "IP:127.0.0.1", "DNS:localhost"]
     fqdn = socket.getfqdn()
     if fqdn and fqdn not in ("localhost", lan_ip):
@@ -1296,6 +1327,18 @@ def main():
         parser.print_help()
         sys.exit(0)
     args = parser.parse_args()
+
+    migrate_legacy_layout()
+
+    # Refuse before the event loop starts, so this surfaces as a plain message
+    # rather than a traceback out of an asyncio task.  Unlinking a live socket
+    # would leave the daemon already serving on it running on an unlinked
+    # inode that nothing can reach, silently stealing pair/unpair/info from it.
+    if ADMIN_SOCK.exists() and not _socket_is_stale(ADMIN_SOCK):
+        print(f"Error: another trustmux daemon is already serving {ADMIN_SOCK}",
+              file=sys.stderr)
+        print("  Stop it first, or use a different state directory.", file=sys.stderr)
+        sys.exit(1)
 
     _load_tokens()
 

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -22,7 +22,8 @@ import tornado.httpserver
 import tornado.web
 import tornado.websocket
 
-from trustmux._paths import Instance, machines_file, migrate_legacy_layout
+from trustmux._paths import (Instance, check_sock_path, machines_file,
+                             migrate_legacy_layout, resolve_instance)
 
 def _resolve_version() -> str:
     import subprocess as _sp
@@ -65,7 +66,7 @@ _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on un
 _https_mode: bool = False             # set by --https; enables Secure cookie
 _listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
-# Which instance's files this daemon owns.
+# Which instance's files this daemon owns; repointed by --instance.
 INSTANCE      = Instance()
 STATE_DIR     = INSTANCE.state
 TOKENS_FILE   = INSTANCE.tokens_file
@@ -74,6 +75,16 @@ CERT_FILE     = INSTANCE.cert_file
 KEY_FILE      = INSTANCE.key_file
 MACHINES_FILE = machines_file()   # shared by every instance
 
+
+def _set_instance(inst: Instance) -> None:
+    """Point this daemon's files at inst. Must run before _load_tokens()."""
+    global INSTANCE, STATE_DIR, TOKENS_FILE, ADMIN_SOCK, CERT_FILE, KEY_FILE
+    INSTANCE    = inst
+    STATE_DIR   = inst.state
+    TOKENS_FILE = inst.tokens_file
+    ADMIN_SOCK  = inst.sock
+    CERT_FILE   = inst.cert_file
+    KEY_FILE    = inst.key_file
 
 
 _INSTALLED_STATIC = Path("/usr/share/trustmux/static")
@@ -1318,6 +1329,9 @@ def main():
                         help="HTTPS mode: Secure cookie + trust proxy headers (use with tailscale serve)")
     parser.add_argument("--self-signed", action="store_true",
                         help="Generate a self-signed TLS cert for direct HTTPS without Tailscale")
+    parser.add_argument("--instance", metavar="NAME", default=None,
+                        help="Instance whose state and runtime files to use "
+                             "(default: default)")
 
     # `trustmuxd help` is a natural guess (matches `trustmux help`'s alias for
     # -h/--help) but argparse has no subcommands here to hang a hidden alias
@@ -1329,6 +1343,10 @@ def main():
     args = parser.parse_args()
 
     migrate_legacy_layout()
+    inst = resolve_instance(args.instance)
+    if not check_sock_path(inst):
+        sys.exit(1)
+    _set_instance(inst)
 
     # Refuse before the event loop starts, so this surfaces as a plain message
     # rather than a traceback out of an asyncio task.  Unlinking a live socket

--- a/mobile/trustmux/_disable.py
+++ b/mobile/trustmux/_disable.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from trustmux._ctl import cmd_stop
-from trustmux._enable import is_hook_line
+from trustmux._enable import is_hook_for
 from trustmux._paths import Instance
 
 _LOGIN_FILES = [
@@ -14,11 +14,13 @@ _LOGIN_FILES = [
 ]
 
 
-def _remove_hook(dest: Path) -> None:
+def _remove_hook(dest: Path, inst: Instance | None = None) -> None:
     if not dest.exists() or not os.access(dest, os.W_OK):
         return
+    inst = inst or Instance()
     lines = dest.read_text().splitlines(keepends=True)
-    filtered = [l for l in lines if not is_hook_line(l)]
+    # Only this instance's hook: disabling one must not un-enable the others.
+    filtered = [l for l in lines if not is_hook_for(l, inst)]
     if len(filtered) < len(lines):
         dest.write_text("".join(filtered))
 
@@ -26,7 +28,7 @@ def _remove_hook(dest: Path) -> None:
 def main(inst: Instance | None = None) -> None:
     inst = inst or Instance()
     for f in _LOGIN_FILES:
-        _remove_hook(f)
+        _remove_hook(f, inst)
 
     cmd_stop(inst=inst)
 
@@ -36,7 +38,7 @@ def main(inst: Instance | None = None) -> None:
     print(f"Paired device tokens are preserved in {inst.tokens_file}.")
     print()
     print("To re-enable later, run:")
-    print("  trustmux enable")
+    print(f"  trustmux enable{inst.label()}")
     print()
 
 

--- a/mobile/trustmux/_disable.py
+++ b/mobile/trustmux/_disable.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from trustmux._ctl import cmd_stop
 from trustmux._enable import is_hook_line
+from trustmux._paths import Instance
 
 _LOGIN_FILES = [
     Path.home() / ".profile",
@@ -22,16 +23,17 @@ def _remove_hook(dest: Path) -> None:
         dest.write_text("".join(filtered))
 
 
-def main() -> None:
+def main(inst: Instance | None = None) -> None:
+    inst = inst or Instance()
     for f in _LOGIN_FILES:
         _remove_hook(f)
 
-    cmd_stop()
+    cmd_stop(inst=inst)
 
     print()
     print("Trustmux daemon stopped. It will no longer start automatically at login.")
     print()
-    print("Paired device tokens are preserved in ~/.config/trustmux/tokens.json.")
+    print(f"Paired device tokens are preserved in {inst.tokens_file}.")
     print()
     print("To re-enable later, run:")
     print("  trustmux enable")

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -3,7 +3,8 @@ import os
 import sys
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, cmd_setup, cmd_start, port_opt
+from trustmux._ctl import (DEFAULT_PORT, can_use_serve, cmd_setup, cmd_start,
+                           port_opt)
 from trustmux._paths import Instance
 
 _HOOK = "trustmux start 2>/dev/null || true\n"
@@ -17,10 +18,11 @@ if "zsh" in os.environ.get("SHELL", ""):
     _LOGIN_FILES.append(Path.home() / ".zprofile")
 
 
-def hook_line(port: int = DEFAULT_PORT) -> str:
-    """Login hook to install. Only carries --port when it is not the default,
-    so profiles written by older versions stay byte-identical."""
-    return f"trustmux start{port_opt(port)} 2>/dev/null || true\n"
+def hook_line(port: int = DEFAULT_PORT, inst: Instance | None = None) -> str:
+    """Login hook to install. Only carries --instance/--port when they are not
+    the defaults, so profiles written by older versions stay byte-identical."""
+    inst = inst or Instance()
+    return f"trustmux start{inst.label()}{port_opt(port)} 2>/dev/null || true\n"
 
 
 def is_hook_line(line: str) -> bool:
@@ -28,15 +30,30 @@ def is_hook_line(line: str) -> bool:
     return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
 
 
+def is_hook_for(line: str, inst: Instance | None = None) -> bool:
+    """True for a hook line belonging to this instance.
 
-def _install_hook(dest: Path, hook: str = _HOOK) -> None:
+    Each instance owns one line, so enabling a second instance appends rather
+    than overwriting the first.
+    """
+    inst = inst or Instance()
+    if not is_hook_line(line):
+        return False
+    if f"--instance {inst.name}" in line:
+        return True
+    # A hook with no --instance is the default instance's.
+    return inst.name == Instance().name and "--instance" not in line
+
+
+def _install_hook(dest: Path, hook: str = _HOOK, inst: Instance | None = None) -> None:
     if not dest.exists():
         return
+    inst = inst or Instance()
     lines = dest.read_text().splitlines(keepends=True)
-    if any(is_hook_line(l) for l in lines):
-        # Rewrite in place so `enable --port N` updates a hook installed
-        # earlier with a different port instead of silently keeping the old one.
-        updated = [hook if is_hook_line(l) else l for l in lines]
+    if any(is_hook_for(l, inst) for l in lines):
+        # Rewrite in place so `enable --port N` updates this instance's hook
+        # instead of silently keeping the old port.
+        updated = [hook if is_hook_for(l, inst) else l for l in lines]
         if updated != lines:
             dest.write_text("".join(updated))
         return
@@ -46,14 +63,25 @@ def _install_hook(dest: Path, hook: str = _HOOK) -> None:
 
 def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
     inst = inst or Instance()
-    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
-        print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
-        print(f"  trustmux enable{port_opt(port)}")
+    # enable == setup + start in serve mode + login hook, so it inherits the
+    # serve restriction. Check up front: otherwise cmd_setup refuses and the
+    # generic "re-run trustmux enable" hint below would just loop.
+    if not can_use_serve(inst):
+        print("", file=sys.stderr)
+        print("  To start it at login anyway, add one of the above to your shell",
+              file=sys.stderr)
+        print("  profile yourself — `enable` only manages serve-mode instances.",
+              file=sys.stderr)
         sys.exit(1)
 
-    hook = hook_line(port)
+    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
+        print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
+        print(f"  trustmux enable{inst.label()}{port_opt(port)}")
+        sys.exit(1)
+
+    hook = hook_line(port, inst)
     for f in _LOGIN_FILES:
-        _install_hook(f, hook)
+        _install_hook(f, hook, inst)
 
     started = cmd_start("serve", port, inst) == 0
 
@@ -67,13 +95,13 @@ def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
     tokens = inst.tokens_file
     if not tokens.exists() or tokens.stat().st_size == 0:
         print("Next step — pair your phone:")
-        print("  trustmux pair")
+        print(f"  trustmux pair{inst.label()}")
         print()
         print("Open the URL printed above in your phone's browser, enter the code, and tap Pair.")
         print()
 
     print("To stop and disable later, run:")
-    print("  trustmux disable")
+    print(f"  trustmux disable{inst.label()}")
     print()
 
 

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -3,7 +3,8 @@ import os
 import sys
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, TOKENS_FILE, cmd_setup, cmd_start, port_opt
+from trustmux._ctl import DEFAULT_PORT, cmd_setup, cmd_start, port_opt
+from trustmux._paths import Instance
 
 _HOOK = "trustmux start 2>/dev/null || true\n"
 
@@ -27,6 +28,7 @@ def is_hook_line(line: str) -> bool:
     return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
 
 
+
 def _install_hook(dest: Path, hook: str = _HOOK) -> None:
     if not dest.exists():
         return
@@ -42,8 +44,9 @@ def _install_hook(dest: Path, hook: str = _HOOK) -> None:
         f.write(f"\n{hook}")
 
 
-def main(port: int = DEFAULT_PORT) -> None:
-    if cmd_setup(quiet=True, port=port) != 0:
+def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
+    inst = inst or Instance()
+    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
         print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
         print(f"  trustmux enable{port_opt(port)}")
         sys.exit(1)
@@ -52,7 +55,7 @@ def main(port: int = DEFAULT_PORT) -> None:
     for f in _LOGIN_FILES:
         _install_hook(f, hook)
 
-    started = cmd_start("serve", port) == 0
+    started = cmd_start("serve", port, inst) == 0
 
     print()
     if started:
@@ -61,7 +64,8 @@ def main(port: int = DEFAULT_PORT) -> None:
         print("Trustmux daemon is already running and will launch automatically at each login.")
     print()
 
-    if not TOKENS_FILE.exists() or TOKENS_FILE.stat().st_size == 0:
+    tokens = inst.tokens_file
+    if not tokens.exists() or tokens.stat().st_size == 0:
         print("Next step — pair your phone:")
         print("  trustmux pair")
         print()

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -9,18 +9,19 @@ import termios
 import tty
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, daemon_info, direct_url, resolve_port, warn_if_peer_blocked
+from trustmux._ctl import (DEFAULT_PORT, Instance, daemon_info, direct_url,
+                           resolve_port, warn_if_peer_blocked)
 
-SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
 
 
-def admin(cmd: dict) -> object:
-    if not SOCK.exists():
+def admin(cmd: dict, inst: Instance | None = None) -> object:
+    inst = inst or Instance()
+    if not inst.sock.exists():
         print("Error: Trustmux daemon not running (socket not found)", file=sys.stderr)
         sys.exit(1)
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
         try:
-            s.connect(str(SOCK))
+            s.connect(str(inst.sock))
         except OSError as e:
             print(f"Error: cannot connect to Trustmux daemon: {e}", file=sys.stderr)
             sys.exit(1)
@@ -60,7 +61,7 @@ def _ts_url() -> str:
     return ""
 
 
-def _pair_url() -> str:
+def _pair_url(inst: Instance | None = None) -> str:
     """Return the URL a phone should open to reach this daemon.
 
     `tailscale serve` fronts the daemon only in the default start mode, which
@@ -68,7 +69,8 @@ def _pair_url() -> str:
     and start-direct the tailnet name does not answer, so use the daemon's own
     address and port instead.
     """
-    info = daemon_info() or {}
+    inst = inst or Instance()
+    info = daemon_info(inst) or {}
     served = info.get("host") in ("127.0.0.1", "localhost", "::1") \
         and info.get("scheme") == "https"
     if served or not info:
@@ -79,7 +81,7 @@ def _pair_url() -> str:
     # (possibly daemon-querying) fallback is only actually needed when info
     # has none -- avoids a second, redundant admin-socket round trip in the
     # common case where info was already fetched above.
-    port = DEFAULT_PORT if info else resolve_port()
+    port = DEFAULT_PORT if info else resolve_port(inst=inst)
     return direct_url(port, info)
 
 
@@ -120,14 +122,15 @@ def _wait_and_clear() -> None:
     print("\033[2J\033[H", end="", flush=True)
 
 
-def main():
-    data = admin({"action": "pair_generate"})
+def main(inst: Instance | None = None):
+    inst = inst or Instance()
+    data = admin({"action": "pair_generate"}, inst)
     if not isinstance(data, dict) or "error" in data:
         print(f"Error: {data.get('error', data)}", file=sys.stderr)
         sys.exit(1)
     code = data["code"]
     mins = data["expires_in"] // 60
-    url = _pair_url()
+    url = _pair_url(inst)
 
     pair_url = f"{url}#{code.replace('-', '')}"
     bar = "═" * 52

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -1,6 +1,7 @@
 """Where trustmux keeps its files.
 
-XDG base directories, under a per-instance subdirectory:
+XDG base directories, with one subdirectory per instance so that two daemons
+never share a pid file, socket or token store:
 
     config  $XDG_CONFIG_HOME/trustmux   machines.json — the only thing the user
                                         writes by hand
@@ -25,6 +26,7 @@ BYOBU_CONFIG_DIR.
 """
 import errno
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +34,11 @@ from pathlib import Path
 _PKG = "trustmux"
 
 DEFAULT_INSTANCE = "default"
+INSTANCE_ENV = "TRUSTMUX_INSTANCE"
+# Instance names are path components and are interpolated into the ~/.profile
+# hook line, so keep them to an unambiguous alphabet: no separators, no
+# leading dot.
+INSTANCE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
 
 # Pre-instances layout: everything sat directly in the config directory.
 _LEGACY_STATE_FILES = ("tokens.json", "cert.pem", "key.pem", "trustmux.log")
@@ -62,10 +69,9 @@ def machines_file() -> Path:
 
 @dataclass(frozen=True)
 class Instance:
-    """One daemon's state directory.
+    """One daemon's private state directory.
 
-    Only the default instance exists for now; the layout is already keyed by
-    name so that selecting another is purely a matter of plumbing.
+    Two daemons never share a pid file, socket or token store.
     """
     name: str = DEFAULT_INSTANCE
 
@@ -97,13 +103,66 @@ class Instance:
     def pid_file(self) -> Path:
         return self.state / "trustmux.pid"
 
+    def label(self) -> str:
+        """' --instance NAME' for non-default instances, for printed hints."""
+        return "" if self.name == DEFAULT_INSTANCE else f" --instance {self.name}"
+
     def ensure_dirs(self) -> None:
         self.state.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.state.mkdir(mode=0o700, exist_ok=True)
         self.state.chmod(0o700)
 
 
+def resolve_instance(explicit: str | None = None) -> Instance:
+    """--instance, then $TRUSTMUX_INSTANCE, then 'default'. Exits 2 if invalid."""
+    # An explicitly empty --instance is an error, not a silent fall-through;
+    # a blank environment variable is treated as unset.
+    if explicit is None:
+        name = os.environ.get(INSTANCE_ENV, "").strip() or DEFAULT_INSTANCE
+    else:
+        name = explicit
+    if not INSTANCE_RE.match(name):
+        print(f"Error: invalid instance name {name!r} — use letters, digits, "
+              "'.', '_' or '-' (max 32, not starting with '.').", file=sys.stderr)
+        sys.exit(2)
+    inst = Instance(name)
+    # Belt and braces: the regex already forbids separators, so this only fires
+    # if that alphabet is ever widened.  Compares unresolved paths, so a
+    # deliberately symlinked instance directory keeps working.
+    if inst.state.parent.name != "instances":
+        print(f"Error: instance name {name!r} escapes its directory.", file=sys.stderr)
+        sys.exit(2)
+    return inst
 
+
+def check_sock_path(inst: Instance, stream=sys.stderr) -> bool:
+    """False (with a message) if the admin socket path is too long to bind.
+
+    struct sockaddr_un caps sun_path at 108 bytes on Linux and 104 on macOS;
+    without this the failure surfaces as a bare OSError from bind().
+    """
+    limit = 104 if sys.platform == "darwin" else 108
+    encoded = len(str(inst.sock).encode())
+    if encoded < limit:
+        return True
+    print(f"Error: admin socket path is {encoded} bytes, over the {limit}-byte "
+          f"limit for unix sockets:\n  {inst.sock}", file=stream)
+    print("Use a shorter instance name, or set $TRUSTMUX_STATE_DIR to a shorter path.",
+          file=stream)
+    return False
+
+
+def known_instances() -> list[Instance]:
+    """Every instance with a state directory, default first."""
+    try:
+        names = sorted(p.name for p in (state_dir() / "instances").iterdir()
+                       if p.is_dir())
+    except OSError:
+        names = []
+    if DEFAULT_INSTANCE in names:
+        names.remove(DEFAULT_INSTANCE)
+        names.insert(0, DEFAULT_INSTANCE)
+    return [Instance(n) for n in names]
 
 
 def legacy_dir() -> Path:

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -1,0 +1,180 @@
+"""Where trustmux keeps its files.
+
+XDG base directories, under a per-instance subdirectory:
+
+    config  $XDG_CONFIG_HOME/trustmux   machines.json — the only thing the user
+                                        writes by hand
+    state   $XDG_STATE_HOME/trustmux    tokens.json, cert.pem, key.pem, log,
+                                        admin socket, pid file
+
+Everything the daemon owns lives together in the state directory, as it always
+has -- just no longer mixed in with configuration.
+
+Deliberately *not* $XDG_RUNTIME_DIR for the socket and pid file, despite that
+being where the spec puts them: systemd-logind removes /run/user/$UID when a
+user's last login session ends unless `loginctl enable-linger` is set, which is
+off by default.  Trustmux exists to be started and then reached later from a
+phone, so a daemon outliving the directory holding its socket -- alive but
+unreachable -- is squarely on the main path.  It also does not exist on macOS
+or in most containers.  Byobu has never used it either (usr/lib/byobu/include/
+dirs.in).  Staleness is instead detected explicitly: see _daemon's admin server
+and _ctl's _pid().
+
+Each base honours a TRUSTMUX_*_DIR override, mirroring byobu's own
+BYOBU_CONFIG_DIR.
+"""
+import errno
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PKG = "trustmux"
+
+DEFAULT_INSTANCE = "default"
+
+# Pre-instances layout: everything sat directly in the config directory.
+_LEGACY_STATE_FILES = ("tokens.json", "cert.pem", "key.pem", "trustmux.log")
+
+
+def _env_dir(name: str) -> Path | None:
+    value = os.environ.get(name, "").strip()
+    return Path(value).expanduser() if value else None
+
+
+def config_dir() -> Path:
+    """User-authored configuration."""
+    return (_env_dir("TRUSTMUX_CONFIG_DIR")
+            or (_env_dir("XDG_CONFIG_HOME") or Path.home() / ".config") / _PKG)
+
+
+def state_dir() -> Path:
+    """Data that must survive a reboot: tokens, TLS keypair, logs."""
+    return (_env_dir("TRUSTMUX_STATE_DIR")
+            or (_env_dir("XDG_STATE_HOME") or Path.home() / ".local" / "state") / _PKG)
+
+
+
+def machines_file() -> Path:
+    """Sibling-machine list for the in-app selector; shared by all instances."""
+    return config_dir() / "machines.json"
+
+
+@dataclass(frozen=True)
+class Instance:
+    """One daemon's state directory.
+
+    Only the default instance exists for now; the layout is already keyed by
+    name so that selecting another is purely a matter of plumbing.
+    """
+    name: str = DEFAULT_INSTANCE
+
+    @property
+    def state(self) -> Path:
+        return state_dir() / "instances" / self.name
+
+    @property
+    def tokens_file(self) -> Path:
+        return self.state / "tokens.json"
+
+    @property
+    def cert_file(self) -> Path:
+        return self.state / "cert.pem"
+
+    @property
+    def key_file(self) -> Path:
+        return self.state / "key.pem"
+
+    @property
+    def log_file(self) -> Path:
+        return self.state / "trustmux.log"
+
+    @property
+    def sock(self) -> Path:
+        return self.state / "trustmux.sock"
+
+    @property
+    def pid_file(self) -> Path:
+        return self.state / "trustmux.pid"
+
+    def ensure_dirs(self) -> None:
+        self.state.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.state.mkdir(mode=0o700, exist_ok=True)
+        self.state.chmod(0o700)
+
+
+
+
+
+def legacy_dir() -> Path:
+    """Where the pre-instances layout kept everything: the config directory.
+
+    Derived from config_dir() rather than hardcoding ~/.config/trustmux, so
+    that overriding the base directories fully isolates a run — otherwise a
+    test or a dev-tree invocation would reach into the real one.
+    """
+    return config_dir()
+
+
+def _move_preserving_mode(src: Path, dst: Path) -> None:
+    """Move src to dst without ever widening its permissions.
+
+    os.replace is atomic but fails across filesystems, which is easy to hit now
+    that state lives under a different base directory than config.  The
+    fallback recreates the file with the source's mode from the outset rather
+    than copying and chmod-ing after, so a 0600 secret is never briefly world
+    readable.
+    """
+    mode = src.stat().st_mode & 0o777
+    try:
+        os.replace(src, dst)
+        return
+    except OSError as e:
+        if e.errno != errno.EXDEV:
+            raise
+    data = src.read_bytes()
+    fd = os.open(dst, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    os.chmod(dst, mode)
+    src.unlink()
+
+
+def migrate_legacy_layout(stream=sys.stderr) -> bool:
+    """Move pre-instances files into the default instance's state directory.
+
+    Per-file and idempotent, so a partial failure can be retried.  Returns True
+    if anything moved.  Never raises: a migration problem must not stop the
+    command the user actually asked for.
+
+    The stale top-level pid file and socket are left alone rather than removed:
+    a daemon from before the upgrade may still be serving on that socket.
+    """
+    legacy = legacy_dir()
+    target = Instance().state
+    pending = [n for n in _LEGACY_STATE_FILES
+               if (legacy / n).exists() and not (target / n).exists()]
+    if not pending:
+        return False
+
+    moved, failed = [], []
+    try:
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target.mkdir(mode=0o700, exist_ok=True)
+    except OSError as e:
+        print(f"trustmux: cannot create {target}: {e}", file=stream)
+        return False
+
+    for name in pending:
+        try:
+            _move_preserving_mode(legacy / name, target / name)
+            moved.append(name)
+        except OSError as e:
+            failed.append(f"{name} ({e})")
+
+    if moved:
+        print(f"trustmux: moved {', '.join(moved)} to {target}", file=stream)
+    if failed:
+        print(f"trustmux: could not move {', '.join(failed)} out of {legacy} — "
+              "move them by hand or they will be ignored.", file=stream)
+    return bool(moved)

--- a/mobile/trustmux/_unpair.py
+++ b/mobile/trustmux/_unpair.py
@@ -2,18 +2,19 @@
 import json
 import socket
 import sys
-from pathlib import Path
 
-SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
+from trustmux._ctl import Instance
 
 
-def admin(cmd: dict) -> object:
-    if not SOCK.exists():
+
+def admin(cmd: dict, inst: Instance | None = None) -> object:
+    inst = inst or Instance()
+    if not inst.sock.exists():
         print("Error: Trustmux daemon not running (socket not found)", file=sys.stderr)
         sys.exit(1)
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
         try:
-            s.connect(str(SOCK))
+            s.connect(str(inst.sock))
         except OSError as e:
             print(f"Error: cannot connect to Trustmux daemon: {e}", file=sys.stderr)
             sys.exit(1)
@@ -46,8 +47,9 @@ def _ua_short(label: str) -> str:
     return label[:30]
 
 
-def main():
-    sessions = admin({"action": "sessions_list"})
+def main(inst: Instance | None = None):
+    inst = inst or Instance()
+    sessions = admin({"action": "sessions_list"}, inst)
     if not isinstance(sessions, list):
         print(f"Error: {sessions}", file=sys.stderr)
         sys.exit(1)
@@ -77,7 +79,7 @@ def main():
         print("Cancelled.")
 
     elif choice.upper() == "A":
-        result = admin({"action": "sessions_delete"})
+        result = admin({"action": "sessions_delete"}, inst)
         if isinstance(result, dict) and result.get("ok"):
             print(f"Removed {result.get('removed', 0)} paired client(s).")
         else:
@@ -88,7 +90,7 @@ def main():
         idx = int(choice) - 1
         token = sessions[idx]["token_full"]
         ip = sessions[idx]["ip"]
-        result = admin({"action": "sessions_delete", "token": token})
+        result = admin({"action": "sessions_delete", "token": token}, inst)
         if isinstance(result, dict) and result.get("ok"):
             print(f"Client {ip} unpaired.")
         else:


### PR DESCRIPTION
**Stacked on #123** — split out of it per review, so the directory question doesn't hold this up. The first commit here is #123; review only the second, or wait until #123 lands and this will rebase down to one commit.

## Why

A second daemon today doesn't merely collide with the first, it corrupts it:

- The admin server takes over any existing socket at startup, so daemon #2 steals the name while #1 keeps serving on an unlinked inode nothing can reach — then #1's exit unlinks the path now belonging to #2. (#123 makes that refuse rather than steal, which turns silent corruption into an error; but with one shared path, an error is all a second daemon can ever get.)
- Each daemon loads `tokens.json` once and rewrites the whole file on every pair/unpair, so pairing on one silently drops a token added by the other.
- The pid file and TLS keypair are likewise single-copy.

`--instance NAME` (and `$TRUSTMUX_INSTANCE`) on every subcommand gives each daemon its own pid file, admin socket, log, tokens and cert:

```bash
trustmux start-direct --instance work --port 3389
trustmux pair --instance work
trustmux list
trustmux stop --instance work
```

## Things worth your attention

**`_pid()` keeps the invariant from 11bb4ca7.** lsof stays authoritative and final, and nothing returns a pid without confirming it owns the *requested* port. What's new: when lsof reports several pids — two daemons on one port at different addresses — "whichever lsof printed first" is a coin flip, so the instance's own pid file (or its admin socket) picks ours *from among processes already known to hold the port*. It's never used to conjure a pid for an idle port, which was the original bug. There's a regression test for the exact wrong-port-stop scenario, plus a live check.

**Serve mode stays singular.** `tailscale serve` publishes on the tailnet's :443, which one daemon can own, so `setup`/`start`/`restart`/`enable` refuse a named instance and point at `start-direct`/`start-local`. `--port` doesn't lift this — it moves only the loopback backend the proxy forwards to. `restart` checks *before* stopping, since it comes back in serve mode and would otherwise stop a named daemon and then refuse to start it. Auto-start at login is therefore default-only and unchanged for existing users.

I considered a `--serve-port` so a second instance could publish on :8443, and decided against it: the tailnet endpoint is the one naturally singular thing here, and a second port flag invites exactly the `--port` vs `--serve-port` confusion. Easy to add later if anyone wants two tailnet endpoints.

**Instance names are validated, not sanitised** — `^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$` — because the name becomes a directory component *and* is interpolated into the `~/.profile` hook line. Separators, traversal, leading dots and shell metacharacters are rejected outright, with a test asserting a rejected name never touches the filesystem.

Also: `trustmux list`; per-instance login hooks (the default's hook stays byte-identical so existing profiles don't churn, and disabling one instance leaves the others alone); the socket path length-checked against `sun_path`'s 108/104-byte cap so a long name fails with a clear message rather than a bare `OSError`; and `_launch` now checks whether the child already exited, since a port conflict is much easier to hit with several instances and a zombie child was being reported as a successful start.

## Testing

336 tests (297 at #123's tip). Each commit was checked out and run on its own, not just the tip.

Verified live: two daemons on 7432 and 3389 both answering, each found and stopped independently, a wrong-port stop leaving the other alone, and the serve refusal leaving a running named instance up rather than stopping it.

## Known gap

Named instances have no auto-start-at-login path, since `enable` is serve-only. Teaching `enable` a mode (`enable --instance work --mode direct`) is a small follow-up if you want it; I left it out rather than growing this PR further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)