### PR TITLE
make 'trustmux pair' go away on its own after timeout and fix docs.

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -124,7 +124,7 @@ trustmux pair
 - Daemon binds to `127.0.0.1:7432` only — not reachable from the network
 - All traffic encrypted by Tailscale WireGuard; HTTPS via `tailscale serve`
 - No relay server — terminal data never leaves your Tailscale mesh
-- Pairing codes: 6-digit, 5-minute TTL, single-use, max 10 attempts
+- Pairing codes: 6-digit, 60-second TTL, single-use, max 3 attempts
 - Session tokens: 256-bit random, stored at mode 0600
 
 ---

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -73,8 +73,13 @@ Ask the running daemon to generate a one-time 6-digit pairing code (valid for
 If
 .BR qrencode (1)
 is installed, a QR code is printed for one-scan pairing.
-The screen is cleared on the next keypress to keep the pairing URL out of the
-terminal scroll-back.
+The command then waits for the code to be used and returns as soon as a device
+pairs, or when the code expires, whichever comes first.
+It clears the screen and prints either
+.B "pair accepted from " \fIIP\fR
+(exit status 0) or
+.B "no client paired"
+(exit status 1).
 .TP
 .B unpair
 List all currently paired devices (IP address, browser label, and pairing

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -69,7 +69,7 @@ Paired device tokens are preserved.
 .TP
 .B pair
 Ask the running daemon to generate a one-time 6-digit pairing code (valid for
-3 minutes) and display it along with the URL your phone should open.
+60 seconds) and display it along with the URL your phone should open.
 If
 .BR qrencode (1)
 is installed, a QR code is printed for one-scan pairing.
@@ -181,7 +181,7 @@ trustmux stop
 The one-time pairing code is a 6-digit decimal value drawn from
 .BR secrets.randbelow (1,000,000),
 giving 1,000,000 possible values.
-The code is valid for 3 minutes.
+The code is valid for 60 seconds.
 After three incorrect guesses the code is immediately invalidated and a new one
 must be generated with
 .BR "trustmux pair" .

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import trustmux._ctl as ctl
 import trustmux._enable as enable
 import trustmux._disable as disable
+import trustmux._pair as pair
 
 _no_daemon = None
 
@@ -1064,6 +1065,94 @@ class TestInstallHookPort(unittest.TestCase):
         disable._remove_hook(p)
         self.assertNotIn('trustmux start', p.read_text())
         self.assertIn('# top', p.read_text())
+
+
+class TestPairWait(unittest.TestCase):
+    """`trustmux pair` returns on its own -- paired, expired, or timed out."""
+
+    def setUp(self):
+        self.sleep = patch('trustmux._pair.time.sleep').start()
+        self.addCleanup(patch.stopall)
+
+    def _poll(self, *replies):
+        return patch('trustmux._pair._poll', side_effect=list(replies))
+
+    def test_returns_ip_when_paired(self):
+        with self._poll({'state': 'paired', 'ip': '100.64.0.7'}):
+            self.assertEqual(pair._wait_for_pair(60), '100.64.0.7')
+        self.sleep.assert_not_called()
+
+    def test_polls_until_paired(self):
+        with self._poll({'state': 'pending', 'expires_in': 59},
+                        {'state': 'pending', 'expires_in': 58},
+                        {'state': 'paired', 'ip': '10.0.0.4'}):
+            self.assertEqual(pair._wait_for_pair(60), '10.0.0.4')
+        self.assertEqual(self.sleep.call_count, 2)
+
+    def test_paired_without_ip_still_reports_success(self):
+        with self._poll({'state': 'paired'}):
+            self.assertEqual(pair._wait_for_pair(60), 'unknown')
+
+    def test_returns_empty_when_code_expires(self):
+        with self._poll({'state': 'expired'}):
+            self.assertEqual(pair._wait_for_pair(60), '')
+
+    def test_returns_empty_when_daemon_disappears(self):
+        with self._poll(None):
+            self.assertEqual(pair._wait_for_pair(60), '')
+
+    def test_gives_up_at_deadline(self):
+        with self._poll({'state': 'pending', 'expires_in': 0}):
+            self.assertEqual(pair._wait_for_pair(0), '')
+
+    def test_daemon_without_pair_status_waits_out_the_code(self):
+        with self._poll({'error': "unknown action: 'pair_status'"}):
+            self.assertEqual(pair._wait_for_pair(5), '')
+        self.assertEqual(self.sleep.call_count, 1)
+        self.assertGreater(self.sleep.call_args[0][0], 4)
+
+
+class TestPairMain(unittest.TestCase):
+    """main() prints the outcome and exits instead of waiting for a keypress."""
+
+    def setUp(self):
+        patch('trustmux._pair.admin',
+              return_value={'code': '123-456', 'expires_in': 60}).start()
+        patch('trustmux._pair._pair_url', return_value='https://host/').start()
+        patch('trustmux._pair.warn_if_peer_blocked').start()
+        patch('trustmux._pair._print_qr').start()
+        patch('trustmux._pair._clear').start()
+        self.addCleanup(patch.stopall)
+
+    def test_reports_accepted_pair(self):
+        with patch('trustmux._pair._wait_for_pair', return_value='10.0.0.4'), \
+             patch('builtins.print') as p:
+            pair.main()
+        out = '\n'.join(str(c[0][0]) for c in p.call_args_list if c[0])
+        self.assertIn('pair accepted from 10.0.0.4', out)
+
+    def test_reports_no_pair_and_exits_nonzero(self):
+        with patch('trustmux._pair._wait_for_pair', return_value=''), \
+             patch('builtins.print') as p:
+            with self.assertRaises(SystemExit) as cm:
+                pair.main()
+        self.assertEqual(cm.exception.code, 1)
+        out = '\n'.join(str(c[0][0]) for c in p.call_args_list if c[0])
+        self.assertIn('no client paired', out)
+
+    def test_ctrl_c_reports_no_pair(self):
+        with patch('trustmux._pair._wait_for_pair', side_effect=KeyboardInterrupt), \
+             patch('builtins.print') as p:
+            with self.assertRaises(SystemExit) as cm:
+                pair.main()
+        self.assertEqual(cm.exception.code, 1)
+        out = '\n'.join(str(c[0][0]) for c in p.call_args_list if c[0])
+        self.assertIn('no client paired', out)
+
+    def test_waits_for_the_code_ttl(self):
+        with patch('trustmux._pair._wait_for_pair', return_value='10.0.0.4') as w:
+            pair.main()
+        w.assert_called_once_with(60)
 
 
 if __name__ == '__main__':

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -283,11 +283,13 @@ class TestPairHandler(AsyncHTTPTestCase):
         bm._pair_code = ''
         bm._pair_attempts = 0
         bm._pair_code_mono_expiry = 0.0
+        bm._pair_paired_ip = ''
 
     def tearDown(self):
         bm._pair_code = ''
         bm._pair_attempts = 0
         bm._pair_code_mono_expiry = 0.0
+        bm._pair_paired_ip = ''
         _clear_sessions()
         super().tearDown()
 
@@ -323,6 +325,8 @@ class TestPairHandler(AsyncHTTPTestCase):
         self.assertIn('trustmux_session', resp.headers.get('Set-Cookie', ''))
         # Code consumed — one-time use
         self.assertEqual(bm._pair_code, '')
+        # Outcome recorded for `trustmux pair` to report
+        self.assertTrue(bm._pair_paired_ip)
 
     def test_valid_code_with_dashes(self):
         code = bm._generate_pair_code()

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -608,12 +608,14 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
         bm._pair_code = ''
         bm._pair_attempts = 0
         bm._pair_code_mono_expiry = 0.0
+        bm._pair_paired_ip = ''
 
     def tearDown(self):
         _clear_sessions()
         bm._pair_code = ''
         bm._pair_attempts = 0
         bm._pair_code_mono_expiry = 0.0
+        bm._pair_paired_ip = ''
 
     async def _call(self, payload) -> dict:
         """Drive _handle_admin with mock reader/writer; return parsed response."""
@@ -651,6 +653,46 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(resp['code']), 7)  # XXX-XXX
         self.assertIn('expires_in', resp)
         self.assertTrue(bm._pair_code)
+
+    async def test_pair_status_pending_while_code_live(self):
+        with patch.object(bm, '_print_pair_code'):
+            await self._call({'action': 'pair_generate'})
+        resp = await self._call({'action': 'pair_status'})
+        self.assertEqual(resp['state'], 'pending')
+        self.assertGreater(resp['expires_in'], 0)
+        self.assertLessEqual(resp['expires_in'], bm._PAIR_CODE_TTL)
+
+    async def test_pair_status_paired_reports_ip(self):
+        bm._pair_paired_ip = '100.64.0.7'
+        resp = await self._call({'action': 'pair_status'})
+        self.assertEqual(resp, {'state': 'paired', 'ip': '100.64.0.7'})
+
+    async def test_pair_status_expired_without_code(self):
+        resp = await self._call({'action': 'pair_status'})
+        self.assertEqual(resp, {'state': 'expired'})
+
+    async def test_pair_status_expired_after_ttl(self):
+        bm._pair_code = '123456'
+        bm._pair_code_mono_expiry = time.monotonic() - 1
+        resp = await self._call({'action': 'pair_status'})
+        self.assertEqual(resp, {'state': 'expired'})
+
+    async def test_pair_generate_clears_previous_result(self):
+        bm._pair_paired_ip = '100.64.0.7'
+        with patch.object(bm, '_print_pair_code'):
+            await self._call({'action': 'pair_generate'})
+        resp = await self._call({'action': 'pair_status'})
+        self.assertEqual(resp['state'], 'pending')
+
+    async def test_pair_status_leaks_no_code_or_token(self):
+        _add_session('tok_secret_value')
+        with patch.object(bm, '_print_pair_code'):
+            await self._call({'action': 'pair_generate'})
+        resp = await self._call({'action': 'pair_status'})
+        body = json.dumps(resp)
+        self.assertNotIn('tok_secret_value', body)
+        self.assertNotIn(bm._pair_code, body)
+        self.assertEqual(set(resp), {'state', 'expires_in'})
 
     async def test_info_reports_listener(self):
         with patch.object(bm, '_listen',

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -55,6 +55,7 @@ _pair_code: str = ""
 _pair_code_expiry: float = 0.0        # wall-clock time, for human display only
 _pair_code_mono_expiry: float = 0.0   # monotonic time, for expiry check
 _pair_attempts: int = 0
+_pair_paired_ip: str = ""             # IP that consumed the last code, for admin "pair_status"
 _MAX_PAIR_ATTEMPTS: int = 3
 _PAIR_CODE_TTL: int = 60              # 60 seconds — keep the window tight
 _TOKEN_EXPIRY_DAYS: int = 90          # sessions expire after 90 days of inactivity
@@ -124,10 +125,12 @@ def _save_tokens() -> None:
 
 def _generate_pair_code() -> str:
     global _pair_code, _pair_code_expiry, _pair_code_mono_expiry, _pair_attempts
+    global _pair_paired_ip
     _pair_code = f"{secrets.randbelow(1000000):06d}"
     _pair_code_expiry = time.time() + _PAIR_CODE_TTL
     _pair_code_mono_expiry = time.monotonic() + _PAIR_CODE_TTL
     _pair_attempts = 0
+    _pair_paired_ip = ""
     return _pair_code
 
 def _print_pair_code() -> None:
@@ -629,6 +632,7 @@ class PingHandler(BaseHandler):
 class PairHandler(BaseHandler):
     async def post(self):
         global _pair_attempts, _pair_code, _pair_code_expiry, _pair_code_mono_expiry
+        global _pair_paired_ip
         if not _pair_code:
             return self.json({"error": "no pairing code active — run trustmux-pair"}, 403)
         if time.monotonic() > _pair_code_mono_expiry:
@@ -667,6 +671,7 @@ class PairHandler(BaseHandler):
         _pair_code_expiry = 0.0
         _pair_code_mono_expiry = 0.0
         _pair_attempts = 0
+        _pair_paired_ip = ip
         print(f"✓ Trustmux: device paired ({ip})", flush=True)
         self.set_cookie(
             "trustmux_session", token,
@@ -1088,6 +1093,17 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
             code = _generate_pair_code()
             _print_pair_code()
             resp = {"code": f"{code[:3]}-{code[3:]}", "expires_in": _PAIR_CODE_TTL}
+
+        elif action == "pair_status":
+            # Outcome of the most recent code, so `trustmux pair` can stop waiting.
+            # Never returns the code itself or a session token.
+            if _pair_paired_ip:
+                resp = {"state": "paired", "ip": _pair_paired_ip}
+            elif _pair_code and time.monotonic() < _pair_code_mono_expiry:
+                resp = {"state": "pending",
+                        "expires_in": int(_pair_code_mono_expiry - time.monotonic())}
+            else:
+                resp = {"state": "expired"}
 
         elif action == "sessions_list":
             resp = [

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -5,8 +5,7 @@ import shutil
 import socket
 import subprocess
 import sys
-import termios
-import tty
+import time
 from pathlib import Path
 
 from trustmux._ctl import DEFAULT_PORT, daemon_info, direct_url, resolve_port, warn_if_peer_blocked
@@ -105,19 +104,62 @@ def _print_qr(url: str) -> None:
         pass
 
 
-def _wait_and_clear() -> None:
-    """Wait for a keypress, then clear the screen."""
-    if not sys.stdin.isatty():
-        return
-    print("  [ press any key to clear ]")
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
+def _poll(cmd: dict) -> dict | None:
+    """Like admin(), but returns None on failure instead of exiting.
+
+    A daemon that goes away mid-wait should end the wait, not crash it.
+    """
+    if not SOCK.exists():
+        return None
     try:
-        tty.setraw(fd)
-        sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-    print("\033[2J\033[H", end="", flush=True)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(10)
+            s.connect(str(SOCK))
+            s.sendall(json.dumps(cmd).encode() + b"\n")
+            s.shutdown(socket.SHUT_WR)
+            chunks = []
+            while True:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        resp = json.loads(b"".join(chunks))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return resp if isinstance(resp, dict) else None
+
+
+def _wait_for_pair(timeout: float) -> str:
+    """Wait for a device to pair, up to timeout seconds.
+
+    Returns the paired device's IP, or "" if nothing paired.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        status = _poll({"action": "pair_status"})
+        if status is None:
+            return ""                      # daemon gone -- nothing left to wait for
+        state = status.get("state")
+        if state == "paired":
+            return status.get("ip") or "unknown"
+        if state is None:
+            # Daemon predates pair_status; wait out the code instead of polling.
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(remaining)
+            return ""
+        if state != "pending":
+            return ""                      # expired
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return ""
+        time.sleep(min(1.0, remaining))
+
+
+def _clear() -> None:
+    """Clear the (now-useless) code and QR off the screen."""
+    if sys.stdout.isatty():
+        print("\033[2J\033[H", end="", flush=True)
 
 
 def main():
@@ -126,7 +168,8 @@ def main():
         print(f"Error: {data.get('error', data)}", file=sys.stderr)
         sys.exit(1)
     code = data["code"]
-    mins = data["expires_in"] // 60
+    ttl = data["expires_in"]
+    mins = ttl // 60
     url = _pair_url()
 
     pair_url = f"{url}#{code.replace('-', '')}"
@@ -139,9 +182,19 @@ def main():
     warn_if_peer_blocked()
 
     _print_qr(pair_url)
-    print()
+    print(f"\n  [ waiting up to {ttl}s for a device to pair ]")
 
-    _wait_and_clear()
+    try:
+        ip = _wait_for_pair(ttl)
+    except KeyboardInterrupt:
+        print()
+        ip = ""
+
+    _clear()
+    if not ip:
+        print("no client paired")
+        sys.exit(1)
+    print(f"pair accepted from {ip}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The trustmux pair required user to hit return, but the token would expire in 60 seconds.
This PR makes the 'trustmux pair' command return on either
1. 60 seconds gone by
2. client attached

it prints the result in either case.

The other thing here is just docs/consistency. there were several different reported timeout values now they all report 60 seconds.