### PR TITLE
trustmux: add --advertise for an address this host cannot see

### DIFF
--- a/mobile/Makefile.am
+++ b/mobile/Makefile.am
@@ -20,6 +20,7 @@ dist_trustmuxmod_DATA = \
 	trustmux/__main__.py \
 	trustmux/_daemon.py \
 	trustmux/_ctl.py \
+	trustmux/_paths.py \
 	trustmux/_pair.py \
 	trustmux/_unpair.py \
 	trustmux/_enable.py \
@@ -66,6 +67,7 @@ EXTRA_DIST = \
 	generate_screenshots.py \
 	tests/__init__.py \
 	tests/test_ctl.py \
+	tests/test_paths.py \
 	tests/test_daemon.py \
 	tests/test_daemon_extended.py
 

--- a/mobile/Makefile.am
+++ b/mobile/Makefile.am
@@ -21,6 +21,7 @@ dist_trustmuxmod_DATA = \
 	trustmux/_daemon.py \
 	trustmux/_ctl.py \
 	trustmux/_paths.py \
+	trustmux/_advertise.py \
 	trustmux/_pair.py \
 	trustmux/_unpair.py \
 	trustmux/_enable.py \
@@ -66,6 +67,7 @@ EXTRA_DIST = \
 	README.md \
 	generate_screenshots.py \
 	tests/__init__.py \
+	tests/test_advertise.py \
 	tests/test_ctl.py \
 	tests/test_paths.py \
 	tests/test_daemon.py \

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -132,6 +132,12 @@ export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
 .venv/bin/python trustmux.in start-local --port 3389
 ```
 
+`start`, `stop`, `status` and `list` only ever act on a daemon the instance
+itself started, which they establish from that instance's own admin socket and
+pid file — never by asking the system who holds a port. So a scratch tree is
+isolated even if it shares a port with your real daemon; `--port` above just
+avoids the two fighting over the bind.
+
 ---
 
 ## Files
@@ -146,7 +152,7 @@ instance. `<I>` below is the `--instance` name, or `default`.
 | `$XDG_STATE_HOME/trustmux/instances/<I>/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.log` | Daemon log (mode 0600) |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.sock` | Admin Unix socket (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.pid` | PID file |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.pid` | PID file — `<pid> <port>` |
 
 Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
 write by hand; everything the daemon owns lives together under state, as it
@@ -157,9 +163,15 @@ spec would put them. systemd-logind deletes `/run/user/$UID` when your last
 login session ends unless `loginctl enable-linger` is set, which would strand a
 still-running daemon with no socket to reach it by — and being started and then
 reached later is the whole point of trustmux. That directory also doesn't exist
-on macOS or in most containers. Leftovers are detected instead of swept away: a
-socket refuses connections once its daemon is gone, and a recorded pid is only
-believed when it's confirmed to hold the port in question.
+on macOS or in most containers. Leftovers are detected instead of swept away:
+once a daemon is gone its socket refuses connections, which is how a stale one
+is told from a live one. A daemon that still accepts connections but has
+stopped replying is still running, so the pid file records `<pid> <port>` —
+enough to stop a hung daemon without having to ask the system who holds a port.
+Asking that question is what an earlier version did, via `lsof`; it answered
+for the whole machine, so it could not tell one instance's daemon from another,
+went blind across network namespaces, and needed a binary that isn't always
+installed and doesn't always support `-ti:<port>`.
 
 `TRUSTMUX_CONFIG_DIR` and `TRUSTMUX_STATE_DIR` override each base, taking
 precedence over the XDG variables.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -99,7 +99,14 @@ trustmux start-direct --instance work --port 3389
 trustmux pair  --instance work
 trustmux list
 trustmux stop  --instance work
+trustmux rm    --instance work    # delete its state directory for good
 ```
+
+An instance is created by its first `start` and otherwise lasts forever, so
+`rm` is how you get rid of one — it deletes the state directory (session
+tokens and TLS keypair included) and removes that instance's login hook, so it
+does not come back at the next login. It refuses while the daemon is running,
+and refuses on `default`; `--force` overrides both, stopping the daemon first.
 
 The unnamed instance is called `default`; it is not special-cased, and lives
 under `instances/default/` like any other.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -88,6 +88,75 @@ trustmux status              # finds it — no need to repeat --port
 `stop`, `status` and `pair` ask the running daemon which port it is on, so only
 the start command needs the flag. `enable --port` records it in the login hook.
 
+### An address this host cannot see
+
+Behind NAT — a cloud instance, most often — the daemon only ever sees an
+internal address, so both the URL `pair` prints and the names in the
+`start-direct` certificate describe a host nothing outside can route to.
+`--advertise` says what a phone should use instead:
+
+```bash
+trustmux start-direct --advertise 203.0.113.45
+trustmux start-direct --advertise https://tmux.example.com/   # proxy on :443
+```
+
+A bare host takes the daemon's own scheme and port; a full URL overrides both,
+which is how a reverse proxy terminating TLS on 443 is expressed. Repeat the
+flag for more than one, and the first supplies the printed URL.
+
+Every advertised address also goes into the self-signed certificate. It has to:
+a browser rejects a certificate that omits the name in the URL bar outright,
+rather than offering the click-through a self-signed one gets.
+
+`--advertise` changes only what is published, not what the daemon binds — you
+still need a firewall rule admitting the port, which does put the daemon on the
+public internet behind just the pairing code and session token.
+
+#### An address that changes
+
+A cloud instance with an ephemeral public address gets a different one across a
+stop/start cycle, so a literal written down once goes quietly stale. `cmd:`
+names a program to run instead, re-run on every daemon start, one address per
+line of its output:
+
+```bash
+cat > /usr/local/bin/external-ip <<'EOF'
+#!/bin/sh
+exec curl --fail --silent -H Metadata-Flavor:Google \
+  http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip
+EOF
+chmod +x /usr/local/bin/external-ip
+
+trustmux start-direct --advertise cmd:/usr/local/bin/external-ip
+```
+
+The program is split into arguments with shell-style quoting but is **not** run
+by a shell — no pipelines, no `$(...)`; those characters are rejected rather
+than passed through, so put a pipeline in a script and name the script. Note
+`--fail` above: without it `curl` prints an error page and exits 0.
+
+Resolution is strict and any failure stops the daemon: a non-zero exit, no
+output, a blank line, a value that is not an address, or more than 5 seconds
+across all sources. A shell wrapper whose `curl` fails typically prints an
+empty line and still exits 0, and reading that as "nothing to advertise" would
+hand out an unreachable URL and a certificate for the wrong host — neither of
+which a warning would fix.
+
+To keep a source across reboots put it in the instance's config file, which is
+also the only place a login hook will find it:
+
+```bash
+mkdir -p ~/.config/trustmux/instances
+echo '{"advertise": ["cmd:/usr/local/bin/external-ip"]}' \
+  > ~/.config/trustmux/instances/default.json
+chmod 600 ~/.config/trustmux/instances/default.json
+```
+
+`--advertise` then `$TRUSTMUX_ADVERTISE` then that file, and whichever is set
+replaces the others outright rather than adding to them — otherwise a
+repeatable flag could never drop a name the file still lists.
+`--no-advertise` advertises nothing despite a configured source.
+
 ### Several daemons at once
 
 `--name NAME` (or `$TRUSTMUX_INSTANCE`) gives a daemon its own pid file,
@@ -154,16 +223,20 @@ instance. `<I>` below is the `--name` name, or `default`.
 
 | Path | Purpose |
 |---|---|
-| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector. Shared by all instances — the only user-authored file |
+| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector. Shared by all instances |
+| `$XDG_CONFIG_HOME/trustmux/instances/<I>.json` | Optional: per-instance settings, hand-written. `{"advertise": [...]}`. Refused if group- or world-writable, since a source can name a program to run |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/tokens.json` | Paired device session tokens (mode 0600) |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.log` | Daemon log (mode 0600) |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.sock` | Admin Unix socket (mode 0600) |
 | `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.pid` | PID file — `<pid> <port>` |
 
-Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
+Defaults are `~/.config` and `~/.local/state`. Config holds only the files you
 write by hand; everything the daemon owns lives together under state, as it
-always has — just no longer mixed in with configuration.
+always has — just no longer mixed in with configuration. An advertise source is
+config rather than state because it records intent, not a result: it is
+re-resolved on every start, which is what makes writing one down safe even when
+the address behind it changes.
 
 The socket and pid file stay here rather than in `$XDG_RUNTIME_DIR`, where the
 spec would put them. systemd-logind deletes `/run/user/$UID` when your last

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -14,7 +14,10 @@ Two tiers:
 
 - tmux (byobu optional but recommended)
 - Python 3.10+
-- [Tailscale](https://tailscale.com) installed, running, and connected
+- [Tailscale](https://tailscale.com) — only for the default `start` mode, which
+  serves over your tailnet. `start-direct` (self-signed HTTPS, binds **all**
+  interfaces — reachable from anywhere the host is) and `start-local` (loopback
+  only, reached through an SSH tunnel) need no Tailscale at all
 
 ---
 
@@ -93,20 +96,49 @@ the start command needs the flag. `enable --port` records it in the login hook.
 cd mobile/
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
-trustmux enable
-trustmux pair
+.venv/bin/python trustmux.in --help
+```
+
+`trustmux.in` and `trustmuxd.in` find the package in the sibling `trustmux/`
+directory, so no install step is needed. To run a throwaway daemon that leaves
+your real one untouched, point both base directories at a scratch tree:
+
+```bash
+export TRUSTMUX_CONFIG_DIR=$(mktemp -d)
+export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
+.venv/bin/python trustmux.in start-local --port 3389
 ```
 
 ---
 
-## Configuration
+## Files
+
+Trustmux follows the XDG base directory spec.
 
 | Path | Purpose |
 |---|---|
-| `~/.config/trustmux/tokens.json` | Paired device session tokens (mode 0600) |
-| `~/.config/trustmux/trustmux.sock` | Admin Unix socket (mode 0600) |
-| `~/.config/trustmux/trustmux.log` | Daemon log (mode 0600) |
-| `~/.config/trustmux/machines.json` | Optional: sibling machines for the machine selector |
+| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector — the only user-authored file |
+| `$XDG_STATE_HOME/trustmux/instances/default/tokens.json` | Paired device session tokens (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.log` | Daemon log (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.sock` | Admin Unix socket (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.pid` | PID file |
+
+Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
+write by hand; everything the daemon owns lives together under state, as it
+always has — just no longer mixed in with configuration.
+
+The socket and pid file stay here rather than in `$XDG_RUNTIME_DIR`, where the
+spec would put them. systemd-logind deletes `/run/user/$UID` when your last
+login session ends unless `loginctl enable-linger` is set, which would strand a
+still-running daemon with no socket to reach it by — and being started and then
+reached later is the whole point of trustmux. That directory also doesn't exist
+on macOS or in most containers. Leftovers are detected instead of swept away: a
+socket refuses connections once its daemon is gone, and a recorded pid is only
+believed when it's confirmed to hold the port in question.
+
+`TRUSTMUX_CONFIG_DIR` and `TRUSTMUX_STATE_DIR` override each base, taking
+precedence over the XDG variables.
 
 ### Multiple machines
 
@@ -117,11 +149,17 @@ trustmux pair
 ]
 ```
 
+**Upgrading:** earlier versions kept everything directly in
+`~/.config/trustmux`. On first run `tokens.json`, `cert.pem`, `key.pem` and
+`trustmux.log` are moved into the state directory above with their modes
+preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
+case a daemon predating the upgrade is still serving on it.
+
 ---
 
 ## Security
 
-- Daemon binds to `127.0.0.1:7432` only — not reachable from the network
+- In the default mode the daemon binds to `127.0.0.1` only — not reachable from the network
 - All traffic encrypted by Tailscale WireGuard; HTTPS via `tailscale serve`
 - No relay server — terminal data never leaves your Tailscale mesh
 - Pairing codes: 6-digit, 60-second TTL, single-use, max 3 attempts
@@ -133,8 +171,12 @@ trustmux pair
 
 ```bash
 cd mobile/
-python3 -m unittest tests.test_daemon -v
+python3 -m unittest discover -s tests -t .
 ```
+
+Needs `tornado` and `cryptography` (`pip install -r requirements.txt`). The
+suite points `TRUSTMUX_CONFIG_DIR`/`TRUSTMUX_STATE_DIR` at a temporary tree, so it never
+reads or writes your real trustmux state.
 
 ---
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -90,16 +90,16 @@ the start command needs the flag. `enable --port` records it in the login hook.
 
 ### Several daemons at once
 
-`--instance NAME` (or `$TRUSTMUX_INSTANCE`) gives a daemon its own pid file,
+`--name NAME` (or `$TRUSTMUX_INSTANCE`) gives a daemon its own pid file,
 admin socket, log, session tokens and TLS certificate, so more than one can run
 side by side — on different ports, or on the same port at different addresses:
 
 ```bash
-trustmux start-direct --instance work --port 3389
-trustmux pair  --instance work
+trustmux start-direct --name work --port 3389
+trustmux pair  --name work
 trustmux list
-trustmux stop  --instance work
-trustmux rm    --instance work    # delete its state directory for good
+trustmux stop  --name work
+trustmux rm    --name work    # delete its state directory for good
 ```
 
 An instance is created by its first `start` and otherwise lasts forever, so
@@ -150,7 +150,7 @@ avoids the two fighting over the bind.
 ## Files
 
 Trustmux follows the XDG base directory spec, with one subdirectory per
-instance. `<I>` below is the `--instance` name, or `default`.
+instance. `<I>` below is the `--name` name, or `default`.
 
 | Path | Purpose |
 |---|---|

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -88,6 +88,29 @@ trustmux status              # finds it — no need to repeat --port
 `stop`, `status` and `pair` ask the running daemon which port it is on, so only
 the start command needs the flag. `enable --port` records it in the login hook.
 
+### Several daemons at once
+
+`--instance NAME` (or `$TRUSTMUX_INSTANCE`) gives a daemon its own pid file,
+admin socket, log, session tokens and TLS certificate, so more than one can run
+side by side — on different ports, or on the same port at different addresses:
+
+```bash
+trustmux start-direct --instance work --port 3389
+trustmux pair  --instance work
+trustmux list
+trustmux stop  --instance work
+```
+
+The unnamed instance is called `default`; it is not special-cased, and lives
+under `instances/default/` like any other.
+
+Only `default` can use `tailscale serve` mode, because `serve` publishes on the
+tailnet's port 443 and only one daemon can own it — a second would silently
+take over the mapping. Named instances use `start-direct` or `start-local`;
+`setup`, `start`, `restart` and `enable` refuse them with a message saying so.
+Note `--port` does not lift this: it moves the loopback backend that
+`tailscale serve` proxies to, not the tailnet-facing port.
+
 ---
 
 ## Setup from source
@@ -113,16 +136,17 @@ export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
 
 ## Files
 
-Trustmux follows the XDG base directory spec.
+Trustmux follows the XDG base directory spec, with one subdirectory per
+instance. `<I>` below is the `--instance` name, or `default`.
 
 | Path | Purpose |
 |---|---|
-| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector — the only user-authored file |
-| `$XDG_STATE_HOME/trustmux/instances/default/tokens.json` | Paired device session tokens (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.log` | Daemon log (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.sock` | Admin Unix socket (mode 0600) |
-| `$XDG_STATE_HOME/trustmux/instances/default/trustmux.pid` | PID file |
+| `$XDG_CONFIG_HOME/trustmux/machines.json` | Optional: sibling machines for the machine selector. Shared by all instances — the only user-authored file |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/tokens.json` | Paired device session tokens (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/cert.pem`, `key.pem` | Self-signed TLS keypair for `start-direct` |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.log` | Daemon log (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.sock` | Admin Unix socket (mode 0600) |
+| `$XDG_STATE_HOME/trustmux/instances/<I>/trustmux.pid` | PID file |
 
 Defaults are `~/.config` and `~/.local/state`. Config holds only the file you
 write by hand; everything the daemon owns lives together under state, as it
@@ -151,8 +175,8 @@ precedence over the XDG variables.
 
 **Upgrading:** earlier versions kept everything directly in
 `~/.config/trustmux`. On first run `tokens.json`, `cert.pem`, `key.pem` and
-`trustmux.log` are moved into the state directory above with their modes
-preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
+`trustmux.log` are moved into the `default` instance's state directory with
+their modes preserved. A stale `trustmux.pid`/`trustmux.sock` is left alone, in
 case a daemon predating the upgrade is still serving on it.
 
 ---

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -1,4 +1,5 @@
 # bash completion for trustmux(1)
+
 _trustmux() {
     local cur prev words cword
     _init_completion || return

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -1,6 +1,6 @@
 # bash completion for trustmux(1)
 
-# Names of instances that have a state directory, for --instance.
+# Names of instances that have a state directory, for --name.
 _trustmux_instances() {
     local base="${TRUSTMUX_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/trustmux}"
     local d
@@ -24,23 +24,23 @@ _trustmux() {
 
     case "$prev" in
         --port)      return ;;                                     # freeform
-        --instance)  COMPREPLY=($(compgen -W "$(_trustmux_instances)" -- "$cur"))
+        --name)      COMPREPLY=($(compgen -W "$(_trustmux_instances)" -- "$cur"))
                      return ;;
     esac
 
     # `list` acts on every instance, so it takes neither flag.
     case "${words[1]}" in
         setup)
-            COMPREPLY=($(compgen -W "--quiet --port --instance" -- "$cur"))
+            COMPREPLY=($(compgen -W "--quiet --port --name" -- "$cur"))
             ;;
         start|start-local|start-direct|stop|restart|status|enable)
-            COMPREPLY=($(compgen -W "--port --instance" -- "$cur"))
+            COMPREPLY=($(compgen -W "--port --name" -- "$cur"))
             ;;
         log|disable|pair|unpair)
-            COMPREPLY=($(compgen -W "--instance" -- "$cur"))
+            COMPREPLY=($(compgen -W "--name" -- "$cur"))
             ;;
         rm)
-            COMPREPLY=($(compgen -W "--instance --force" -- "$cur"))
+            COMPREPLY=($(compgen -W "--name --force" -- "$cur"))
             ;;
         list)
             ;;

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -24,6 +24,7 @@ _trustmux() {
 
     case "$prev" in
         --port)      return ;;                                     # freeform
+        --advertise) return ;;                                     # freeform
         --name)      COMPREPLY=($(compgen -W "$(_trustmux_instances)" -- "$cur"))
                      return ;;
     esac
@@ -33,7 +34,10 @@ _trustmux() {
         setup)
             COMPREPLY=($(compgen -W "--quiet --port --name" -- "$cur"))
             ;;
-        start|start-local|start-direct|stop|restart|status|enable)
+        start|start-local|start-direct|restart|enable)
+            COMPREPLY=($(compgen -W "--port --name --advertise --no-advertise" -- "$cur"))
+            ;;
+        stop|status)
             COMPREPLY=($(compgen -W "--port --name" -- "$cur"))
             ;;
         log|disable|pair|unpair)

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -1,28 +1,45 @@
 # bash completion for trustmux(1)
 
+# Names of instances that have a state directory, for --instance.
+_trustmux_instances() {
+    local base="${TRUSTMUX_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/trustmux}"
+    local d
+    for d in "$base"/instances/*/; do
+        [[ -d $d ]] || continue
+        d=${d%/}
+        printf '%s\n' "${d##*/}"
+    done
+}
+
 _trustmux() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="setup start start-local start-direct stop restart status log enable disable pair unpair"
+    local subcommands="setup start start-local start-direct stop restart status log list enable disable pair unpair"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
         return
     fi
 
-    if [[ $prev == "--port" ]]; then
-        return
-    fi
+    case "$prev" in
+        --port)      return ;;                                     # freeform
+        --instance)  COMPREPLY=($(compgen -W "$(_trustmux_instances)" -- "$cur"))
+                     return ;;
+    esac
 
+    # `list` acts on every instance, so it takes neither flag.
     case "${words[1]}" in
         setup)
-            COMPREPLY=($(compgen -W "--quiet --port" -- "$cur"))
+            COMPREPLY=($(compgen -W "--quiet --port --instance" -- "$cur"))
             ;;
         start|start-local|start-direct|stop|restart|status|enable)
-            COMPREPLY=($(compgen -W "--port" -- "$cur"))
+            COMPREPLY=($(compgen -W "--port --instance" -- "$cur"))
             ;;
         log|disable|pair|unpair)
+            COMPREPLY=($(compgen -W "--instance" -- "$cur"))
+            ;;
+        list)
             ;;
     esac
 }

--- a/mobile/bash-completion/trustmux
+++ b/mobile/bash-completion/trustmux
@@ -15,7 +15,7 @@ _trustmux() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="setup start start-local start-direct stop restart status log list enable disable pair unpair"
+    local subcommands="setup start start-local start-direct stop restart status log list rm enable disable pair unpair"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
@@ -38,6 +38,9 @@ _trustmux() {
             ;;
         log|disable|pair|unpair)
             COMPREPLY=($(compgen -W "--instance" -- "$cur"))
+            ;;
+        rm)
+            COMPREPLY=($(compgen -W "--instance --force" -- "$cur"))
             ;;
         list)
             ;;

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -147,6 +147,106 @@ logout; re-running
 .B "enable \-\-port"
 rewrites an existing hook rather than leaving the old port in place.
 .TP
+.BI \-\-advertise " SOURCE"
+Address a phone should use, for when it is not the one this host can see.
+Accepted by
+.BR start ,
+.BR start\-local ,
+.BR start\-direct ,
+.B restart
+and
+.BR enable .
+Repeatable.
+.IP
+Behind NAT — a cloud instance, most often — the daemon only ever sees an
+internal address, so both the URL
+.B pair
+prints and the names in the certificate
+.B start\-direct
+generates describe a host nothing outside can route to.
+.I SOURCE
+overrides that.
+It does
+.I not
+change what the daemon binds; combine it with a firewall rule that admits the
+port.
+.IP
+.I SOURCE
+is one of:
+.RS
+.TP
+.I HOST
+or
+.I HOST:PORT
+A literal address or name.
+The daemon's own scheme and port fill in what is omitted, so
+.B \-\-advertise\ 203.0.113.45
+on a daemon serving HTTPS on 7432 advertises
+.IR https://203.0.113.45:7432/ .
+.TP
+.I URL
+A full
+.I http://
+or
+.I https://
+URL, which overrides both scheme and port — for a reverse proxy terminating
+TLS on 443 in front of the daemon.
+A path, query or fragment is rejected: trustmux serves from the root, and the
+pairing code is carried in the fragment.
+.TP
+.BI cmd: PROGRAM
+Run
+.I PROGRAM
+and take one address per line of its standard output.
+.RE
+.IP
+.B cmd:
+is how an address that changes stays correct.
+A cloud instance with an ephemeral public address gets a different one across a
+stop/start cycle, so a literal written down once would quietly go stale, while
+.B cmd:
+is re-run on every daemon start.
+.IP
+.I PROGRAM
+is split into arguments with shell-style quoting but is
+.I not
+run by a shell: no pipelines, no redirection, no
+.IR $(...) .
+Those characters are rejected rather than passed through to the program, so put
+a pipeline in a script and name the script.
+An absolute path is safest, a daemon's
+.B PATH
+being whatever started it.
+.IP
+Resolution is strict, and any failure stops the daemon rather than falling back
+to the address it would have guessed: a non-zero exit, no output, a blank line,
+a value that is not an address, or more than 5 seconds across all sources.
+This is deliberate.
+A shell wrapper whose
+.B curl
+fails typically prints an empty line and still exits 0, and treating that as
+"nothing to advertise" would hand out an unreachable URL and a certificate for
+the wrong host — neither of which a warning would fix.
+.IP
+Every resolved address is added to the certificate as a subject alternative
+name; the first supplies the URL that
+.BR pair ,
+.B status
+and
+.B start
+print.
+A browser rejects a certificate that omits the name in the URL bar outright,
+rather than offering the click-through a self-signed certificate gets, so
+advertising an address without certifying it would be worse than useless.
+.TP
+.B \-\-no\-advertise
+Advertise nothing, ignoring any source in
+.B TRUSTMUX_ADVERTISE
+or the instance's configuration file.
+Accepted wherever
+.B \-\-advertise
+is.
+.TP
 .BI \-\-name " NAME"
 Act on the named instance instead of
 .BR default .
@@ -208,6 +308,21 @@ Default instance when
 is not given.
 An invalid name is an error, not a silent fallback.
 .TP
+.B TRUSTMUX_ADVERTISE
+Default advertise source when
+.B \-\-advertise
+is not given.
+Holds a single source, not a list: no separator would be safe, since
+.RB ` : '
+collides with both URL schemes and the
+.B cmd:
+prefix while
+.RB ` , '
+can appear inside a command's arguments.
+A
+.B cmd:
+source already yields as many addresses as it likes, so nothing is out of reach.
+.TP
 .B TRUSTMUX_CONFIG_DIR
 .TQ
 .B TRUSTMUX_STATE_DIR
@@ -246,7 +361,31 @@ when unset.
 .TP
 .I $XDG_CONFIG_HOME/trustmux/machines.json
 Optional: sibling machine list for the in-app machine selector.
-Shared by every instance, being the only user-authored file here.
+Shared by every instance.
+.TP
+.I $XDG_CONFIG_HOME/trustmux/instances/INSTANCE.json
+Optional per-instance settings, hand-written.
+One key so far:
+.BR advertise ,
+a string or list of strings, each a
+.B \-\-advertise
+source.
+.IP
+.RS
+.nf
+{"advertise": ["cmd:/usr/local/bin/external-ip", "tmux.example.com"]}
+.fi
+.RE
+.IP
+This is the durable home for a source, and the only one a login hook will find:
+.B \-\-advertise
+applies to one daemon and then is gone.
+Sources are re-resolved on every start, which is what makes writing one down
+safe even when the address behind it changes.
+.IP
+Because a source can name a program to run, a file writable by group or other
+is refused rather than read; keep it mode 0600.
+Configuration rather than state because it records intent, not a result.
 .SS State
 .TP
 .I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
@@ -363,6 +502,38 @@ export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
 trustmux start\-local \-\-port 3389
 .fi
 .RE
+.PP
+On a cloud instance whose public address the host itself cannot see.
+Write a program that prints it — here a one-liner against the metadata
+service, which unlike a shell pipeline reports its own failure:
+.PP
+.RS
+.nf
+$ cat /usr/local/bin/external\-ip
+#!/bin/sh
+exec curl \-\-fail \-\-silent \-H Metadata\-Flavor:Google \\
+  http://metadata.google.internal/computeMetadata/v1/instance/\\
+network\-interfaces/0/access\-configs/0/external\-ip
+
+$ trustmux start\-direct \-\-advertise cmd:/usr/local/bin/external\-ip
+$ trustmux pair
+.fi
+.RE
+.PP
+To keep it across reboots, put the source in the instance's configuration file
+(see
+.BR FILES )
+rather than in the command line, and the address is looked up afresh each time:
+.PP
+.RS
+.nf
+mkdir \-p ~/.config/trustmux/instances
+echo '{"advertise": ["cmd:/usr/local/bin/external\-ip"]}' \\
+  > ~/.config/trustmux/instances/default.json
+chmod 600 ~/.config/trustmux/instances/default.json
+trustmux start\-direct
+.fi
+.RE
 .SH SECURITY
 .SS "Pairing code"
 The one-time pairing code is a 6-digit decimal value drawn from
@@ -402,6 +573,16 @@ In
 .B start\-direct
 mode the daemon binds on all interfaces; the pairing-code and session-token
 protections above remain in force, but the network attack surface is broader.
+.B \-\-advertise
+does not itself widen this — it changes only what is published — but
+advertising a public address is normally paired with a firewall rule admitting
+the port, and that does: the daemon then faces the internet with the pairing
+code and session token as its only protection, rather than a local network.
+Prefer
+.B start
+or
+.B start\-local
+where either will do.
 In
 .B start\-local
 mode the daemon binds to 127.0.0.1 only and is accessible solely through an

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -194,6 +194,14 @@ Each takes precedence over the corresponding XDG variable.
 Pointing both at a scratch directory is the supported way to run a throwaway
 daemon — from a development tree, for instance — without touching the real
 one.
+.B start ,
+.B stop ,
+.B status
+and
+.B list
+act only on a daemon that this instance itself started, determined from its own
+admin socket and pid file rather than from who holds a port, so the isolation
+holds even when the scratch daemon shares a port with the real one.
 .SH FILES
 Files live in the XDG base directories, with one subdirectory per instance:
 .I $XDG_CONFIG_HOME
@@ -243,7 +251,12 @@ and
 to ask the daemon which port it is on.
 .TP
 .I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.pid
-PID file written at daemon startup.
+PID file written at daemon startup, holding
+.RI \(dq pid " " port \(dq.
+The port is recorded so that a daemon which has stopped replying on its admin
+socket can still be matched against the port
+.B stop
+was asked about.
 .PP
 The socket and pid file are deliberately kept here rather than under
 .IR $XDG_RUNTIME_DIR ,

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -48,8 +48,13 @@ Stop then start the daemon in HTTPS mode.
 Show whether the daemon is running and the URL to connect to.
 .TP
 .B log
-Tail the daemon log (see
+Tail this instance's daemon log (see
 .BR FILES ).
+.TP
+.B list
+List every instance that has a state directory, with the port, scheme and pid
+of any that are running.
+Instances whose daemon is stopped are shown with dashes.
 .SS "Login hook"
 .TP
 .B enable
@@ -60,10 +65,18 @@ user's shell login file
 or
 .IR ~/.zprofile )
 so the daemon starts automatically on each login.
+Only available for the
+.B default
+instance, since it starts the daemon in
+.B tailscale serve
+mode; see
+.BR \-\-instance .
 .TP
 .B disable
 Stop the running daemon and remove the login hook so the daemon no longer
 starts automatically.
+Only this instance's hook is removed, so disabling one leaves any others in
+place.
 Paired device tokens are preserved.
 .SS "Device pairing"
 .TP
@@ -119,6 +132,46 @@ records the port in the login hook it writes, so a non-default port survives
 logout; re-running
 .B "enable \-\-port"
 rewrites an existing hook rather than leaving the old port in place.
+.TP
+.BI \-\-instance " NAME"
+Act on the named instance instead of
+.BR default .
+Accepted by every subcommand.
+Each instance keeps its own pid file, admin socket, log, session tokens and
+TLS certificate, so several daemons can run at once — on different ports,
+or on the same port at different bind addresses.
+.IP
+.I NAME
+must match
+.RB ` [A-Za-z0-9][A-Za-z0-9._-]{0,31} ':
+it becomes a directory name and is written into the login hook, so separators,
+leading dots and shell metacharacters are rejected rather than sanitised.
+.IP
+Only the
+.B default
+instance can use
+.B tailscale serve
+mode.
+.B serve
+publishes on the tailnet's port 443, which just one daemon can own — a
+second would silently take over the mapping and leave the first running but
+unreachable.
+Named instances therefore use
+.B start\-direct
+or
+.BR start\-local ,
+and
+.BR setup ,
+.BR start ,
+.B restart
+and
+.B enable
+refuse them with a message pointing at those modes.
+Note that
+.B \-\-port
+does not lift this restriction: it moves only the loopback backend that
+.B tailscale serve
+proxies to, not the tailnet-facing port.
 .SH ENVIRONMENT
 .TP
 .B TRUSTMUX_PORT
@@ -126,6 +179,12 @@ Default port when
 .B \-\-port
 is not given, for users who always want a different port.
 An out-of-range or non-numeric value is an error, not a silent fallback.
+.TP
+.B TRUSTMUX_INSTANCE
+Default instance when
+.B \-\-instance
+is not given.
+An invalid name is an error, not a silent fallback.
 .TP
 .B TRUSTMUX_CONFIG_DIR
 .TQ
@@ -136,7 +195,7 @@ Pointing both at a scratch directory is the supported way to run a throwaway
 daemon — from a development tree, for instance — without touching the real
 one.
 .SH FILES
-Files live in the XDG base directories:
+Files live in the XDG base directories, with one subdirectory per instance:
 .I $XDG_CONFIG_HOME
 (default
 .IR ~/.config )
@@ -145,27 +204,35 @@ holds the one file the user writes by hand, and
 (default
 .IR ~/.local/state )
 holds everything the daemon owns.
+.PP
+Below,
+.I INSTANCE
+is the
+.B \-\-instance
+name, or
+.B default
+when unset.
 .SS Configuration
 .TP
 .I $XDG_CONFIG_HOME/trustmux/machines.json
 Optional: sibling machine list for the in-app machine selector.
-The only user-authored file here.
+Shared by every instance, being the only user-authored file here.
 .SS State
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
 Paired device session tokens (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/cert.pem
 .TQ
-.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/key.pem
 Self-signed TLS keypair used by
 .BR start\-direct .
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.log
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.log
 Daemon log file, tailed by
 .BR "trustmux log" .
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR pair ,
 .B unpair
@@ -175,7 +242,7 @@ and
 .B status
 to ask the daemon which port it is on.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.pid
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.pid
 PID file written at daemon startup.
 .PP
 The socket and pid file are deliberately kept here rather than under
@@ -200,7 +267,9 @@ On first run,
 .I key.pem
 and
 .I trustmux.log
-are moved from there into the state directory above, preserving their modes.
+are moved from there into the
+.B default
+instance's state directory, preserving their modes.
 Any stale
 .I trustmux.pid
 and
@@ -239,6 +308,17 @@ trustmux stop
 .fi
 .RE
 .PP
+A second daemon alongside the first, with its own tokens and log:
+.PP
+.RS
+.nf
+trustmux start\-direct \-\-instance work \-\-port 3389
+trustmux pair \-\-instance work
+trustmux list
+trustmux stop \-\-instance work
+.fi
+.RE
+.PP
 A throwaway daemon that touches none of the above:
 .PP
 .RS
@@ -266,7 +346,7 @@ An incorrect guess also incurs a 0.5-second artificial delay.
 .SS "Session tokens"
 After a successful pairing the daemon issues a 256-bit URL-safe session token
 .RB ( secrets.token_urlsafe (32))
-stored in
+stored in this instance's
 .I tokens.json
 (mode 0600; see
 .BR FILES )

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -55,6 +55,20 @@ Tail this instance's daemon log (see
 List every instance that has a state directory, with the port, scheme and pid
 of any that are running.
 Instances whose daemon is stopped are shown with dashes.
+.TP
+.B rm
+Delete this instance's state directory — session tokens, TLS keypair, log,
+socket and pid file — and remove its login hook so it does not start again at
+the next login.
+.IP
+An instance is created by its first
+.B start
+and persists until removed, so this is the only way to retire one.
+Refused while the instance's daemon is running, and refused for the
+.B default
+instance;
+.B \-\-force
+overrides both, stopping a running daemon first.
 .SS "Login hook"
 .TP
 .B enable
@@ -172,6 +186,14 @@ Note that
 does not lift this restriction: it moves only the loopback backend that
 .B tailscale serve
 proxies to, not the tailnet-facing port.
+.TP
+.B \-\-force
+Accepted by
+.BR rm .
+Remove the instance even though its daemon is running (it is stopped first),
+or even though it is the
+.B default
+instance.
 .SH ENVIRONMENT
 .TP
 .B TRUSTMUX_PORT

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -48,8 +48,8 @@ Stop then start the daemon in HTTPS mode.
 Show whether the daemon is running and the URL to connect to.
 .TP
 .B log
-Tail the daemon log at
-.IR ~/.config/trustmux/trustmux.log .
+Tail the daemon log (see
+.BR FILES ).
 .SS "Login hook"
 .TP
 .B enable
@@ -126,25 +126,87 @@ Default port when
 .B \-\-port
 is not given, for users who always want a different port.
 An out-of-range or non-numeric value is an error, not a silent fallback.
+.TP
+.B TRUSTMUX_CONFIG_DIR
+.TQ
+.B TRUSTMUX_STATE_DIR
+Override the configuration and state base directories individually.
+Each takes precedence over the corresponding XDG variable.
+Pointing both at a scratch directory is the supported way to run a throwaway
+daemon — from a development tree, for instance — without touching the real
+one.
 .SH FILES
+Files live in the XDG base directories:
+.I $XDG_CONFIG_HOME
+(default
+.IR ~/.config )
+holds the one file the user writes by hand, and
+.I $XDG_STATE_HOME
+(default
+.IR ~/.local/state )
+holds everything the daemon owns.
+.SS Configuration
 .TP
-.I ~/.config/trustmux/trustmux.log
-Daemon log file.
+.I $XDG_CONFIG_HOME/trustmux/machines.json
+Optional: sibling machine list for the in-app machine selector.
+The only user-authored file here.
+.SS State
 .TP
-.I ~/.config/trustmux/trustmux.pid
-PID file written at daemon startup.
-.TP
-.I ~/.config/trustmux/trustmux.sock
-Admin Unix socket used by
-.B pair
-and
-.BR unpair .
-.TP
-.I ~/.config/trustmux/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
 Paired device session tokens (mode 0600).
 .TP
-.I ~/.config/trustmux/machines.json
-Optional: sibling machine list for the in-app machine selector.
+.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.TQ
+.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+Self-signed TLS keypair used by
+.BR start\-direct .
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.log
+Daemon log file, tailed by
+.BR "trustmux log" .
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+Admin Unix socket (mode 0600) used by
+.BR pair ,
+.B unpair
+and by
+.B stop
+and
+.B status
+to ask the daemon which port it is on.
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.pid
+PID file written at daemon startup.
+.PP
+The socket and pid file are deliberately kept here rather than under
+.IR $XDG_RUNTIME_DIR ,
+where the spec would put them: systemd-logind deletes
+.I /run/user/$UID
+when a user's last login session ends unless
+.B loginctl enable-linger
+is set, which would strand a still-running daemon with no socket to reach it
+by — and trustmux exists precisely to be started and then reached later.
+That directory also does not exist on macOS or in most containers.
+A socket or pid file left behind by a killed daemon is therefore detected
+rather than swept away: the socket refuses connections once its daemon is
+gone, and a recorded pid is only believed when it is confirmed to hold the
+port in question.
+.SS Migration
+Earlier versions kept everything directly in
+.IR ~/.config/trustmux .
+On first run,
+.IR tokens.json ,
+.IR cert.pem ,
+.I key.pem
+and
+.I trustmux.log
+are moved from there into the state directory above, preserving their modes.
+Any stale
+.I trustmux.pid
+and
+.I trustmux.sock
+are deliberately left in place, since a daemon predating the upgrade may still
+be serving on that socket.
 .SH EXAMPLES
 Typical first-time setup:
 .PP
@@ -176,6 +238,16 @@ trustmux pair
 trustmux stop
 .fi
 .RE
+.PP
+A throwaway daemon that touches none of the above:
+.PP
+.RS
+.nf
+export TRUSTMUX_CONFIG_DIR=$(mktemp \-d)
+export TRUSTMUX_STATE_DIR=$TRUSTMUX_CONFIG_DIR/state
+trustmux start\-local \-\-port 3389
+.fi
+.RE
 .SH SECURITY
 .SS "Pairing code"
 The one-time pairing code is a 6-digit decimal value drawn from
@@ -195,8 +267,10 @@ An incorrect guess also incurs a 0.5-second artificial delay.
 After a successful pairing the daemon issues a 256-bit URL-safe session token
 .RB ( secrets.token_urlsafe (32))
 stored in
-.I ~/.config/trustmux/tokens.json
-(mode 0600) and delivered to the browser as an
+.I tokens.json
+(mode 0600; see
+.BR FILES )
+and delivered to the browser as an
 .BR httponly ,
 .B SameSite=Strict
 cookie.

--- a/mobile/man/man1/trustmux.1
+++ b/mobile/man/man1/trustmux.1
@@ -84,7 +84,7 @@ Only available for the
 instance, since it starts the daemon in
 .B tailscale serve
 mode; see
-.BR \-\-instance .
+.BR \-\-name .
 .TP
 .B disable
 Stop the running daemon and remove the login hook so the daemon no longer
@@ -147,7 +147,7 @@ logout; re-running
 .B "enable \-\-port"
 rewrites an existing hook rather than leaving the old port in place.
 .TP
-.BI \-\-instance " NAME"
+.BI \-\-name " NAME"
 Act on the named instance instead of
 .BR default .
 Accepted by every subcommand.
@@ -204,7 +204,7 @@ An out-of-range or non-numeric value is an error, not a silent fallback.
 .TP
 .B TRUSTMUX_INSTANCE
 Default instance when
-.B \-\-instance
+.B \-\-name
 is not given.
 An invalid name is an error, not a silent fallback.
 .TP
@@ -238,7 +238,7 @@ holds everything the daemon owns.
 Below,
 .I INSTANCE
 is the
-.B \-\-instance
+.B \-\-name
 name, or
 .B default
 when unset.
@@ -347,10 +347,10 @@ A second daemon alongside the first, with its own tokens and log:
 .PP
 .RS
 .nf
-trustmux start\-direct \-\-instance work \-\-port 3389
-trustmux pair \-\-instance work
+trustmux start\-direct \-\-name work \-\-port 3389
+trustmux pair \-\-name work
 trustmux list
-trustmux stop \-\-instance work
+trustmux stop \-\-name work
 .fi
 .RE
 .PP

--- a/mobile/man/man1/trustmuxd.1
+++ b/mobile/man/man1/trustmuxd.1
@@ -5,6 +5,7 @@ trustmuxd \- Trustmux daemon (mobile companion for tmux/Byobu sessions)
 .B trustmuxd
 [\fB\-\-host\fP \fIADDR\fP]
 [\fB\-\-port\fP \fIPORT\fP]
+[\fB\-\-instance\fP \fINAME\fP]
 [\fB\-\-https\fP]
 [\fB\-\-self\-signed\fP]
 [\fB\-\-version\fP]
@@ -22,8 +23,8 @@ a self-signed ECDSA certificate and binds directly on the network interface.
 .PP
 Authentication uses 6-digit one-time pairing codes (generated with
 .BR trustmux\-pair (1))
-and permanent per-device session tokens stored as described under
-.BR FILES .
+and permanent per-device session tokens stored per instance (see
+.BR FILES ).
 .PP
 In normal use, the daemon is managed via
 .BR trustmux (1)
@@ -44,26 +45,38 @@ Use with \fBtailscale serve\fP.
 Generate a self-signed ECDSA P-256 TLS certificate for direct
 HTTPS access without Tailscale.
 .TP
+.BI \-\-instance " NAME"
+Which instance's state and runtime files to use (default:
+.BR default ).
+Each instance has its own tokens, TLS keypair, log, admin socket and pid file,
+so several daemons can run side by side.
+.B trustmux (1)
+passes this through when it starts a daemon.
+.TP
 .B \-\-version
 Print version and exit.
 .SH FILES
-Paths follow the XDG base directories.
+Paths follow the XDG base directories, one subdirectory per instance;
+.I INSTANCE
+below is the
+.B \-\-instance
+name.
 .B trustmux (1)
 documents the full layout, the fallbacks and the
 .B TRUSTMUX_*_DIR
 overrides.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
 Persistent session tokens (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/cert.pem
 Self-signed TLS certificate (mode 0644), created on first
 \fB\-\-self\-signed\fP start.
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/key.pem
 TLS private key (mode 0600).
 .TP
-.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/INSTANCE/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR trustmux\-pair (1)
 and

--- a/mobile/man/man1/trustmuxd.1
+++ b/mobile/man/man1/trustmuxd.1
@@ -5,9 +5,11 @@ trustmuxd \- Trustmux daemon (mobile companion for tmux/Byobu sessions)
 .B trustmuxd
 [\fB\-\-host\fP \fIADDR\fP]
 [\fB\-\-port\fP \fIPORT\fP]
-[\fB\-\-instance\fP \fINAME\fP]
+[\fB\-\-name\fP \fINAME\fP]
 [\fB\-\-https\fP]
 [\fB\-\-self\-signed\fP]
+[\fB\-\-advertise\fP \fISOURCE\fP]
+[\fB\-\-no\-advertise\fP]
 [\fB\-\-version\fP]
 .SH DESCRIPTION
 .B trustmuxd
@@ -45,7 +47,7 @@ Use with \fBtailscale serve\fP.
 Generate a self-signed ECDSA P-256 TLS certificate for direct
 HTTPS access without Tailscale.
 .TP
-.BI \-\-instance " NAME"
+.BI \-\-name " NAME"
 Which instance's state and runtime files to use (default:
 .BR default ).
 Each instance has its own tokens, TLS keypair, log, admin socket and pid file,
@@ -53,18 +55,73 @@ so several daemons can run side by side.
 .B trustmux (1)
 passes this through when it starts a daemon.
 .TP
+.BI \-\-advertise " SOURCE"
+Address to publish and to name in the TLS certificate, for when it is not the
+one this host can see.
+Repeatable.
+.I SOURCE
+is a literal
+.IR HOST ,
+.IR HOST:PORT ,
+a full URL, or
+.BI cmd: PROGRAM
+to run
+.I PROGRAM
+and read one address per line of its standard output.
+.IP
+Sources are resolved once, at startup, before the certificate is generated and
+before the admin socket is bound.
+Any failure to resolve one — a non-zero exit, no output, a blank line, a value
+that is not an address, or more than 5 seconds across all sources — stops the
+daemon, in the same way an unavailable TLS implementation does: an unreachable
+URL, or a certificate for the wrong host, is not something a warning would fix.
+.IP
+The resolved addresses are reported over the admin socket, which is how
+.B "trustmux pair"
+and
+.B "trustmux status"
+come to print exactly what the certificate attests.
+.IP
+When no
+.B \-\-advertise
+or
+.B \-\-no\-advertise
+is given, the daemon reads
+.B TRUSTMUX_ADVERTISE
+and then the instance's configuration file itself.
+.B trustmux (1)
+always passes one or the other, so a daemon it starts uses only the sources
+.I it
+resolved.
+See
+.BR trustmux (1)
+for the source syntax in full.
+.TP
+.B \-\-no\-advertise
+Advertise nothing, ignoring
+.B TRUSTMUX_ADVERTISE
+and the instance's configuration file.
+.TP
 .B \-\-version
 Print version and exit.
 .SH FILES
 Paths follow the XDG base directories, one subdirectory per instance;
 .I INSTANCE
 below is the
-.B \-\-instance
+.B \-\-name
 name.
 .B trustmux (1)
 documents the full layout, the fallbacks and the
 .B TRUSTMUX_*_DIR
 overrides.
+.TP
+.I $XDG_CONFIG_HOME/trustmux/instances/INSTANCE.json
+Optional, hand-written: advertise sources for this instance, read when neither
+.B \-\-advertise
+nor
+.B \-\-no\-advertise
+was given.
+Refused if writable by group or other, since a source can name a program to run.
 .TP
 .I $XDG_STATE_HOME/trustmux/instances/INSTANCE/tokens.json
 Persistent session tokens (mode 0600).

--- a/mobile/man/man1/trustmuxd.1
+++ b/mobile/man/man1/trustmuxd.1
@@ -22,8 +22,8 @@ a self-signed ECDSA certificate and binds directly on the network interface.
 .PP
 Authentication uses 6-digit one-time pairing codes (generated with
 .BR trustmux\-pair (1))
-and permanent per-device session tokens stored in
-.IR ~/.config/trustmux/tokens.json .
+and permanent per-device session tokens stored as described under
+.BR FILES .
 .PP
 In normal use, the daemon is managed via
 .BR trustmux (1)
@@ -47,22 +47,27 @@ HTTPS access without Tailscale.
 .B \-\-version
 Print version and exit.
 .SH FILES
+Paths follow the XDG base directories.
+.B trustmux (1)
+documents the full layout, the fallbacks and the
+.B TRUSTMUX_*_DIR
+overrides.
 .TP
-.I ~/.config/trustmux/tokens.json
+.I $XDG_STATE_HOME/trustmux/instances/default/tokens.json
 Persistent session tokens (mode 0600).
 .TP
-.I ~/.config/trustmux/trustmux.sock
+.I $XDG_STATE_HOME/trustmux/instances/default/cert.pem
+Self-signed TLS certificate (mode 0644), created on first
+\fB\-\-self\-signed\fP start.
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/key.pem
+TLS private key (mode 0600).
+.TP
+.I $XDG_STATE_HOME/trustmux/instances/default/trustmux.sock
 Admin Unix socket (mode 0600) used by
 .BR trustmux\-pair (1)
 and
 .BR trustmux\-unpair (1).
-.TP
-.I ~/.config/trustmux/cert.pem
-Self-signed TLS certificate (mode 0644), created on first
-\fB\-\-self\-signed\fP start.
-.TP
-.I ~/.config/trustmux/key.pem
-TLS private key (mode 0600).
 .SH SEE ALSO
 .BR trustmux (1),
 .BR trustmux\-pair (1),

--- a/mobile/tests/test_advertise.py
+++ b/mobile/tests/test_advertise.py
@@ -1,0 +1,382 @@
+"""Tests for trustmux._advertise."""
+
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import trustmux._advertise as adv
+from trustmux._paths import Instance
+
+_tmp_root = None
+_tmp_env = None
+
+
+def setUpModule():
+    # Root the base directories in a temp tree: _from_config() reads the
+    # instance config file, which must never be the developer's real one.
+    global _tmp_root, _tmp_env
+    _tmp_root = tempfile.TemporaryDirectory()
+    root = Path(_tmp_root.name)
+    _tmp_env = patch.dict(os.environ, {
+        'TRUSTMUX_CONFIG_DIR': str(root / 'config'),
+        'TRUSTMUX_STATE_DIR':  str(root / 'state'),
+    })
+    _tmp_env.start()
+    os.environ.pop('TRUSTMUX_ADVERTISE', None)
+
+
+def tearDownModule():
+    _tmp_env.stop()
+    _tmp_root.cleanup()
+
+
+def _script(body: str, mode: int = 0o755) -> str:
+    """Write an executable script and return its absolute path."""
+    d = tempfile.mkdtemp(dir=_tmp_root.name)
+    path = Path(d) / "prog"
+    path.write_text(body)
+    path.chmod(mode)
+    return str(path)
+
+
+class TestNormalizeLiterals(unittest.TestCase):
+
+    def test_bare_ipv4_takes_scheme_and_port_from_daemon(self):
+        self.assertEqual(adv.normalize('34.1.2.3', 'https', 7432),
+                         ('https://34.1.2.3:7432/', '34.1.2.3'))
+
+    def test_bare_name(self):
+        self.assertEqual(adv.normalize('tmux.example.com', 'https', 7432),
+                         ('https://tmux.example.com:7432/', 'tmux.example.com'))
+
+    def test_explicit_port_beats_the_daemon_port(self):
+        self.assertEqual(adv.normalize('host:8443', 'https', 7432).url,
+                         'https://host:8443/')
+
+    def test_default_port_is_not_shown(self):
+        self.assertEqual(adv.normalize('host', 'https', 443).url, 'https://host/')
+        self.assertEqual(adv.normalize('host', 'http', 80).url, 'http://host/')
+
+    def test_trailing_dot_dropped_for_the_certificate(self):
+        self.assertEqual(adv.normalize('host.example.com.', 'https', 443).host,
+                         'host.example.com')
+
+    def test_bare_ipv6_is_bracketed_in_the_url_only(self):
+        got = adv.normalize('2001:db8::1', 'https', 7432)
+        self.assertEqual(got, ('https://[2001:db8::1]:7432/', '2001:db8::1'))
+
+    def test_bracketed_ipv6_with_port(self):
+        self.assertEqual(adv.normalize('[2001:db8::1]:8443', 'https', 7432).url,
+                         'https://[2001:db8::1]:8443/')
+
+    def test_rejects_empty(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'blank line'):
+            adv.normalize('')
+
+    def test_rejects_whitespace_padding(self):
+        with self.assertRaises(adv.AdvertiseError):
+            adv.normalize(' host ', 'https', 443)
+
+    def test_rejects_wildcard_bind_address(self):
+        for value in ('0.0.0.0', '::'):
+            with self.assertRaisesRegex(adv.AdvertiseError, 'wildcard'):
+                adv.normalize(value, 'https', 7432)
+
+    def test_rejects_bad_port(self):
+        for value in ('host:0', 'host:70000', 'host:nope'):
+            with self.assertRaisesRegex(adv.AdvertiseError, 'port'):
+                adv.normalize(value, 'https', 7432)
+
+    def test_rejects_unusable_hostname(self):
+        for value in ('-host', 'ho st', 'host..example', 'host_1'):
+            with self.assertRaises(adv.AdvertiseError):
+                adv.normalize(value, 'https', 7432)
+
+    def test_rejects_unbalanced_bracket(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, "unbalanced"):
+            adv.normalize('[2001:db8::1', 'https', 7432)
+
+
+class TestNormalizeUrls(unittest.TestCase):
+
+    def test_full_url_overrides_scheme_and_port(self):
+        # The proxy-on-443 case: neither the daemon's port nor its scheme applies.
+        self.assertEqual(adv.normalize('https://tmux.example.com/', 'http', 7432),
+                         ('https://tmux.example.com/', 'tmux.example.com'))
+
+    def test_url_without_trailing_slash(self):
+        self.assertEqual(adv.normalize('https://host:8443', 'https', 7432).url,
+                         'https://host:8443/')
+
+    def test_rejects_other_schemes(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'scheme'):
+            adv.normalize('ftp://host/')
+
+    def test_rejects_a_path(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'root only'):
+            adv.normalize('https://host/trustmux')
+
+    def test_rejects_a_fragment_since_pairing_uses_it(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'fragment'):
+            adv.normalize('https://host/#123456')
+
+    def test_rejects_credentials(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'credentials'):
+            adv.normalize('https://user:pw@host/')
+
+    def test_rejects_invalid_port(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'port'):
+            adv.normalize('https://host:99999/')
+
+
+class TestResolveCmd(unittest.TestCase):
+
+    def test_one_value_per_line(self):
+        prog = _script('#!/bin/sh\nprintf "34.1.2.3\\ntmux.example.com\\n"\n')
+        got = adv.resolve([f'cmd:{prog}'], 'https', 7432)
+        self.assertEqual([a.url for a in got],
+                         ['https://34.1.2.3:7432/', 'https://tmux.example.com:7432/'])
+        self.assertEqual([a.host for a in got], ['34.1.2.3', 'tmux.example.com'])
+
+    def test_quoted_argument_survives_without_a_shell(self):
+        prog = _script('#!/bin/sh\ntest "$1" = "a b" && echo host.example.com\n')
+        got = adv.resolve([f'cmd:{prog} "a b"'], 'https', 443)
+        self.assertEqual([a.url for a in got], ['https://host.example.com/'])
+
+    def test_nonzero_exit_is_fatal_and_quotes_stderr(self):
+        prog = _script('#!/bin/sh\necho "no metadata" >&2\nexit 7\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, 'exited 7: no metadata'):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_blank_line_is_fatal_not_skipped(self):
+        # The shell-pipeline failure mode: a wrapper that swallows an error and
+        # prints an empty line must not read as "nothing to advertise".
+        prog = _script('#!/bin/sh\necho ""\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, 'blank line'):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_no_output_is_fatal(self):
+        prog = _script('#!/bin/sh\nexit 0\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, 'printed nothing'):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_unusable_line_names_the_source(self):
+        prog = _script('#!/bin/sh\necho "not a host!"\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, prog):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_error_page_on_stdout_is_rejected(self):
+        prog = _script('#!/bin/sh\necho "<html>404 Not Found</html>"\n')
+        with self.assertRaises(adv.AdvertiseError):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_timeout_is_fatal(self):
+        prog = _script('#!/bin/sh\nsleep 30\n')
+        with patch.object(adv, 'CMD_BUDGET', 0.4):
+            with self.assertRaisesRegex(adv.AdvertiseError, 'still running'):
+                adv.resolve([f'cmd:{prog}'])
+
+    def test_missing_program_is_fatal(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'not found'):
+            adv.resolve(['cmd:/nonexistent/trustmux-test-prog'])
+
+    def test_non_executable_program_is_fatal(self):
+        prog = _script('#!/bin/sh\necho host\n', mode=0o644)
+        with self.assertRaises(adv.AdvertiseError):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_shell_metacharacters_are_refused_not_passed_through(self):
+        for spec in ('cmd:/bin/echo host | tr -d x',
+                     'cmd:/bin/echo $(hostname)',
+                     'cmd:/bin/echo a; /bin/echo b',
+                     'cmd:/bin/echo `hostname`'):
+            with self.assertRaisesRegex(adv.AdvertiseError, 'does not use a shell'):
+                adv.resolve([spec])
+
+    def test_unbalanced_quote_is_fatal(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'cannot parse'):
+            adv.resolve(['cmd:/bin/echo "unclosed'])
+
+    def test_empty_command_is_fatal(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'names no command'):
+            adv.resolve(['cmd:   '])
+
+    def test_output_cannot_recurse_into_another_cmd(self):
+        prog = _script('#!/bin/sh\necho "cmd:/bin/echo host"\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, 'cannot produce another'):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_oversized_output_is_fatal(self):
+        prog = _script('#!/bin/sh\nyes host.example.com | head -n 20000\n')
+        with self.assertRaises(adv.AdvertiseError):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_too_many_values_is_fatal(self):
+        prog = _script('#!/bin/sh\nfor i in $(seq 1 40); do echo "h$i.example.com"; done\n')
+        with self.assertRaisesRegex(adv.AdvertiseError, 'more than'):
+            adv.resolve([f'cmd:{prog}'])
+
+    def test_sources_share_one_budget(self):
+        # Two sources that each fit the budget alone must not together exceed
+        # the wait _ctl._launch() is willing to give the daemon.
+        prog = _script('#!/bin/sh\nsleep 1\necho host.example.com\n')
+        with patch.object(adv, 'CMD_BUDGET', 1.4):
+            with self.assertRaisesRegex(adv.AdvertiseError, 'out of time|still running'):
+                adv.resolve([f'cmd:{prog}', f'cmd:{prog}'])
+
+
+class TestResolveOrderAndDedup(unittest.TestCase):
+
+    def test_first_value_is_first(self):
+        got = adv.resolve(['a.example.com', 'b.example.com'], 'https', 443)
+        self.assertEqual([a.host for a in got], ['a.example.com', 'b.example.com'])
+
+    def test_repeated_host_is_dropped_keeping_the_first(self):
+        got = adv.resolve(['host:1234', 'host:5678'], 'https', 443)
+        self.assertEqual([a.url for a in got], ['https://host:1234/'])
+
+    def test_literal_and_cmd_sources_mix(self):
+        prog = _script('#!/bin/sh\necho 34.1.2.3\n')
+        got = adv.resolve(['tmux.example.com', f'cmd:{prog}'], 'https', 7432)
+        self.assertEqual([a.host for a in got], ['tmux.example.com', '34.1.2.3'])
+
+    def test_no_sources_resolves_to_nothing(self):
+        self.assertEqual(adv.resolve([]), [])
+
+
+class TestCheckSources(unittest.TestCase):
+    """Validation the CLI can do before launching anything."""
+
+    def test_accepts_what_resolve_would(self):
+        adv.check_sources(['34.1.2.3', 'https://host/', 'cmd:/bin/echo host'])
+
+    def test_catches_a_shell_pipeline(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'does not use a shell'):
+            adv.check_sources(['cmd:/bin/echo host | tr -d x'])
+
+    def test_catches_a_mistyped_literal(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'root only'):
+            adv.check_sources(['https://host/trustmux'])
+
+    def test_runs_nothing(self):
+        # Whether the program works is the daemon's business; a source naming
+        # one that does not exist yet must not fail the command that starts it.
+        with patch('subprocess.run') as run:
+            adv.check_sources(['cmd:/nonexistent/prog'])
+        run.assert_not_called()
+
+
+class TestResolveSources(unittest.TestCase):
+
+    def setUp(self):
+        self.inst = Instance('advtest')
+        self.inst.config_file.parent.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: self.inst.config_file.unlink(missing_ok=True))
+
+    def _config(self, obj, mode: int = 0o600):
+        self.inst.config_file.write_text(json.dumps(obj))
+        self.inst.config_file.chmod(mode)
+
+    def test_flag_wins_and_replaces_rather_than_appends(self):
+        self._config({'advertise': ['stale.example.com']})
+        with patch.dict(os.environ, {'TRUSTMUX_ADVERTISE': 'env.example.com'}):
+            got = adv.resolve_sources(['flag.example.com'], False, self.inst)
+        self.assertEqual(got, ['flag.example.com'])
+
+    def test_env_wins_over_config(self):
+        self._config({'advertise': ['stale.example.com']})
+        with patch.dict(os.environ, {'TRUSTMUX_ADVERTISE': 'env.example.com'}):
+            self.assertEqual(adv.resolve_sources(None, False, self.inst),
+                             ['env.example.com'])
+
+    def test_env_is_a_single_source_not_a_list(self):
+        # A cmd: source can hold spaces and commas, so no delimiter is safe.
+        with patch.dict(os.environ, {'TRUSTMUX_ADVERTISE': 'cmd:/bin/prog --a b'}):
+            self.assertEqual(adv.resolve_sources(None, False, self.inst),
+                             ['cmd:/bin/prog --a b'])
+
+    def test_blank_env_is_unset_not_an_error(self):
+        self._config({'advertise': ['cfg.example.com']})
+        with patch.dict(os.environ, {'TRUSTMUX_ADVERTISE': '  '}):
+            self.assertEqual(adv.resolve_sources(None, False, self.inst),
+                             ['cfg.example.com'])
+
+    def test_config_list(self):
+        self._config({'advertise': ['a.example.com', 'cmd:/bin/prog']})
+        self.assertEqual(adv.resolve_sources(None, False, self.inst),
+                         ['a.example.com', 'cmd:/bin/prog'])
+
+    def test_config_accepts_a_bare_string(self):
+        self._config({'advertise': 'a.example.com'})
+        self.assertEqual(adv.resolve_sources(None, False, self.inst),
+                         ['a.example.com'])
+
+    def test_absent_config_is_not_an_error(self):
+        self.assertEqual(adv.resolve_sources(None, False, self.inst), [])
+
+    def test_config_without_the_key_is_not_an_error(self):
+        self._config({'something-else': 1})
+        self.assertEqual(adv.resolve_sources(None, False, self.inst), [])
+
+    def test_group_writable_config_is_refused(self):
+        # It can name a program to run, so anyone who can write it can choose
+        # what this daemon executes.
+        self._config({'advertise': ['cmd:/bin/prog']}, mode=0o660)
+        with self.assertRaisesRegex(adv.AdvertiseError, 'writable by group'):
+            adv.resolve_sources(None, False, self.inst)
+
+    def test_world_writable_config_is_refused(self):
+        self._config({'advertise': ['a.example.com']}, mode=0o606)
+        with self.assertRaisesRegex(adv.AdvertiseError, 'writable by group'):
+            adv.resolve_sources(None, False, self.inst)
+
+    def test_malformed_config_is_an_error(self):
+        self.inst.config_file.write_text('{not json')
+        self.inst.config_file.chmod(0o600)
+        with self.assertRaisesRegex(adv.AdvertiseError, 'cannot read'):
+            adv.resolve_sources(None, False, self.inst)
+
+    def test_wrong_shape_is_an_error(self):
+        self._config({'advertise': [1, 2]})
+        with self.assertRaisesRegex(adv.AdvertiseError, 'list'):
+            adv.resolve_sources(None, False, self.inst)
+
+    def test_no_advertise_overrides_a_configured_source(self):
+        self._config({'advertise': ['cfg.example.com']})
+        self.assertEqual(adv.resolve_sources(None, True, self.inst), [])
+
+    def test_no_advertise_with_advertise_is_an_error(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'mutually exclusive'):
+            adv.resolve_sources(['host.example.com'], True, self.inst)
+
+    def test_empty_flag_value_is_an_error(self):
+        with self.assertRaisesRegex(adv.AdvertiseError, 'needs a value'):
+            adv.resolve_sources([''], False, self.inst)
+
+
+class TestAdvertisedUrls(unittest.TestCase):
+    """Shaped defensively: this crosses the admin socket."""
+
+    def test_reads_the_list(self):
+        self.assertEqual(adv.advertised_urls({'advertise': ['https://h/']}),
+                         ['https://h/'])
+
+    def test_missing_or_wrong_type_is_empty(self):
+        for info in (None, {}, {'advertise': None}, {'advertise': 'https://h/'},
+                     {'advertise': 7}):
+            self.assertEqual(adv.advertised_urls(info), [])
+
+    def test_non_string_members_are_dropped(self):
+        self.assertEqual(adv.advertised_urls({'advertise': ['https://h/', 1, '']}),
+                         ['https://h/'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -151,6 +151,41 @@ class TestPid(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Two instances, one port: attribution must not be a coin flip
+# ---------------------------------------------------------------------------
+
+class TestPidInstanceAttribution(unittest.TestCase):
+    """Two daemons may share a port on different addresses (127.0.0.1:7432 and
+    192.168.1.5:7432), so lsof reports both pids. The instance's own pid file
+    says which of them is ours -- but only ever to *choose among* processes
+    already known to hold the port, never to invent one."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('attrib')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def test_prefers_own_pid_over_whichever_lsof_listed_first(self):
+        write_pid(self.inst, 5678)
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+
+    def test_another_instances_daemon_on_our_port_is_not_ours(self):
+        # Our pid file names a live daemon, but it is not the one holding this
+        # port -- so this instance is not running on it.
+        write_pid(self.inst, 5678)
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertIsNone(ctl._pid(7432, self.inst))
+
+    def test_admin_socket_attributes_when_the_pidfile_is_gone(self):
+        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
+            with patch('trustmux._ctl.daemon_info', return_value={'pid': 5678}):
+                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+
+
+# ---------------------------------------------------------------------------
 # Regression: _pid(port) must never return an unrelated daemon's pid for a
 # port nothing is listening on (verified live: this previously let
 # `trustmux stop --port <unrelated port>` kill an unrelated running daemon).
@@ -1038,6 +1073,11 @@ class TestLaunchPort(unittest.TestCase):
         # Never handed to a shell.
         self.assertNotIn('shell', mock_popen.call_args.kwargs)
 
+    def test_passes_instance_to_daemon(self):
+        mock_popen = self._launch(3389, self.inst)
+        argv = mock_popen.call_args[0][0]
+        self.assertEqual(argv[argv.index('--instance') + 1], 'launchtest')
+
     def test_writes_pid_to_this_instance(self):
         self._launch(3389, self.inst)
         self.assertTrue(self.inst.pid_file.exists())
@@ -1232,6 +1272,228 @@ class TestPairMain(unittest.TestCase):
         with patch('trustmux._pair._wait_for_pair', return_value='10.0.0.4') as w:
             pair.main()
         w.assert_called_once_with(60, ctl.Instance())
+
+
+# ---------------------------------------------------------------------------
+# Instances: isolation, listing, per-instance login hooks
+# ---------------------------------------------------------------------------
+
+class TestInstanceIsolation(unittest.TestCase):
+
+    def test_resolve_port_asks_the_named_instance(self):
+        work = ctl.Instance('work')
+        with patch('trustmux._ctl.daemon_info') as info:
+            info.return_value = {'port': 3389}
+            self.assertEqual(ctl.resolve_port(inst=work), 3389)
+        info.assert_called_once_with(work)
+
+    def test_status_and_stop_address_the_named_instance(self):
+        work = ctl.Instance('work')
+        work.ensure_dirs()
+        self.addCleanup(shutil.rmtree, work.state, True)
+        with patch('trustmux._ctl._pid', return_value=None) as mock_pid:
+            with patch('builtins.print'):
+                ctl.cmd_status(3389, work)
+        self.assertEqual(mock_pid.call_args[0][1], work)
+
+
+class TestCmdList(unittest.TestCase):
+
+    def setUp(self):
+        self.made = []
+        for name in ('default', 'work'):
+            inst = ctl.Instance(name)
+            inst.ensure_dirs()
+            self.made.append(inst)
+            self.addCleanup(shutil.rmtree, inst.state, True)
+
+    def _run(self):
+        with patch('builtins.print') as mock_print:
+            rc = ctl.cmd_list()
+        return rc, ' '.join(str(c) for c in mock_print.call_args_list)
+
+    def test_lists_every_instance(self):
+        rc, out = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn('default', out)
+        self.assertIn('work', out)
+
+    def test_reports_a_running_instance_with_its_port(self):
+        def fake_info(inst):
+            return {'port': 3389, 'scheme': 'https'} if inst.name == 'work' else None
+        with patch('trustmux._ctl.daemon_info', side_effect=fake_info):
+            with patch('trustmux._ctl._pid', return_value=4321):
+                rc, out = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn('3389', out)
+        self.assertIn('running (pid 4321)', out)
+
+    def test_reports_stopped_instances(self):
+        with patch('trustmux._ctl._recorded_pid', return_value=None):
+            rc, out = self._run()
+        self.assertIn('stopped', out)
+
+
+class TestPerInstanceHooks(unittest.TestCase):
+
+    def _profile(self, content=''):
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.profile', delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(Path(f.name).unlink, True)
+        return Path(f.name)
+
+    def test_hook_line_carries_instance_and_port(self):
+        line = enable.hook_line(3389, ctl.Instance('work'))
+        self.assertEqual(line,
+                         'trustmux start --instance work --port 3389 2>/dev/null || true\n')
+
+    def test_default_instance_keeps_the_legacy_line(self):
+        self.assertEqual(enable.hook_line(ctl.DEFAULT_PORT, ctl.Instance()), enable._HOOK)
+
+    def test_second_instance_appends_rather_than_replacing(self):
+        p = self._profile('# top\n')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 2)
+        self.assertIn('--instance work', text)
+
+    def test_reenabling_one_instance_rewrites_only_its_line(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        enable._install_hook(p, enable.hook_line(9999, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 2)
+        self.assertIn('--port 9999', text)
+        self.assertNotIn('--port 3389', text)
+
+    def test_disable_removes_only_that_instance(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        disable._remove_hook(p, ctl.Instance('work'))
+        text = p.read_text()
+        self.assertNotIn('--instance work', text)
+        self.assertIn('trustmux start 2>/dev/null', text)
+
+    def test_disabling_default_leaves_named_instances(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance()), ctl.Instance())
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        disable._remove_hook(p, ctl.Instance())
+        text = p.read_text()
+        self.assertIn('--instance work', text)
+        self.assertNotIn('trustmux start 2>/dev/null', text)
+
+
+# ---------------------------------------------------------------------------
+# serve mode is singular: only one daemon can own the tailnet's :443
+# ---------------------------------------------------------------------------
+
+class TestServeModeGuard(unittest.TestCase):
+    """`tailscale serve` publishes on the tailnet's port 443. A second
+    `tailscale serve --bg` silently replaces the first mapping, so a named
+    instance must not be allowed into serve mode at all. --port does not help:
+    it moves only the loopback backend, not the tailnet-facing port."""
+
+    def _stderr(self):
+        import io
+        return io.StringIO()
+
+    def test_default_instance_may_use_serve(self):
+        self.assertTrue(ctl.can_use_serve(ctl.Instance(), self._stderr()))
+
+    def test_named_instance_may_not(self):
+        buf = self._stderr()
+        self.assertFalse(ctl.can_use_serve(ctl.Instance('work'), buf))
+        msg = buf.getvalue()
+        self.assertIn('work', msg)
+        self.assertIn('443', msg)
+        # Points at the modes that actually work for a second instance.
+        self.assertIn('start-direct --instance work', msg)
+        self.assertIn('start-local --instance work', msg)
+
+    def test_cmd_start_serve_refuses_named_instance(self):
+        with patch('trustmux._ctl._launch') as mock_launch:
+            with patch('trustmux._ctl._ensure_ts_serve') as mock_serve:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    rc = ctl.cmd_start('serve', 7432, ctl.Instance('work'))
+        self.assertEqual(rc, 1)
+        mock_launch.assert_not_called()
+        # Crucially, the existing serve mapping is never touched.
+        mock_serve.assert_not_called()
+
+    def test_refusal_happens_before_any_probing(self):
+        # The refusal is certain, so it must not first query a daemon or
+        # fork lsof.
+        with patch('trustmux._ctl._pid') as mock_pid:
+            with patch('trustmux._ctl.daemon_info') as mock_info:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    ctl.cmd_start('serve', None, ctl.Instance('work'))
+        mock_pid.assert_not_called()
+        mock_info.assert_not_called()
+
+    def test_named_instance_may_still_use_direct_and_local(self):
+        for mode in ('start-direct', 'start-local'):
+            with self.subTest(mode=mode):
+                with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
+                    with patch('trustmux._ctl._check_tmux', return_value=True):
+                        with patch('trustmux._ctl._check_tls', return_value=True):
+                            with patch('trustmux._ctl._pid', return_value=None):
+                                with patch('builtins.print'):
+                                    rc = ctl.cmd_start(mode, 3389, ctl.Instance('work'))
+                self.assertEqual(rc, 0)
+                mock_launch.assert_called_once()
+
+    def test_restart_refuses_before_stopping_anything(self):
+        # restart brings the daemon back in serve mode; refusing only at the
+        # start step would leave a running named instance stopped.
+        with patch('trustmux._ctl._refuse_root'), \
+             patch('trustmux._ctl.sys.argv',
+                   ['trustmux', 'restart', '--instance', 'work']), \
+             patch('trustmux._ctl.cmd_stop') as mock_stop, \
+             patch('trustmux._ctl.cmd_start') as mock_start, \
+             patch('trustmux._ctl.sys.stderr', self._stderr()):
+            with self.assertRaises(SystemExit) as cm:
+                ctl.main()
+        self.assertEqual(cm.exception.code, 1)
+        mock_stop.assert_not_called()
+        mock_start.assert_not_called()
+
+    def test_cmd_setup_refuses_named_instance(self):
+        with patch('trustmux._ctl._ensure_ts_serve') as mock_serve:
+            with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                rc = ctl.cmd_setup(inst=ctl.Instance('work'))
+        self.assertEqual(rc, 1)
+        mock_serve.assert_not_called()
+
+    def test_enable_refuses_named_instance_without_looping(self):
+        with patch('trustmux._enable.cmd_setup') as mock_setup:
+            with patch('trustmux._enable._install_hook') as mock_hook:
+                with patch('trustmux._ctl.sys.stderr', self._stderr()):
+                    with patch('sys.stderr', self._stderr()):
+                        with self.assertRaises(SystemExit) as cm:
+                            enable.main(3389, ctl.Instance('work'))
+        self.assertEqual(cm.exception.code, 1)
+        # Refused up front: no setup attempt, no hook written.
+        mock_setup.assert_not_called()
+        mock_hook.assert_not_called()
+
+    def test_enable_still_works_for_the_default_instance(self):
+        with patch('trustmux._enable.cmd_setup', return_value=0) as mock_setup:
+            with patch('trustmux._enable.cmd_start', return_value=0):
+                with patch('trustmux._enable._install_hook'):
+                    with patch('trustmux._paths.Instance.tokens_file'):
+                        with patch('builtins.print'):
+                            enable.main(ctl.DEFAULT_PORT, ctl.Instance())
+        mock_setup.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -578,26 +578,39 @@ class TestCmdStop(unittest.TestCase):
 
     def test_not_found_on_this_port_preserves_pidfile_of_live_other_daemon(self):
         # Nothing is on the requested port, but the pid file tracks a
-        # genuinely alive daemon on some other port -- must not be deleted
-        # just because the wrong port was asked about (regression: previously
-        # unconditional, which threw away bookkeeping for a live daemon).
-        write_pid(self.inst, 4321)
-        with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+        # genuinely alive daemon on some other port -- shown by its socket
+        # still accepting. Must not be deleted just because the wrong port was
+        # asked about (regression: previously unconditional, which threw away
+        # bookkeeping for a live daemon).
+        write_pid(self.inst, 4321, 3389)
+        with wedged_socket(), patch('trustmux._ctl._pid', return_value=None):
+            with patch('trustmux._ctl.os.kill', return_value=None):
                 result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
-        mock_kill.assert_called_once_with(4321, 0)  # liveness probe, not a real kill
         self.assertTrue(self.inst.pid_file.exists())
 
     def test_not_found_on_this_port_cleans_up_genuinely_dead_pidfile(self):
         # Same "not found" case, but the pid file's own pid is dead: this is
         # the genuinely-stale case, and should still be cleaned up as before.
-        write_pid(self.inst, 4321)
-        with patch('trustmux._ctl._pid', return_value=None):
+        write_pid(self.inst, 4321, 3389)
+        with wedged_socket(), patch('trustmux._ctl._pid', return_value=None):
             with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
                 result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
         self.assertFalse(self.inst.pid_file.exists())
+
+    def test_a_pidfile_outliving_a_reboot_is_cleaned_up(self):
+        # The state directory survives a reboot but pids restart, so the
+        # recorded pid may now be an unrelated live process. The dead socket
+        # is what settles it: no daemon here, so the file is leftover.
+        write_pid(self.inst, 4321, 7432)
+        with no_socket(), patch('trustmux._ctl._pid', return_value=None):
+            with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+                result = ctl.cmd_stop(7432, self.inst)
+        self.assertEqual(result, 0)
+        self.assertFalse(self.inst.pid_file.exists())
+        # ...and the innocent process that inherited the pid is not signalled.
+        self.assertEqual([c for c in mock_kill.call_args_list if c.args[1] != 0], [])
 
 
 # ---------------------------------------------------------------------------

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -1551,6 +1551,35 @@ class TestPerInstanceHooks(unittest.TestCase):
         self.assertFalse(enable.is_hook_for(old, ctl.Instance()))
         self.assertFalse(enable.is_hook_for(old, ctl.Instance('other')))
 
+    def test_instance_name_prefix_does_not_collide(self):
+        # "work" is a string-prefix of "workstation" -- is_hook_for() must not
+        # match on that alone, or enabling/disabling one clobbers the other.
+        workstation = enable.hook_line(3389, ctl.Instance('workstation'))
+        self.assertFalse(enable.is_hook_for(workstation, ctl.Instance('work')))
+        self.assertTrue(enable.is_hook_for(workstation, ctl.Instance('workstation')))
+
+    def test_reenabling_a_prefix_instance_does_not_rewrite_the_longer_one(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('workstation')),
+                             ctl.Instance('workstation'))
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        text = p.read_text()
+        self.assertEqual(text.count('trustmux start'), 2)
+        self.assertIn('--name workstation', text)
+        self.assertIn('--name work ', text)
+
+    def test_disabling_a_prefix_instance_leaves_the_longer_one(self):
+        p = self._profile('')
+        enable._install_hook(p, enable.hook_line(3389, ctl.Instance('workstation')),
+                             ctl.Instance('workstation'))
+        enable._install_hook(p, enable.hook_line(7432, ctl.Instance('work')),
+                             ctl.Instance('work'))
+        disable._remove_hook(p, ctl.Instance('work'))
+        text = p.read_text()
+        self.assertIn('--name workstation', text)
+        self.assertNotIn('--name work ', text)
+
     def test_default_instance_keeps_the_legacy_line(self):
         self.assertEqual(enable.hook_line(ctl.DEFAULT_PORT, ctl.Instance()), enable._HOOK)
 

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -1145,7 +1145,7 @@ class TestLaunchPort(unittest.TestCase):
     def test_passes_instance_to_daemon(self):
         mock_popen = self._launch(3389, self.inst)
         argv = mock_popen.call_args[0][0]
-        self.assertEqual(argv[argv.index('--instance') + 1], 'launchtest')
+        self.assertEqual(argv[argv.index('--name') + 1], 'launchtest')
 
     def test_writes_pid_to_this_instance(self):
         self._launch(3389, self.inst)
@@ -1539,7 +1539,17 @@ class TestPerInstanceHooks(unittest.TestCase):
     def test_hook_line_carries_instance_and_port(self):
         line = enable.hook_line(3389, ctl.Instance('work'))
         self.assertEqual(line,
-                         'trustmux start --instance work --port 3389 2>/dev/null || true\n')
+                         'trustmux start --name work --port 3389 2>/dev/null || true\n')
+
+    def test_a_hook_written_as_dash_dash_instance_is_still_recognised(self):
+        # The flag was --instance before it was --name. Hooks sit in
+        # ~/.profile and are not rewritten on upgrade, so an old-spelling hook
+        # must still be matched or disable/rm would leave it behind to start
+        # an instance that has been deleted.
+        old = 'trustmux start --instance work --port 3389 2>/dev/null || true\n'
+        self.assertTrue(enable.is_hook_for(old, ctl.Instance('work')))
+        self.assertFalse(enable.is_hook_for(old, ctl.Instance()))
+        self.assertFalse(enable.is_hook_for(old, ctl.Instance('other')))
 
     def test_default_instance_keeps_the_legacy_line(self):
         self.assertEqual(enable.hook_line(ctl.DEFAULT_PORT, ctl.Instance()), enable._HOOK)
@@ -1551,7 +1561,7 @@ class TestPerInstanceHooks(unittest.TestCase):
                              ctl.Instance('work'))
         text = p.read_text()
         self.assertEqual(text.count('trustmux start'), 2)
-        self.assertIn('--instance work', text)
+        self.assertIn('--name work', text)
 
     def test_reenabling_one_instance_rewrites_only_its_line(self):
         p = self._profile('')
@@ -1572,7 +1582,7 @@ class TestPerInstanceHooks(unittest.TestCase):
                              ctl.Instance('work'))
         disable._remove_hook(p, ctl.Instance('work'))
         text = p.read_text()
-        self.assertNotIn('--instance work', text)
+        self.assertNotIn('--name work', text)
         self.assertIn('trustmux start 2>/dev/null', text)
 
     def test_disabling_default_leaves_named_instances(self):
@@ -1582,7 +1592,7 @@ class TestPerInstanceHooks(unittest.TestCase):
                              ctl.Instance('work'))
         disable._remove_hook(p, ctl.Instance())
         text = p.read_text()
-        self.assertIn('--instance work', text)
+        self.assertIn('--name work', text)
         self.assertNotIn('trustmux start 2>/dev/null', text)
 
 
@@ -1610,8 +1620,8 @@ class TestServeModeGuard(unittest.TestCase):
         self.assertIn('work', msg)
         self.assertIn('443', msg)
         # Points at the modes that actually work for a second instance.
-        self.assertIn('start-direct --instance work', msg)
-        self.assertIn('start-local --instance work', msg)
+        self.assertIn('start-direct --name work', msg)
+        self.assertIn('start-local --name work', msg)
 
     def test_cmd_start_serve_refuses_named_instance(self):
         with patch('trustmux._ctl._launch') as mock_launch:
@@ -1650,7 +1660,7 @@ class TestServeModeGuard(unittest.TestCase):
         # start step would leave a running named instance stopped.
         with patch('trustmux._ctl._refuse_root'), \
              patch('trustmux._ctl.sys.argv',
-                   ['trustmux', 'restart', '--instance', 'work']), \
+                   ['trustmux', 'restart', '--name', 'work']), \
              patch('trustmux._ctl.cmd_stop') as mock_stop, \
              patch('trustmux._ctl.cmd_start') as mock_start, \
              patch('trustmux._ctl.sys.stderr', self._stderr()):

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -1,5 +1,6 @@
 """Tests for trustmux._ctl, _enable, _disable."""
 
+import io
 import json
 import os
 import shutil
@@ -1117,6 +1118,160 @@ class TestDirectUrl(unittest.TestCase):
     def test_live_daemon_port_wins_over_caller(self):
         url = ctl.direct_url(4444, {'host': '127.0.0.1', 'port': 3389, 'scheme': 'http'})
         self.assertEqual(url, 'http://localhost:3389/')
+
+    def test_advertised_address_wins_over_the_discovered_one(self):
+        # The NAT case: the daemon binds every interface and can only see an
+        # internal address, but the operator said what a phone can reach.
+        with patch('trustmux._ctl._lan_ip', return_value='10.128.0.7'):
+            url = ctl.direct_url(7432, {'host': '0.0.0.0', 'port': 7432,
+                                        'scheme': 'https',
+                                        'advertise': ['https://34.1.2.3:7432/']})
+        self.assertEqual(url, 'https://34.1.2.3:7432/')
+
+    def test_first_advertised_address_is_the_one_printed(self):
+        url = ctl.direct_url(7432, {'host': '0.0.0.0', 'scheme': 'https',
+                                    'advertise': ['https://a/', 'https://b/']})
+        self.assertEqual(url, 'https://a/')
+
+    def test_empty_advertise_list_falls_back(self):
+        with patch('trustmux._ctl._lan_ip', return_value='192.168.1.9'):
+            url = ctl.direct_url(7432, {'host': '0.0.0.0', 'scheme': 'https',
+                                        'advertise': []})
+        self.assertEqual(url, 'https://192.168.1.9:7432/')
+
+
+class TestPairUrl(unittest.TestCase):
+    """What `trustmux pair` puts in the URL and QR code."""
+
+    def setUp(self):
+        import trustmux._pair as pair
+        self.pair = pair
+        self.inst = ctl.Instance('pairurl')
+
+    def _url(self, info):
+        with patch('trustmux._pair.daemon_info', return_value=info):
+            return self.pair._pair_url(self.inst)
+
+    def test_advertised_address_beats_the_tailnet_name(self):
+        # The operator's answer to exactly this question wins, and it is the one
+        # the daemon's certificate was built around.
+        with patch('trustmux._pair._ts_url', return_value='https://host.ts.net/') as ts:
+            url = self._url({'host': '127.0.0.1', 'scheme': 'https',
+                             'advertise': ['https://34.1.2.3:7432/']})
+        self.assertEqual(url, 'https://34.1.2.3:7432/')
+        ts.assert_not_called()
+
+    def test_tailnet_name_still_used_when_nothing_is_advertised(self):
+        with patch('trustmux._pair._ts_url', return_value='https://host.ts.net/'):
+            url = self._url({'host': '127.0.0.1', 'scheme': 'https',
+                             'advertise': []})
+        self.assertEqual(url, 'https://host.ts.net/')
+
+    def test_advertised_address_beats_the_lan_address(self):
+        with patch('trustmux._ctl._lan_ip', return_value='10.128.0.7'):
+            url = self._url({'host': '0.0.0.0', 'port': 7432, 'scheme': 'https',
+                             'advertise': ['https://tmux.example.com/']})
+        self.assertEqual(url, 'https://tmux.example.com/')
+
+    def test_pairing_code_appends_cleanly_to_an_advertised_url(self):
+        # The URL always ends in '/', so the fragment never merges with a host.
+        url = self._url({'host': '0.0.0.0', 'scheme': 'https',
+                         'advertise': ['https://tmux.example.com/']})
+        self.assertEqual(f"{url}#123456", 'https://tmux.example.com/#123456')
+
+
+class TestAdvertiseArgs(unittest.TestCase):
+    """What the CLI hands the daemon it launches."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('advargs')
+
+    def test_sources_are_spelled_out_in_order(self):
+        got = ctl.advertise_args(['a.example.com', 'cmd:/bin/prog'], False, self.inst)
+        self.assertEqual(got, ['--advertise', 'a.example.com',
+                               '--advertise', 'cmd:/bin/prog'])
+
+    def test_no_sources_still_says_so_explicitly(self):
+        # Otherwise the daemon would consult the environment and config file
+        # itself, and --no-advertise could not override a configured source.
+        self.assertEqual(ctl.advertise_args(None, False, self.inst),
+                         ['--no-advertise'])
+        self.assertEqual(ctl.advertise_args(None, True, self.inst),
+                         ['--no-advertise'])
+
+    def test_an_unusable_source_is_caught_before_launching(self):
+        with self.assertRaises(ctl.AdvertiseError):
+            ctl.advertise_args(['cmd:/bin/echo host | tr -d x'], False, self.inst)
+
+
+class TestEnableAdvertiseNote(unittest.TestCase):
+    """`enable` writes a hook that carries no --advertise, so a source given on
+    the command line applies once and then vanishes. Say so."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('advnote')
+
+    def _note(self, advertise, no_advertise=False, env=None):
+        with patch.dict(os.environ, {'TRUSTMUX_ADVERTISE': env} if env else {},
+                        clear=False):
+            if env is None:
+                os.environ.pop('TRUSTMUX_ADVERTISE', None)
+            with patch('sys.stderr', new_callable=io.StringIO) as err:
+                enable._warn_transient_advertise(advertise, no_advertise, self.inst)
+            return err.getvalue()
+
+    def test_flag_is_flagged_and_points_at_the_config_file(self):
+        out = self._note(['cmd:/bin/prog'])
+        self.assertIn('--advertise', out)
+        self.assertIn(str(self.inst.config_file), out)
+        self.assertIn('"advertise": ["cmd:/bin/prog"]', out)
+
+    def test_env_var_is_flagged(self):
+        out = self._note(None, env='tmux.example.com')
+        self.assertIn('TRUSTMUX_ADVERTISE', out)
+        self.assertIn('"advertise": ["tmux.example.com"]', out)
+
+    def test_silent_when_the_source_is_already_durable(self):
+        # From the config file, which is exactly what the hook will read.
+        self.assertEqual(self._note(None), '')
+
+    def test_silent_under_no_advertise(self):
+        # Nothing was advertised, so nothing is being lost.
+        self.assertEqual(self._note(None, True, env='tmux.example.com'), '')
+
+
+class TestLogError(unittest.TestCase):
+    """Why a daemon refused to start, taken from what it logged."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('logerror')
+        self.inst.ensure_dirs()
+        self.addCleanup(lambda: self.inst.log_file.unlink(missing_ok=True))
+
+    def test_finds_the_daemons_error_line(self):
+        self.inst.log_file.write_text('Trustmux: starting\n'
+                                      'Error: /bin/prog exited 22: no metadata\n')
+        self.assertEqual(ctl._log_error(self.inst),
+                         'Error: /bin/prog exited 22: no metadata')
+
+    def test_earlier_attempts_are_not_reported(self):
+        # The log is appended to across starts, so an offset is what keeps a
+        # stale error from being blamed for this one.
+        self.inst.log_file.write_text('Error: an old failure\n')
+        mark = self.inst.log_file.stat().st_size
+        with self.inst.log_file.open('a') as f:
+            f.write('Trustmux daemon on https://0.0.0.0:7432\n')
+        self.assertEqual(ctl._log_error(self.inst, mark), '')
+
+    def test_the_last_error_wins(self):
+        self.inst.log_file.write_text('Error: first\nError: second\n')
+        self.assertEqual(ctl._log_error(self.inst), 'Error: second')
+
+    def test_no_error_and_no_log_are_both_empty(self):
+        self.inst.log_file.write_text('Trustmux: nothing wrong here\n')
+        self.assertEqual(ctl._log_error(self.inst), '')
+        self.inst.log_file.unlink()
+        self.assertEqual(ctl._log_error(self.inst), '')
 
 
 class TestLaunchPort(unittest.TestCase):

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -1343,6 +1343,49 @@ class TestPairMain(unittest.TestCase):
         w.assert_called_once_with(60, ctl.Instance())
 
 
+class TestPairPollInstance(unittest.TestCase):
+    """The pairing wait polls the named instance's socket, not a fixed path."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('polltest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def _listen(self) -> socket.socket:
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(str(self.inst.sock))
+        srv.listen(1)
+        self.addCleanup(srv.close)
+        return srv
+
+    def test_poll_reaches_the_named_instance(self):
+        srv = self._listen()
+
+        def handle():
+            conn, _ = srv.accept()
+            with conn:
+                conn.recv(4096)
+                conn.sendall(b'{"state": "paired", "ip": "10.0.0.4"}\n')
+
+        t = threading.Thread(target=handle, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+        self.assertEqual(pair._poll({'action': 'pair_status'}, self.inst),
+                         {'state': 'paired', 'ip': '10.0.0.4'})
+
+    def test_poll_ignores_another_instances_live_socket(self):
+        self._listen()
+        self.assertIsNone(pair._poll({'action': 'pair_status'},
+                                     ctl.Instance('polltest-other')))
+
+    def test_wait_polls_the_instance_it_was_given(self):
+        work = ctl.Instance('work')
+        with patch('trustmux._pair._poll',
+                   return_value={'state': 'paired', 'ip': '10.0.0.4'}) as p:
+            self.assertEqual(pair._wait_for_pair(60, work), '10.0.0.4')
+        p.assert_called_once_with({'action': 'pair_status'}, work)
+
+
 # ---------------------------------------------------------------------------
 # Instances: isolation, listing, per-instance login hooks
 # ---------------------------------------------------------------------------

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import signal
 import socket
 import sys
@@ -19,18 +20,38 @@ import trustmux._disable as disable
 import trustmux._pair as pair
 
 _no_daemon = None
+_tmp_root = None
+_tmp_env = None
 
 
 def setUpModule():
+    # Root every base directory in a temp tree so the suite can never read or
+    # write the developer's real trustmux state.
+    global _no_daemon, _tmp_root, _tmp_env
+    _tmp_root = tempfile.TemporaryDirectory()
+    root = Path(_tmp_root.name)
+    _tmp_env = patch.dict(os.environ, {
+        'TRUSTMUX_CONFIG_DIR': str(root / 'config'),
+        'TRUSTMUX_STATE_DIR':  str(root / 'state'),
+    })
+    _tmp_env.start()
     # resolve_port() asks the running daemon which port it is on; without this
     # the suite would pick up a real trustmux on the developer's machine.
-    global _no_daemon
     _no_daemon = patch('trustmux._ctl.daemon_info', return_value=None)
     _no_daemon.start()
 
 
 def tearDownModule():
     _no_daemon.stop()
+    _tmp_env.stop()
+    _tmp_root.cleanup()
+
+
+def write_pid(inst, pid):
+    """Give inst a pid file containing pid."""
+    inst.ensure_dirs()
+    inst.pid_file.write_text(str(pid))
+    return inst.pid_file
 
 
 # ---------------------------------------------------------------------------
@@ -50,19 +71,24 @@ class TestPid(unittest.TestCase):
     nothing was listening on, and in turn let `trustmux stop --port <wrong>`
     kill the wrong daemon (see TestPidCrossPortRegression below)."""
 
+    def setUp(self):
+        self.inst = ctl.Instance('pidtest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
     def test_lsof_returns_pid(self):
         with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
-            self.assertEqual(ctl._pid(3389), 1234)
+            self.assertEqual(ctl._pid(3389, self.inst), 1234)
 
-    def test_lsof_multiple_lines_uses_first(self):
+    def test_lsof_first_pid_when_this_instance_has_no_claim(self):
         with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
-            self.assertEqual(ctl._pid(3389), 1234)
+            self.assertEqual(ctl._pid(3389, self.inst), 1234)
 
     def test_lsof_empty_output_is_definitive_none(self):
         # lsof ran fine, found nothing: no fallback, no daemon_info() call.
         with patch('trustmux._ctl.subprocess.check_output', return_value=''):
             with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
         mock_info.assert_not_called()
 
     def test_lsof_called_process_error_is_definitive_none(self):
@@ -72,15 +98,25 @@ class TestPid(unittest.TestCase):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=subprocess.CalledProcessError(1, 'lsof')):
             with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
         mock_info.assert_not_called()
+
+    def test_a_live_pidfile_cannot_conjure_a_pid_for_an_idle_port(self):
+        # Same invariant as above, with this instance's pid file naming a
+        # genuinely live process: still None, because nothing holds the port.
+        import subprocess
+        write_pid(self.inst, 9999)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=subprocess.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.os.kill', return_value=None):
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_falls_back_to_daemon_info_matching_port(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 4321, 'port': 3389}):
-                self.assertEqual(ctl._pid(3389), 4321)
+                self.assertEqual(ctl._pid(3389, self.inst), 4321)
 
     def test_lsof_missing_and_daemon_info_reports_different_port(self):
         # The exact regression this class exists to prevent: a live daemon
@@ -89,20 +125,29 @@ class TestPid(unittest.TestCase):
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 4321, 'port': 7432}):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_and_no_daemon_answers(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info', return_value=None):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
 
     def test_lsof_missing_and_daemon_info_reports_junk_pid(self):
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=FileNotFoundError):
             with patch('trustmux._ctl.daemon_info',
                        return_value={'pid': 'not-a-pid', 'port': 3389}):
-                self.assertIsNone(ctl._pid(3389))
+                self.assertIsNone(ctl._pid(3389, self.inst))
+
+    def test_lsof_full_listing_is_treated_as_unusable_not_as_a_pid(self):
+        # An lsof that does not understand -ti:<port> prints a whole table
+        # instead of failing; its columns must not be misread as pids.
+        listing = '1084\t/usr/lib/systemd/systemd\t0\t/dev/null\n'
+        with patch('trustmux._ctl.subprocess.check_output', return_value=listing):
+            with patch('trustmux._ctl.daemon_info', return_value=None) as mock_info:
+                self.assertIsNone(ctl._pid(3389, self.inst))
+        mock_info.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -113,30 +158,51 @@ class TestPid(unittest.TestCase):
 
 class TestPidCrossPortRegression(unittest.TestCase):
 
-    def _mock_pidfile(self, exists=False, content=''):
-        m = MagicMock()
-        m.exists.return_value = exists
-        m.read_text.return_value = content
-        return m
+    def setUp(self):
+        self.inst = ctl.Instance('crossport')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
 
     def test_stop_on_unrelated_port_does_not_kill_the_real_daemon(self):
         import subprocess as sp
-        # Real daemon is on 3389 (PIDFILE reflects it, and is genuinely
-        # alive); lsof is queried for 4444, where nothing listens, and
-        # genuinely finds nothing. Must never send SIGTERM to the pid
-        # PIDFILE names -- only cmd_stop's own liveness *probe* (signal 0,
-        # harmless) is expected, to decide whether to also clean PIDFILE up.
+        # Real daemon is on 3389 (the pid file reflects it, and it is
+        # genuinely alive); lsof is queried for 4444, where nothing listens,
+        # and genuinely finds nothing. Must never send SIGTERM to the pid the
+        # pid file names -- only the harmless liveness probe (signal 0), used
+        # to decide whether to also clean the pid file up.
+        write_pid(self.inst, 3141)
         with patch('trustmux._ctl.subprocess.check_output',
                    side_effect=sp.CalledProcessError(1, 'lsof')):
             with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl.PIDFILE',
-                           self._mock_pidfile(exists=True, content='3141\n')):
-                    with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
-                        with patch('builtins.print'):
-                            result = ctl.cmd_stop(4444)
-        mock_kill.assert_called_once_with(3141, 0)  # liveness probe only
+                with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+                    with patch('builtins.print'):
+                        result = ctl.cmd_stop(4444, self.inst)
         self.assertNotIn(call(3141, signal.SIGTERM), mock_kill.call_args_list)
+        for c in mock_kill.call_args_list:
+            self.assertEqual(c, call(3141, 0))   # liveness probes only
         self.assertEqual(result, 0)
+
+    def test_live_pidfile_survives_a_stop_on_a_different_port(self):
+        import subprocess as sp
+        write_pid(self.inst, 3141)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=sp.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.daemon_info', return_value=None):
+                with patch('trustmux._ctl.os.kill', return_value=None):
+                    with patch('builtins.print'):
+                        ctl.cmd_stop(4444, self.inst)
+        self.assertTrue(self.inst.pid_file.exists())
+
+    def test_dead_pidfile_is_cleaned_up(self):
+        import subprocess as sp
+        write_pid(self.inst, 3141)
+        with patch('trustmux._ctl.subprocess.check_output',
+                   side_effect=sp.CalledProcessError(1, 'lsof')):
+            with patch('trustmux._ctl.daemon_info', return_value=None):
+                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+                    with patch('builtins.print'):
+                        ctl.cmd_stop(4444, self.inst)
+        self.assertFalse(self.inst.pid_file.exists())
 
     def test_start_on_unrelated_port_is_not_falsely_refused(self):
         import subprocess as sp
@@ -145,10 +211,9 @@ class TestPidCrossPortRegression(unittest.TestCase):
             with patch('trustmux._ctl.daemon_info', return_value=None):
                 with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
                     with patch('builtins.print'):
-                        result = ctl.cmd_start('start-local', 4444)
+                        result = ctl.cmd_start('start-local', 4444, self.inst)
         mock_launch.assert_called_once()
         self.assertEqual(result, 0)
-
 
 # ---------------------------------------------------------------------------
 # _ts_host()
@@ -406,67 +471,61 @@ class TestCmdStart(unittest.TestCase):
 
 class TestCmdStop(unittest.TestCase):
 
-    def _mock_pidfile(self, exists=False, content=''):
-        m = MagicMock()
-        m.exists.return_value = exists
-        m.read_text.return_value = content
-        return m
+    def setUp(self):
+        self.inst = ctl.Instance('stoptest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
 
     def test_not_running_returns_0(self):
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', self._mock_pidfile(exists=False)):
-                self.assertEqual(ctl.cmd_stop(), 0)
+            self.assertEqual(ctl.cmd_stop(inst=self.inst), 0)
 
     def test_kills_process_and_removes_pidfile(self):
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE',
-                       self._mock_pidfile(exists=True, content='4321')):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, signal.SIGTERM)
+        self.assertFalse(self.inst.pid_file.exists())
 
     def test_pidfile_mismatch_refuses_to_kill(self):
+        write_pid(self.inst, 9999)
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE',
-                       self._mock_pidfile(exists=True, content='9999')):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 1)
         mock_kill.assert_not_called()
 
     def test_no_pidfile_still_kills(self):
         with patch('trustmux._ctl._pid', return_value=4321):
-            with patch('trustmux._ctl.PIDFILE', self._mock_pidfile(exists=False)):
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    result = ctl.cmd_stop()
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, signal.SIGTERM)
 
     def test_not_found_on_this_port_preserves_pidfile_of_live_other_daemon(self):
-        # Nothing is on the requested port, but PIDFILE tracks a genuinely
-        # alive daemon on some other port -- must not be deleted just
-        # because the wrong port was asked about (regression: previously
+        # Nothing is on the requested port, but the pid file tracks a
+        # genuinely alive daemon on some other port -- must not be deleted
+        # just because the wrong port was asked about (regression: previously
         # unconditional, which threw away bookkeeping for a live daemon).
-        pidfile = self._mock_pidfile(exists=True, content='4321')
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', pidfile):
-                with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
-                    result = ctl.cmd_stop(4444)
+            with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+                result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
         mock_kill.assert_called_once_with(4321, 0)  # liveness probe, not a real kill
-        pidfile.unlink.assert_not_called()
+        self.assertTrue(self.inst.pid_file.exists())
 
     def test_not_found_on_this_port_cleans_up_genuinely_dead_pidfile(self):
-        # Same "not found" case, but PIDFILE's own pid is dead: this is the
-        # genuinely-stale case, and should still be cleaned up as before.
-        pidfile = self._mock_pidfile(exists=True, content='4321')
+        # Same "not found" case, but the pid file's own pid is dead: this is
+        # the genuinely-stale case, and should still be cleaned up as before.
+        write_pid(self.inst, 4321)
         with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl.PIDFILE', pidfile):
-                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
-                    result = ctl.cmd_stop(4444)
+            with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+                result = ctl.cmd_stop(4444, self.inst)
         self.assertEqual(result, 0)
-        pidfile.unlink.assert_called_once_with(missing_ok=True)
+        self.assertFalse(self.inst.pid_file.exists())
 
 
 # ---------------------------------------------------------------------------
@@ -628,7 +687,7 @@ class TestEnableMain(unittest.TestCase):
         with patch('trustmux._enable.cmd_setup', return_value=0):
             with patch('trustmux._enable.cmd_start', return_value=0):
                 with patch('trustmux._enable._LOGIN_FILES', []):
-                    with patch('trustmux._enable.TOKENS_FILE') as tf:
+                    with patch('trustmux._paths.Instance.tokens_file') as tf:
                         tf.exists.return_value = True
                         tf.stat.return_value = MagicMock(st_size=100)
                         enable.main()   # should not raise
@@ -897,9 +956,10 @@ class TestDaemonInfo(unittest.TestCase):
     def setUp(self):
         _no_daemon.stop()
         self.addCleanup(_no_daemon.start)
-        self.td = tempfile.TemporaryDirectory()
-        self.addCleanup(self.td.cleanup)
-        self.sock_path = Path(self.td.name) / 'trustmux.sock'
+        self.inst = ctl.Instance('infotest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+        self.sock_path = self.inst.sock
 
     def _serve_once(self, reply: bytes) -> None:
         srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -918,25 +978,21 @@ class TestDaemonInfo(unittest.TestCase):
         self.addCleanup(t.join, 5)
 
     def test_none_when_socket_absent(self):
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
     def test_returns_listener_details(self):
         self._serve_once(b'{"pid": 42, "host": "0.0.0.0", "port": 3389, "scheme": "https"}\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            info = ctl.daemon_info()
+        info = ctl.daemon_info(self.inst)
         self.assertEqual(info['port'], 3389)
         self.assertEqual(info['scheme'], 'https')
 
     def test_none_on_error_reply(self):
         self._serve_once(b'{"error": "unknown action"}\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
     def test_none_on_garbage_reply(self):
         self._serve_once(b'not json\n')
-        with patch('trustmux._ctl.ADMIN_SOCK', self.sock_path):
-            self.assertIsNone(ctl.daemon_info())
+        self.assertIsNone(ctl.daemon_info(self.inst))
 
 
 class TestDirectUrl(unittest.TestCase):
@@ -961,19 +1017,41 @@ class TestDirectUrl(unittest.TestCase):
 
 class TestLaunchPort(unittest.TestCase):
 
+    def setUp(self):
+        self.inst = ctl.Instance('launchtest')
+        self.inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def _launch(self, port, inst):
+        with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
+            mock_popen.return_value.poll.return_value = None   # still alive
+            with patch('trustmux._ctl.time.sleep'):
+                with patch('trustmux._ctl._pid', return_value=4321):
+                    ctl._launch(port, ['--host', '127.0.0.1'], inst)
+        return mock_popen
+
     def test_passes_resolved_port_to_daemon(self):
-        with patch('trustmux._ctl._ensure_dir'):
-            with patch('trustmux._ctl.LOGFILE'):
-                with patch('trustmux._ctl.PIDFILE'):
-                    with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
-                        with patch('trustmux._ctl.time.sleep'):
-                            with patch('trustmux._ctl._pid', return_value=4321):
-                                ctl._launch(3389, ['--host', '127.0.0.1'])
+        mock_popen = self._launch(3389, self.inst)
         argv = mock_popen.call_args[0][0]
         self.assertIn('--port', argv)
         self.assertEqual(argv[argv.index('--port') + 1], '3389')
         # Never handed to a shell.
         self.assertNotIn('shell', mock_popen.call_args.kwargs)
+
+    def test_writes_pid_to_this_instance(self):
+        self._launch(3389, self.inst)
+        self.assertTrue(self.inst.pid_file.exists())
+
+    def test_reports_failure_when_the_daemon_dies_on_startup(self):
+        # Port conflicts are easy to hit once several instances are in play;
+        # a child that has already exited must not be reported as started.
+        with patch('trustmux._ctl.subprocess.Popen') as mock_popen:
+            mock_popen.return_value.poll.return_value = 1   # already exited
+            with patch('trustmux._ctl.time.sleep'):
+                with patch('trustmux._ctl._pid', return_value=4321):
+                    result = ctl._launch(3389, ['--host', '127.0.0.1'], self.inst)
+        self.assertIsNone(result)
+        self.assertFalse(self.inst.pid_file.exists())
 
 
 class TestEnsureTsServePort(unittest.TestCase):
@@ -1000,19 +1078,20 @@ class TestCmdStartPort(unittest.TestCase):
         with patch('trustmux._ctl._pid', return_value=999) as mock_pid:
             with patch('builtins.print'):
                 self.assertEqual(ctl.cmd_start('start-local', 3389), 1)
-        mock_pid.assert_called_once_with(3389)
+        mock_pid.assert_called_once_with(3389, ctl.Instance())
 
 
 class TestCmdStopPort(unittest.TestCase):
 
     def test_stops_pid_found_on_requested_port(self):
+        inst = ctl.Instance('stopport')
+        inst.ensure_dirs()
+        self.addCleanup(shutil.rmtree, inst.state, True)
         with patch('trustmux._ctl._pid', return_value=1234) as mock_pid:
-            with patch('trustmux._ctl.PIDFILE') as mock_pidfile:
-                mock_pidfile.exists.return_value = False
-                with patch('trustmux._ctl.os.kill') as mock_kill:
-                    with patch('builtins.print'):
-                        self.assertEqual(ctl.cmd_stop(3389), 0)
-        mock_pid.assert_called_once_with(3389)
+            with patch('trustmux._ctl.os.kill') as mock_kill:
+                with patch('builtins.print'):
+                    self.assertEqual(ctl.cmd_stop(3389, inst), 0)
+        mock_pid.assert_called_once_with(3389, inst)
         mock_kill.assert_called_once_with(1234, signal.SIGTERM)
 
 
@@ -1152,7 +1231,7 @@ class TestPairMain(unittest.TestCase):
     def test_waits_for_the_code_ttl(self):
         with patch('trustmux._pair._wait_for_pair', return_value='10.0.0.4') as w:
             pair.main()
-        w.assert_called_once_with(60)
+        w.assert_called_once_with(60, ctl.Instance())
 
 
 if __name__ == '__main__':

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -47,11 +47,24 @@ def tearDownModule():
     _tmp_root.cleanup()
 
 
-def write_pid(inst, pid):
-    """Give inst a pid file containing pid."""
+def write_pid(inst, pid, port=None):
+    """Give inst a pid file naming pid, optionally on port."""
     inst.ensure_dirs()
-    inst.pid_file.write_text(str(pid))
+    if port is None:
+        inst.pid_file.write_text(str(pid))      # pre-port format
+    else:
+        ctl.write_pid_file(inst, pid, port)
     return inst.pid_file
+
+
+def no_socket():
+    """This instance has no daemon: nothing accepts on its admin socket."""
+    return patch('trustmux._ctl.socket_is_live', return_value=False)
+
+
+def wedged_socket():
+    """A daemon is there -- the socket accepts -- but it never replies."""
+    return patch('trustmux._ctl.socket_is_live', return_value=True)
 
 
 # ---------------------------------------------------------------------------
@@ -59,95 +72,89 @@ def write_pid(inst, pid):
 # ---------------------------------------------------------------------------
 
 class TestPid(unittest.TestCase):
-    """lsof's answer (found or not-found) is trusted outright and is final --
-    it directly observes what owns the requested port. The only fallback is
-    asking the running daemon what port *it* is on, which is used solely
-    when lsof itself cannot run at all, and only trusted when the daemon's
-    reported port matches the one actually being asked about.
+    """_pid() has to answer two questions at once -- "is this daemon ours?"
+    and "is it on the port asked about?" -- and it answers both from inside
+    the instance's own state directory: the admin socket and the pid file.
 
-    There must be no fallback that can return a pid without confirming it
-    owns the *requested* port: that is what let a stale/unrelated PIDFILE
-    entry cause `_pid(port)` to return a different daemon's pid for a port
-    nothing was listening on, and in turn let `trustmux stop --port <wrong>`
-    kill the wrong daemon (see TestPidCrossPortRegression below)."""
+    Nothing system-wide is consulted, which is deliberate. Two invariants,
+    each from a shipped bug:
+
+    * Never return a pid without confirming it owns the *requested* port --
+      what let a stale PIDFILE entry make `trustmux stop --port <wrong>` kill
+      the wrong daemon (see TestPidCrossPortRegression below).
+    * Never return a pid this instance does not claim -- asking the system who
+      holds a port answers for the whole machine, so it let a scratch instance
+      report and stop a real daemon sharing its port (see
+      TestPidInstanceIsolation below)."""
 
     def setUp(self):
         self.inst = ctl.Instance('pidtest')
         self.inst.ensure_dirs()
         self.addCleanup(shutil.rmtree, self.inst.state, True)
 
-    def test_lsof_returns_pid(self):
-        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
+    def test_our_daemons_own_reply_is_authoritative(self):
+        # A reply on this instance's private socket names both the pid and the
+        # port it actually bound, so nothing else needs asking. This is also
+        # the only path that works in a network namespace whose listening
+        # sockets are invisible from where the CLI runs.
+        with patch('trustmux._ctl.daemon_info',
+                   return_value={'pid': 4321, 'port': 3389}):
+            self.assertEqual(ctl._pid(3389, self.inst), 4321)
+
+    def test_our_daemon_reporting_a_different_port_is_not_on_this_one(self):
+        with patch('trustmux._ctl.daemon_info',
+                   return_value={'pid': 4321, 'port': 7432}):
+            self.assertIsNone(ctl._pid(3389, self.inst))
+
+    def test_a_junk_pid_from_the_daemon_is_not_believed(self):
+        with patch('trustmux._ctl.daemon_info',
+                   return_value={'pid': 'not-a-pid', 'port': 3389}):
+            self.assertIsNone(ctl._pid(3389, self.inst))
+
+    def test_a_wedged_daemon_is_still_found_via_its_pid_file(self):
+        # No reply, but the socket still accepts: the daemon is alive and just
+        # not answering. This is what lets `stop` kill a hung daemon.
+        write_pid(self.inst, 1234, 3389)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
             self.assertEqual(ctl._pid(3389, self.inst), 1234)
 
-    def test_lsof_first_pid_when_this_instance_has_no_claim(self):
-        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
-            self.assertEqual(ctl._pid(3389, self.inst), 1234)
+    def test_a_wedged_daemon_recorded_on_another_port_is_not_on_this_one(self):
+        write_pid(self.inst, 1234, 7432)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
-    def test_lsof_empty_output_is_definitive_none(self):
-        # lsof ran fine, found nothing: no fallback, no daemon_info() call.
-        with patch('trustmux._ctl.subprocess.check_output', return_value=''):
-            with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389, self.inst))
-        mock_info.assert_not_called()
+    def test_a_dead_socket_means_not_running_however_live_the_pid_file(self):
+        # SIGKILLed daemon: the socket file survives but refuses connections.
+        # A pid file naming a genuinely live (recycled) pid must not override
+        # that -- the socket is what proves this instance has a daemon.
+        write_pid(self.inst, 9999, 3389)
+        with no_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
-    def test_lsof_called_process_error_is_definitive_none(self):
-        # The real, common case: lsof -ti:<port> exits non-zero when nothing
-        # matches. Must NOT fall through to a port-blind fallback.
-        import subprocess
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=subprocess.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.daemon_info') as mock_info:
-                self.assertIsNone(ctl._pid(3389, self.inst))
-        mock_info.assert_not_called()
+    def test_a_dead_pid_in_the_pid_file_is_not_returned(self):
+        write_pid(self.inst, 9999, 3389)
+        with wedged_socket(), patch('trustmux._ctl.os.kill',
+                                    side_effect=ProcessLookupError):
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
-    def test_a_live_pidfile_cannot_conjure_a_pid_for_an_idle_port(self):
-        # Same invariant as above, with this instance's pid file naming a
-        # genuinely live process: still None, because nothing holds the port.
-        import subprocess
-        write_pid(self.inst, 9999)
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=subprocess.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.os.kill', return_value=None):
-                self.assertIsNone(ctl._pid(3389, self.inst))
+    def test_no_socket_and_no_pid_file_is_not_running(self):
+        with no_socket():
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
-    def test_lsof_missing_falls_back_to_daemon_info_matching_port(self):
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=FileNotFoundError):
-            with patch('trustmux._ctl.daemon_info',
-                       return_value={'pid': 4321, 'port': 3389}):
-                self.assertEqual(ctl._pid(3389, self.inst), 4321)
+    def test_a_pre_port_pid_file_can_no_longer_place_the_daemon(self):
+        # Upgrade case: a pid file written before the port was recorded still
+        # identifies the daemon, but cannot say which port it is on, so it
+        # must not be credited with one. The socket path covers the normal
+        # case, and the next start rewrites the file.
+        write_pid(self.inst, 1234)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
-    def test_lsof_missing_and_daemon_info_reports_different_port(self):
-        # The exact regression this class exists to prevent: a live daemon
-        # on some OTHER port must never be returned for the requested one.
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=FileNotFoundError):
-            with patch('trustmux._ctl.daemon_info',
-                       return_value={'pid': 4321, 'port': 7432}):
-                self.assertIsNone(ctl._pid(3389, self.inst))
-
-    def test_lsof_missing_and_no_daemon_answers(self):
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=FileNotFoundError):
-            with patch('trustmux._ctl.daemon_info', return_value=None):
-                self.assertIsNone(ctl._pid(3389, self.inst))
-
-    def test_lsof_missing_and_daemon_info_reports_junk_pid(self):
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=FileNotFoundError):
-            with patch('trustmux._ctl.daemon_info',
-                       return_value={'pid': 'not-a-pid', 'port': 3389}):
-                self.assertIsNone(ctl._pid(3389, self.inst))
-
-    def test_lsof_full_listing_is_treated_as_unusable_not_as_a_pid(self):
-        # An lsof that does not understand -ti:<port> prints a whole table
-        # instead of failing; its columns must not be misread as pids.
-        listing = '1084\t/usr/lib/systemd/systemd\t0\t/dev/null\n'
-        with patch('trustmux._ctl.subprocess.check_output', return_value=listing):
-            with patch('trustmux._ctl.daemon_info', return_value=None) as mock_info:
-                self.assertIsNone(ctl._pid(3389, self.inst))
-        mock_info.assert_called_once()
+    def test_a_garbled_pid_file_is_ignored_not_fatal(self):
+        write_pid(self.inst, 0)
+        self.inst.pid_file.write_text('not a pid at all\n')
+        with wedged_socket():
+            self.assertIsNone(ctl._pid(3389, self.inst))
 
 
 # ---------------------------------------------------------------------------
@@ -155,34 +162,74 @@ class TestPid(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestPidInstanceAttribution(unittest.TestCase):
-    """Two daemons may share a port on different addresses (127.0.0.1:7432 and
-    192.168.1.5:7432), so lsof reports both pids. The instance's own pid file
-    says which of them is ours -- but only ever to *choose among* processes
-    already known to hold the port, never to invent one."""
+    """Two daemons may share a port on different addresses (127.0.0.4:3339 and
+    127.9.9.9:3339), or sit in different network namespaces entirely. Either
+    way "who holds the port" is ambiguous or unanswerable system-wide, so
+    attribution comes from each instance's own socket and pid file."""
 
     def setUp(self):
-        self.inst = ctl.Instance('attrib')
+        self.a = ctl.Instance('attrib-a')
+        self.b = ctl.Instance('attrib-b')
+        for i in (self.a, self.b):
+            i.ensure_dirs()
+            self.addCleanup(shutil.rmtree, i.state, True)
+
+    def test_each_instance_reports_its_own_daemon_on_the_shared_port(self):
+        replies = {self.a.sock: {'pid': 1111, 'port': 3339},
+                   self.b.sock: {'pid': 2222, 'port': 3339}}
+        with patch('trustmux._ctl.daemon_info',
+                   side_effect=lambda i: replies[i.sock]):
+            self.assertEqual(ctl._pid(3339, self.a), 1111)
+            self.assertEqual(ctl._pid(3339, self.b), 2222)
+
+    def test_a_wedged_instance_is_attributed_from_its_own_pid_file(self):
+        write_pid(self.a, 1111, 3339)
+        write_pid(self.b, 2222, 3339)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertEqual(ctl._pid(3339, self.a), 1111)
+            self.assertEqual(ctl._pid(3339, self.b), 2222)
+
+
+# ---------------------------------------------------------------------------
+# Regression: an instance must never be told about, or act on, a daemon it
+# does not own. Reported live against this PR: with a real daemon on the
+# default port and a scratch $TRUSTMUX_STATE_DIR never started in, `status`
+# printed the real daemon's pid and `stop` would have SIGTERMed it.
+# ---------------------------------------------------------------------------
+
+class TestPidInstanceIsolation(unittest.TestCase):
+    """An instance with no claim of its own -- nothing accepting on its socket,
+    no pid file -- is not running, whatever else holds the port."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('isolation')
         self.inst.ensure_dirs()
         self.addCleanup(shutil.rmtree, self.inst.state, True)
 
-    def test_prefers_own_pid_over_whichever_lsof_listed_first(self):
-        write_pid(self.inst, 5678)
-        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
-            with patch('trustmux._ctl.os.kill', return_value=None):
-                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+    def test_an_unstarted_instance_does_not_adopt_a_daemon_on_its_port(self):
+        with no_socket():
+            self.assertIsNone(ctl._pid(7432, self.inst))
 
-    def test_another_instances_daemon_on_our_port_is_not_ours(self):
-        # Our pid file names a live daemon, but it is not the one holding this
-        # port -- so this instance is not running on it.
-        write_pid(self.inst, 5678)
-        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n'):
-            with patch('trustmux._ctl.os.kill', return_value=None):
-                self.assertIsNone(ctl._pid(7432, self.inst))
+    def test_status_of_an_unstarted_instance_reports_not_running(self):
+        with no_socket(), patch('builtins.print') as mock_print:
+            result = ctl.cmd_status(7432, self.inst)
+        self.assertEqual(result, 0)
+        printed = ' '.join(str(c) for c in mock_print.call_args_list)
+        self.assertIn('not running', printed)
 
-    def test_admin_socket_attributes_when_the_pidfile_is_gone(self):
-        with patch('trustmux._ctl.subprocess.check_output', return_value='1234\n5678\n'):
-            with patch('trustmux._ctl.daemon_info', return_value={'pid': 5678}):
-                self.assertEqual(ctl._pid(7432, self.inst), 5678)
+    def test_stop_in_an_unstarted_instance_signals_nothing(self):
+        with no_socket(), patch('trustmux._ctl.os.kill') as mock_kill:
+            with patch('builtins.print'):
+                result = ctl.cmd_stop(7432, self.inst)
+        self.assertEqual(result, 0)
+        mock_kill.assert_not_called()
+
+    def test_nothing_in_this_path_shells_out(self):
+        # The whole point: answering "is my daemon running?" must not ask the
+        # system a machine-wide question, so it must not run a subprocess.
+        with no_socket(), patch('trustmux._ctl.subprocess.check_output',
+                                side_effect=AssertionError('must not shell out')):
+            self.assertIsNone(ctl._pid(7432, self.inst))
 
 
 # ---------------------------------------------------------------------------
@@ -199,56 +246,40 @@ class TestPidCrossPortRegression(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.inst.state, True)
 
     def test_stop_on_unrelated_port_does_not_kill_the_real_daemon(self):
-        import subprocess as sp
-        # Real daemon is on 3389 (the pid file reflects it, and it is
-        # genuinely alive); lsof is queried for 4444, where nothing listens,
-        # and genuinely finds nothing. Must never send SIGTERM to the pid the
-        # pid file names -- only the harmless liveness probe (signal 0), used
-        # to decide whether to also clean the pid file up.
-        write_pid(self.inst, 3141)
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=sp.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
-                    with patch('builtins.print'):
-                        result = ctl.cmd_stop(4444, self.inst)
+        # Our daemon is genuinely alive on 3389; `stop --port 4444` asks about
+        # a port nothing is on. Must never send SIGTERM to the pid the pid file
+        # names -- only the harmless liveness probe (signal 0), used to decide
+        # whether to also clean the pid file up.
+        write_pid(self.inst, 3141, 3389)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None) as mock_kill:
+            with patch('builtins.print'):
+                result = ctl.cmd_stop(4444, self.inst)
         self.assertNotIn(call(3141, signal.SIGTERM), mock_kill.call_args_list)
         for c in mock_kill.call_args_list:
             self.assertEqual(c, call(3141, 0))   # liveness probes only
         self.assertEqual(result, 0)
 
     def test_live_pidfile_survives_a_stop_on_a_different_port(self):
-        import subprocess as sp
-        write_pid(self.inst, 3141)
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=sp.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl.os.kill', return_value=None):
-                    with patch('builtins.print'):
-                        ctl.cmd_stop(4444, self.inst)
+        write_pid(self.inst, 3141, 3389)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            with patch('builtins.print'):
+                ctl.cmd_stop(4444, self.inst)
         self.assertTrue(self.inst.pid_file.exists())
 
     def test_dead_pidfile_is_cleaned_up(self):
-        import subprocess as sp
-        write_pid(self.inst, 3141)
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=sp.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
-                    with patch('builtins.print'):
-                        ctl.cmd_stop(4444, self.inst)
+        write_pid(self.inst, 3141, 3389)
+        with no_socket(), patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+            with patch('builtins.print'):
+                ctl.cmd_stop(4444, self.inst)
         self.assertFalse(self.inst.pid_file.exists())
 
     def test_start_on_unrelated_port_is_not_falsely_refused(self):
-        import subprocess as sp
-        with patch('trustmux._ctl.subprocess.check_output',
-                   side_effect=sp.CalledProcessError(1, 'lsof')):
-            with patch('trustmux._ctl.daemon_info', return_value=None):
-                with patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
-                    with patch('builtins.print'):
-                        result = ctl.cmd_start('start-local', 4444, self.inst)
+        with no_socket(), patch('trustmux._ctl._launch', return_value=1234) as mock_launch:
+            with patch('builtins.print'):
+                result = ctl.cmd_start('start-local', 4444, self.inst)
         mock_launch.assert_called_once()
         self.assertEqual(result, 0)
+
 
 # ---------------------------------------------------------------------------
 # _ts_host()
@@ -486,14 +517,14 @@ class TestCmdStart(unittest.TestCase):
                         self.assertEqual(ctl.cmd_start('start-direct'), 0)
 
     def test_returns_1_when_launch_fails(self):
-        with patch('trustmux._ctl._pid', return_value=None):
-            with patch('trustmux._ctl._check_tmux', return_value=True):
-                with patch('trustmux._ctl._check_tls', return_value=True):
-                    with patch('trustmux._ctl.subprocess.run'):
-                        with patch('trustmux._ctl._ts_host', return_value='engawa.ts.net'):
-                            with patch('trustmux._ctl._ensure_ts_serve', return_value=True):
-                                with patch('trustmux._ctl._launch', return_value=None):
-                                    self.assertEqual(ctl.cmd_start('serve'), 1)
+        with patch('trustmux._ctl._pid', return_value=None), \
+             patch('trustmux._ctl._check_tmux', return_value=True), \
+             patch('trustmux._ctl._check_tls', return_value=True), \
+             patch('trustmux._ctl.subprocess.run'), \
+             patch('trustmux._ctl._ts_host', return_value='engawa.ts.net'), \
+             patch('trustmux._ctl._ensure_ts_serve', return_value=True), \
+             patch('trustmux._ctl._launch', return_value=None):
+            self.assertEqual(ctl.cmd_start('serve'), 1)
 
     def test_unknown_mode_returns_1(self):
         with patch('trustmux._ctl._pid', return_value=None):
@@ -515,24 +546,30 @@ class TestCmdStop(unittest.TestCase):
         with patch('trustmux._ctl._pid', return_value=None):
             self.assertEqual(ctl.cmd_stop(inst=self.inst), 0)
 
+    def _signals(self, mock_kill):
+        """Real signals sent, dropping the harmless signal-0 liveness probes."""
+        return [c for c in mock_kill.call_args_list if c.args[1] != 0]
+
     def test_kills_process_and_removes_pidfile(self):
-        write_pid(self.inst, 4321)
+        write_pid(self.inst, 4321, 7432)
         with patch('trustmux._ctl._pid', return_value=4321):
             with patch('trustmux._ctl.os.kill') as mock_kill:
                 result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 0)
-        mock_kill.assert_called_once_with(4321, signal.SIGTERM)
+        self.assertEqual(self._signals(mock_kill), [call(4321, signal.SIGTERM)])
         self.assertFalse(self.inst.pid_file.exists())
 
     def test_pidfile_mismatch_refuses_to_kill(self):
-        write_pid(self.inst, 9999)
+        write_pid(self.inst, 9999, 7432)
         with patch('trustmux._ctl._pid', return_value=4321):
             with patch('trustmux._ctl.os.kill') as mock_kill:
                 result = ctl.cmd_stop(inst=self.inst)
         self.assertEqual(result, 1)
-        mock_kill.assert_not_called()
+        self.assertEqual(self._signals(mock_kill), [])
 
     def test_no_pidfile_still_kills(self):
+        # A pid with no pid file backing it can now only have come from this
+        # instance's own admin socket, so it is still ours to signal.
         with patch('trustmux._ctl._pid', return_value=4321):
             with patch('trustmux._ctl.os.kill') as mock_kill:
                 result = ctl.cmd_stop(inst=self.inst)
@@ -957,6 +994,25 @@ class TestResolvePort(unittest.TestCase):
         with patch('trustmux._ctl.daemon_info', return_value={'port': 'wat'}):
             self.assertEqual(ctl.resolve_port(), ctl.DEFAULT_PORT)
 
+    def test_falls_back_to_the_recorded_port_for_a_wedged_daemon(self):
+        # Without this, `stop`/`status` on a daemon that stopped replying would
+        # be asked about DEFAULT_PORT, not the port it was started on, and so
+        # would report it as not running -- verified live with SIGSTOP.
+        inst = ctl.Instance('wedgedport')
+        write_pid(inst, 4321, 5555)
+        self.addCleanup(shutil.rmtree, inst.state, True)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertEqual(ctl.resolve_port(inst=inst), 5555)
+
+    def test_a_recorded_port_is_ignored_once_the_socket_is_dead(self):
+        # SIGKILLed daemon: the pid file survives and its pid may even be
+        # recycled, so `start` must not be diverted to a port nobody asked for.
+        inst = ctl.Instance('deadport')
+        write_pid(inst, 4321, 5555)
+        self.addCleanup(shutil.rmtree, inst.state, True)
+        with no_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            self.assertEqual(ctl.resolve_port(inst=inst), ctl.DEFAULT_PORT)
+
     def test_blank_env_is_ignored(self):
         os.environ[ctl.PORT_ENV] = '   '
         self.assertEqual(ctl.resolve_port(), ctl.DEFAULT_PORT)
@@ -1329,9 +1385,20 @@ class TestCmdList(unittest.TestCase):
         self.assertIn('running (pid 4321)', out)
 
     def test_reports_stopped_instances(self):
-        with patch('trustmux._ctl._recorded_pid', return_value=None):
+        with no_socket():
             rc, out = self._run()
         self.assertIn('stopped', out)
+
+    def test_reports_a_wedged_instance_from_its_pid_file(self):
+        # Socket accepts but never replies: still running, and the pid file
+        # supplies the port that the daemon can no longer be asked for.
+        inst = ctl.Instance('wedged')
+        write_pid(inst, 4321, 3389)
+        self.addCleanup(shutil.rmtree, inst.state, True)
+        with wedged_socket(), patch('trustmux._ctl.os.kill', return_value=None):
+            rc, out = self._run()
+        self.assertIn('running (pid 4321)', out)
+        self.assertIn('3389', out)
 
 
 class TestPerInstanceHooks(unittest.TestCase):

--- a/mobile/tests/test_ctl.py
+++ b/mobile/tests/test_ctl.py
@@ -1366,6 +1366,119 @@ class TestInstanceIsolation(unittest.TestCase):
         self.assertEqual(mock_pid.call_args[0][1], work)
 
 
+# ---------------------------------------------------------------------------
+# cmd_rm()
+# ---------------------------------------------------------------------------
+
+class TestCmdRm(unittest.TestCase):
+    """Instances are created implicitly by the first start, so there has to be
+    a way to undo that -- including the secrets the directory holds."""
+
+    def setUp(self):
+        self.inst = ctl.Instance('rmtest')
+        self.inst.ensure_dirs()
+        self.inst.tokens_file.write_text('{}')
+        self.addCleanup(shutil.rmtree, self.inst.state, True)
+
+    def _rm(self, inst=None, force=False):
+        with patch('builtins.print') as mock_print:
+            rc = ctl.cmd_rm(inst or self.inst, force)
+        return rc, ' '.join(str(c) for c in mock_print.call_args_list)
+
+    def test_removes_a_stopped_instance(self):
+        with no_socket():
+            rc, out = self._rm()
+        self.assertEqual(rc, 0)
+        self.assertFalse(self.inst.state.exists())
+
+    def test_says_when_tokens_were_discarded(self):
+        with no_socket():
+            rc, out = self._rm()
+        self.assertIn('pair again', out)
+
+    def test_unknown_instance_is_an_error(self):
+        rc, out = self._rm(ctl.Instance('never-existed'))
+        self.assertEqual(rc, 1)
+
+    def test_refuses_while_running(self):
+        with patch('trustmux._ctl._pid', return_value=4321):
+            rc, out = self._rm()
+        self.assertEqual(rc, 1)
+        self.assertTrue(self.inst.state.exists())
+
+    def test_force_stops_a_running_instance_then_removes_it(self):
+        with patch('trustmux._ctl._pid', return_value=4321):
+            with patch('trustmux._ctl.cmd_stop', return_value=0) as mock_stop:
+                with patch('trustmux._ctl.os.kill', side_effect=ProcessLookupError):
+                    rc, out = self._rm(force=True)
+        self.assertEqual(rc, 0)
+        mock_stop.assert_called_once()
+        self.assertFalse(self.inst.state.exists())
+
+    def test_a_failed_stop_removes_nothing(self):
+        with patch('trustmux._ctl._pid', return_value=4321):
+            with patch('trustmux._ctl.cmd_stop', return_value=1):
+                rc, out = self._rm(force=True)
+        self.assertEqual(rc, 1)
+        self.assertTrue(self.inst.state.exists())
+
+    def test_refuses_the_default_instance_without_force(self):
+        default = ctl.Instance()
+        default.ensure_dirs()
+        self.addCleanup(shutil.rmtree, default.state, True)
+        with no_socket():
+            rc, out = self._rm(default)
+        self.assertEqual(rc, 1)
+        self.assertTrue(default.state.exists())
+        self.assertIn('--force', out)
+
+    def test_force_removes_the_default_instance(self):
+        default = ctl.Instance()
+        default.ensure_dirs()
+        self.addCleanup(shutil.rmtree, default.state, True)
+        with no_socket():
+            rc, out = self._rm(default, force=True)
+        self.assertEqual(rc, 0)
+        self.assertFalse(default.state.exists())
+
+    def test_the_login_hook_goes_too(self):
+        # Otherwise the next login starts the instance again and recreates
+        # everything that was just deleted.
+        with no_socket():
+            with patch('trustmux._disable._remove_hook') as mock_hook:
+                ctl.cmd_rm(self.inst)
+        self.assertTrue(mock_hook.called)
+        self.assertEqual(mock_hook.call_args[0][1], self.inst)
+
+    def test_a_symlinked_state_dir_loses_the_link_not_the_target(self):
+        target = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, target, True)
+        (target / 'tokens.json').write_text('{}')
+        linked = ctl.Instance('symlinked')
+        shutil.rmtree(linked.state, ignore_errors=True)
+        linked.state.parent.mkdir(parents=True, exist_ok=True)
+        linked.state.symlink_to(target)
+        self.addCleanup(lambda: linked.state.unlink(missing_ok=True))
+        with no_socket():
+            rc, out = self._rm(linked)
+        self.assertEqual(rc, 0)
+        self.assertFalse(linked.state.is_symlink())
+        self.assertTrue((target / 'tokens.json').exists())   # target untouched
+
+    def test_refuses_a_target_outside_the_instances_directory(self):
+        # cmd_rm is callable directly, so the containment check must not rely
+        # on resolve_instance() having vetted the name.
+        outside = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, outside, True)
+        (outside / 'precious').write_text('do not delete')
+        rogue = ctl.Instance('rogue')
+        with patch.object(type(rogue), 'state',
+                          property(lambda self: outside)):
+            rc, out = self._rm(rogue)
+        self.assertEqual(rc, 1)
+        self.assertTrue((outside / 'precious').exists())
+
+
 class TestCmdList(unittest.TestCase):
 
     def setUp(self):

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -463,5 +463,68 @@ class TestMainHelp(unittest.TestCase):
             self.assertEqual(cm.exception.code, 0)
 
 
+class TestSelfSignedCertSans(unittest.TestCase):
+    """An advertised host has to be in the certificate.
+
+    A browser refuses a certificate that omits the name in the URL bar
+    outright, rather than offering the click-through a self-signed one gets, so
+    advertising an address without certifying it would be worse than useless.
+    """
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        root = Path(self.td.name)
+        for attr, value in (('STATE_DIR', root), ('CERT_FILE', root / 'cert.pem'),
+                            ('KEY_FILE', root / 'key.pem')):
+            p = patch.object(bm, attr, value)
+            p.start()
+            self.addCleanup(p.stop)
+        # Keep the local-discovery SANs deterministic.
+        p = patch.object(bm, '_tailscale_ip', return_value=None)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _sans(self, lan_ip, advertised=()):
+        from cryptography import x509
+        from cryptography.x509.oid import ExtensionOID
+        with patch('builtins.print'):
+            bm._ensure_self_signed_cert(lan_ip, advertised)
+        cert = x509.load_pem_x509_certificate(bm.CERT_FILE.read_bytes())
+        ext = cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value
+        return ([str(ip) for ip in ext.get_values_for_type(x509.IPAddress)],
+                ext.get_values_for_type(x509.DNSName))
+
+    def test_advertised_ip_becomes_an_ip_san(self):
+        ips, _ = self._sans('10.128.0.7', ['34.1.2.3'])
+        self.assertIn('34.1.2.3', ips)
+        self.assertIn('10.128.0.7', ips)     # the local one is still there
+
+    def test_advertised_name_becomes_a_dns_san(self):
+        _, names = self._sans('10.128.0.7', ['tmux.example.com'])
+        self.assertIn('tmux.example.com', names)
+
+    def test_several_advertised_hosts_all_land(self):
+        ips, names = self._sans('10.128.0.7', ['34.1.2.3', 'tmux.example.com'])
+        self.assertIn('34.1.2.3', ips)
+        self.assertIn('tmux.example.com', names)
+
+    def test_advertised_ipv6_becomes_an_ip_san(self):
+        ips, _ = self._sans('10.128.0.7', ['2001:db8::1'])
+        self.assertIn('2001:db8::1', ips)
+
+    def test_a_host_already_covered_is_not_duplicated(self):
+        ips, _ = self._sans('10.128.0.7', ['10.128.0.7', '127.0.0.1'])
+        self.assertEqual(ips.count('10.128.0.7'), 1)
+        self.assertEqual(ips.count('127.0.0.1'), 1)
+
+    def test_no_advertised_hosts_leaves_the_previous_sans_alone(self):
+        ips, names = self._sans('10.128.0.7')
+        self.assertIn('10.128.0.7', ips)
+        self.assertIn('127.0.0.1', ips)
+        self.assertIn('localhost', names)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -41,6 +41,42 @@ def _clear_sessions():
 
 
 # ---------------------------------------------------------------------------
+# Stale admin socket
+# ---------------------------------------------------------------------------
+
+class TestStaleSocket(unittest.TestCase):
+    """The state directory persists across logout and reboot, so a socket left
+    behind by a killed daemon stays on disk. Connecting is what distinguishes
+    it from one a live daemon is serving -- unlinking blindly would let a
+    second daemon steal a live socket, leaving the first unreachable."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.path = Path(self.td.name) / 'trustmux.sock'
+
+    def test_leftover_socket_file_is_stale(self):
+        import socket as _socket
+        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        s.bind(str(self.path))
+        s.listen(1)
+        s.close()                       # daemon died without unlinking
+        self.assertTrue(self.path.exists())
+        self.assertTrue(bm._socket_is_stale(self.path))
+
+    def test_live_socket_is_not_stale(self):
+        import socket as _socket
+        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        s.bind(str(self.path))
+        s.listen(1)
+        self.addCleanup(s.close)
+        self.assertFalse(bm._socket_is_stale(self.path))
+
+    def test_missing_socket_is_stale(self):
+        self.assertTrue(bm._socket_is_stale(self.path))
+
+
+# ---------------------------------------------------------------------------
 # Token persistence
 # ---------------------------------------------------------------------------
 
@@ -48,19 +84,19 @@ class TestTokenPersistence(unittest.TestCase):
     def setUp(self):
         _clear_sessions()
         self._tmpdir = tempfile.TemporaryDirectory()
-        self._orig_config = bm.CONFIG_DIR
+        self._orig_state = bm.STATE_DIR
         self._orig_tokens = bm.TOKENS_FILE
-        bm.CONFIG_DIR = Path(self._tmpdir.name) / 'trustmux'
-        bm.TOKENS_FILE = bm.CONFIG_DIR / 'tokens.json'
+        bm.STATE_DIR = Path(self._tmpdir.name) / 'trustmux'
+        bm.TOKENS_FILE = bm.STATE_DIR / 'tokens.json'
 
     def tearDown(self):
         _clear_sessions()
-        bm.CONFIG_DIR = self._orig_config
+        bm.STATE_DIR = self._orig_state
         bm.TOKENS_FILE = self._orig_tokens
         self._tmpdir.cleanup()
 
     def _write_tokens(self, data):
-        bm.CONFIG_DIR.mkdir(parents=True)
+        bm.STATE_DIR.mkdir(parents=True)
         bm.TOKENS_FILE.write_text(json.dumps(data))
 
     def test_load_missing_file_is_no_op(self):
@@ -85,7 +121,7 @@ class TestTokenPersistence(unittest.TestCase):
         self.assertNotIn('bad_missing', bm._sessions)
 
     def test_load_corrupt_json_does_not_raise(self):
-        bm.CONFIG_DIR.mkdir(parents=True)
+        bm.STATE_DIR.mkdir(parents=True)
         bm.TOKENS_FILE.write_text('not json!!!')
         bm._load_tokens()
         self.assertEqual(bm._sessions, {})
@@ -693,6 +729,14 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('tok_secret_value', body)
         self.assertNotIn(bm._pair_code, body)
         self.assertEqual(set(resp), {'state', 'expires_in'})
+
+    async def test_info_pid_identifies_which_daemon_answered(self):
+        # Two daemons each own their instance's socket, so the pid in the
+        # reply is how a caller tells them apart.
+        with patch.object(bm, '_listen',
+                          {'host': '127.0.0.1', 'port': 7432, 'scheme': 'https'}):
+            resp = await self._call({'action': 'info'})
+        self.assertEqual(resp['pid'], os.getpid())
 
     async def test_info_reports_listener(self):
         with patch.object(bm, '_listen',

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -80,7 +80,7 @@ class TestStaleSocket(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestSetInstance(unittest.TestCase):
-    """--instance repoints every path the daemon owns."""
+    """--name repoints every path the daemon owns."""
 
     def setUp(self):
         self._orig = (bm.INSTANCE, bm.STATE_DIR, bm.TOKENS_FILE,

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -794,7 +794,7 @@ class TestAdminSocket(unittest.IsolatedAsyncioTestCase):
                           {'host': '127.0.0.1', 'port': 7432, 'scheme': 'http'}):
             resp = await self._call({'action': 'info'})
         self.assertNotIn('tok_secret_value', json.dumps(resp))
-        self.assertEqual(set(resp), {'pid', 'host', 'port', 'scheme'})
+        self.assertEqual(set(resp), {'pid', 'host', 'port', 'scheme', 'advertise'})
 
     async def test_info_before_listen_is_empty_not_an_error(self):
         with patch.object(bm, '_listen', {}):

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -75,6 +75,47 @@ class TestStaleSocket(unittest.TestCase):
     def test_missing_socket_is_stale(self):
         self.assertTrue(bm._socket_is_stale(self.path))
 
+# ---------------------------------------------------------------------------
+# Instance selection
+# ---------------------------------------------------------------------------
+
+class TestSetInstance(unittest.TestCase):
+    """--instance repoints every path the daemon owns."""
+
+    def setUp(self):
+        self._orig = (bm.INSTANCE, bm.STATE_DIR, bm.TOKENS_FILE,
+                      bm.ADMIN_SOCK, bm.CERT_FILE, bm.KEY_FILE)
+
+    def tearDown(self):
+        (bm.INSTANCE, bm.STATE_DIR, bm.TOKENS_FILE,
+         bm.ADMIN_SOCK, bm.CERT_FILE, bm.KEY_FILE) = self._orig
+
+    def test_repoints_state_and_runtime(self):
+        from trustmux._paths import Instance
+        work = Instance('work')
+        bm._set_instance(work)
+        self.assertEqual(bm.TOKENS_FILE, work.tokens_file)
+        self.assertEqual(bm.ADMIN_SOCK, work.sock)
+        self.assertEqual(bm.CERT_FILE, work.cert_file)
+        self.assertEqual(bm.KEY_FILE, work.key_file)
+        self.assertEqual(bm.STATE_DIR, work.state)
+
+    def test_two_instances_never_collide(self):
+        from trustmux._paths import Instance
+        bm._set_instance(Instance('a'))
+        a = (bm.TOKENS_FILE, bm.ADMIN_SOCK, bm.CERT_FILE)
+        bm._set_instance(Instance('b'))
+        b = (bm.TOKENS_FILE, bm.ADMIN_SOCK, bm.CERT_FILE)
+        for x, y in zip(a, b):
+            self.assertNotEqual(x, y)
+
+    def test_machines_file_stays_shared(self):
+        from trustmux._paths import Instance, machines_file
+        before = bm.MACHINES_FILE
+        bm._set_instance(Instance('work'))
+        self.assertEqual(bm.MACHINES_FILE, before)
+        self.assertEqual(bm.MACHINES_FILE, machines_file())
+
 
 # ---------------------------------------------------------------------------
 # Token persistence

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -15,8 +15,8 @@ import trustmux._paths as paths
 class BaseDirs(unittest.TestCase):
     """Give each test a clean, fully-overridden environment."""
 
-    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR",
-           "XDG_CONFIG_HOME", "XDG_STATE_HOME")
+    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR", "TRUSTMUX_INSTANCE",
+           "XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_RUNTIME_DIR")
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -109,8 +109,80 @@ class TestInstancePaths(BaseDirs):
         inst.ensure_dirs()
         inst.ensure_dirs()   # must not raise
 
+    def test_label_only_set_for_non_default(self):
+        self.assertEqual(paths.Instance().label(), "")
+        self.assertEqual(paths.Instance("work").label(), " --instance work")
 
 
+class TestResolveInstance(BaseDirs):
+
+    def test_default_when_nothing_set(self):
+        self.assertEqual(paths.resolve_instance().name, "default")
+
+    def test_explicit_wins_over_env(self):
+        os.environ["TRUSTMUX_INSTANCE"] = "fromenv"
+        self.assertEqual(paths.resolve_instance("fromflag").name, "fromflag")
+
+    def test_env_used_when_no_flag(self):
+        os.environ["TRUSTMUX_INSTANCE"] = "fromenv"
+        self.assertEqual(paths.resolve_instance().name, "fromenv")
+
+    def test_accepts_reasonable_names(self):
+        for name in ("work", "a", "A1", "my-box", "my_box", "v1.2", "x" * 32):
+            self.assertEqual(paths.resolve_instance(name).name, name)
+
+    def test_rejects_traversal_and_separators(self):
+        for bad in ("..", ".", "../..", "a/b", "a/../b", "/abs", "a\\b",
+                    ".hidden", "", "x" * 33, "sp ace", "semi;colon",
+                    "$(id)", "`id`", "quo'te", "new\nline"):
+            with self.subTest(name=bad):
+                with patch("trustmux._paths.sys.stderr"):
+                    with self.assertRaises(SystemExit) as cm:
+                        paths.resolve_instance(bad)
+                self.assertEqual(cm.exception.code, 2)
+
+    def test_a_rejected_name_never_reaches_the_filesystem(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        with patch("trustmux._paths.sys.stderr"):
+            with self.assertRaises(SystemExit):
+                paths.resolve_instance("../escape")
+        self.assertEqual(list(self.root.rglob("escape")), [])
+
+
+class TestSockPathLength(BaseDirs):
+
+    def test_ok_for_a_normal_path(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "/home/u/.local/state/trustmux"
+        self.assertTrue(paths.check_sock_path(paths.Instance("work")))
+
+    def test_rejects_an_overlong_path(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "/" + "d" * 120
+        import io
+        buf = io.StringIO()
+        self.assertFalse(paths.check_sock_path(paths.Instance("work"), buf))
+        self.assertIn("unix socket", buf.getvalue())
+
+
+class TestKnownInstances(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        os.environ["TRUSTMUX_RUN_DIR"] = str(self.root / "run")
+
+    def test_empty_before_anything_exists(self):
+        self.assertEqual(paths.known_instances(), [])
+
+    def test_lists_default_first_then_alphabetical(self):
+        for name in ("zulu", "default", "alpha"):
+            paths.Instance(name).ensure_dirs()
+        self.assertEqual([i.name for i in paths.known_instances()],
+                         ["default", "alpha", "zulu"])
+
+    def test_ignores_stray_files(self):
+        paths.Instance("real").ensure_dirs()
+        (self.root / "state" / "instances" / "a-file").write_text("x")
+        self.assertEqual([i.name for i in paths.known_instances()], ["real"])
 
 
 class TestMigration(BaseDirs):

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -1,0 +1,329 @@
+"""Tests for trustmux._paths — XDG base directories and instance isolation."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import trustmux._paths as paths
+
+
+class BaseDirs(unittest.TestCase):
+    """Give each test a clean, fully-overridden environment."""
+
+    ENV = ("TRUSTMUX_CONFIG_DIR", "TRUSTMUX_STATE_DIR",
+           "XDG_CONFIG_HOME", "XDG_STATE_HOME")
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.root = Path(self.td.name)
+        self._env = patch.dict(os.environ, {}, clear=False)
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        for name in self.ENV:
+            os.environ.pop(name, None)
+
+    def home(self, *parts) -> Path:
+        return Path.home().joinpath(*parts)
+
+
+class TestXdgDefaults(BaseDirs):
+
+    def test_defaults_follow_the_spec(self):
+        self.assertEqual(paths.config_dir(), self.home(".config", "trustmux"))
+        self.assertEqual(paths.state_dir(), self.home(".local", "state", "trustmux"))
+
+    def test_xdg_vars_are_honoured(self):
+        os.environ["XDG_CONFIG_HOME"] = str(self.root / "c")
+        os.environ["XDG_STATE_HOME"] = str(self.root / "s")
+        self.assertEqual(paths.config_dir(), self.root / "c" / "trustmux")
+        self.assertEqual(paths.state_dir(), self.root / "s" / "trustmux")
+
+    def test_trustmux_vars_win_over_xdg(self):
+        os.environ["XDG_STATE_HOME"] = str(self.root / "ignored")
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "wins")
+        self.assertEqual(paths.state_dir(), self.root / "wins")
+
+    def test_xdg_runtime_dir_is_deliberately_not_used(self):
+        # systemd-logind removes /run/user/$UID at last logout without
+        # linger, which would strand a running daemon's socket.
+        os.environ["XDG_RUNTIME_DIR"] = str(self.root / "runtime")
+        inst = paths.Instance()
+        for pth in (inst.sock, inst.pid_file):
+            self.assertNotIn("runtime", str(pth))
+
+    def test_machines_file_is_shared_config_not_per_instance(self):
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.root / "c")
+        self.assertEqual(paths.machines_file(), self.root / "c" / "machines.json")
+
+    def test_blank_env_var_is_ignored(self):
+        os.environ["TRUSTMUX_STATE_DIR"] = "   "
+        self.assertEqual(paths.state_dir(), self.home(".local", "state", "trustmux"))
+
+
+class TestInstancePaths(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+
+    def test_default_instance_is_not_special_cased(self):
+        inst = paths.Instance()
+        self.assertEqual(inst.name, "default")
+        self.assertEqual(inst.state, self.root / "state" / "instances" / "default")
+
+    def test_every_daemon_owned_file_lives_in_the_state_dir(self):
+        inst = paths.Instance("work")
+        for attr in ("tokens_file", "cert_file", "key_file", "log_file",
+                     "sock", "pid_file"):
+            self.assertEqual(getattr(inst, attr).parent, inst.state, attr)
+
+    def test_nothing_the_daemon_writes_lands_in_the_config_dir(self):
+        # The whole point of the change: config holds only machines.json.
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.root / "config")
+        inst = paths.Instance()
+        for attr in ("tokens_file", "cert_file", "key_file", "log_file",
+                     "sock", "pid_file"):
+            self.assertFalse(
+                str(getattr(inst, attr)).startswith(str(self.root / "config")), attr)
+
+    def test_two_instances_share_nothing(self):
+        a, b = paths.Instance("a"), paths.Instance("b")
+        for attr in ("sock", "pid_file", "tokens_file", "log_file",
+                     "cert_file", "key_file"):
+            self.assertNotEqual(getattr(a, attr), getattr(b, attr), attr)
+
+    def test_ensure_dirs_is_private(self):
+        inst = paths.Instance("perms")
+        inst.ensure_dirs()
+        self.assertTrue(inst.state.is_dir())
+        self.assertEqual(inst.state.stat().st_mode & 0o777, 0o700)
+
+    def test_ensure_dirs_is_idempotent(self):
+        inst = paths.Instance("twice")
+        inst.ensure_dirs()
+        inst.ensure_dirs()   # must not raise
+
+
+
+
+
+class TestMigration(BaseDirs):
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        self.legacy = self.root / "legacy"
+        self.legacy.mkdir()
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.legacy)
+
+    def _legacy_file(self, name, content="x", mode=0o600):
+        p = self.legacy / name
+        p.write_text(content)
+        p.chmod(mode)
+        return p
+
+    def test_no_op_when_nothing_to_migrate(self):
+        self.assertFalse(paths.migrate_legacy_layout(stream=None))
+
+    def test_moves_state_files_into_default_instance(self):
+        self._legacy_file("tokens.json", '{"tok": {}}')
+        self._legacy_file("cert.pem", "cert", 0o644)
+        self._legacy_file("key.pem", "key")
+        self._legacy_file("trustmux.log", "log")
+        import io
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        target = paths.Instance().state
+        self.assertEqual((target / "tokens.json").read_text(), '{"tok": {}}')
+        self.assertEqual((target / "key.pem").read_text(), "key")
+        self.assertEqual((target / "trustmux.log").read_text(), "log")
+
+    def test_leaves_no_copy_behind(self):
+        self._legacy_file("tokens.json")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertFalse((self.legacy / "tokens.json").exists())
+
+    def test_preserves_0600_on_secrets(self):
+        self._legacy_file("tokens.json", '{}', 0o600)
+        self._legacy_file("key.pem", "key", 0o600)
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        target = paths.Instance().state
+        for name in ("tokens.json", "key.pem"):
+            self.assertEqual((target / name).stat().st_mode & 0o777, 0o600, name)
+
+    def test_target_directory_is_private(self):
+        self._legacy_file("tokens.json")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertEqual(paths.Instance().state.stat().st_mode & 0o777, 0o700)
+
+    def test_idempotent_second_run_does_nothing(self):
+        self._legacy_file("tokens.json")
+        import io
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        self.assertFalse(paths.migrate_legacy_layout(stream=io.StringIO()))
+
+    def test_does_not_clobber_an_existing_instance(self):
+        target = paths.Instance().state
+        target.mkdir(parents=True)
+        (target / "tokens.json").write_text("new")
+        self._legacy_file("tokens.json", "old")
+        self.assertFalse(paths.migrate_legacy_layout(stream=None))
+        self.assertEqual((target / "tokens.json").read_text(), "new")
+
+    def test_isolated_by_config_dir_override(self):
+        # The legacy location follows $TRUSTMUX_CONFIG_DIR, so an overridden
+        # run never reaches into the real ~/.config/trustmux.
+        self.assertEqual(paths.legacy_dir(), self.legacy)
+
+    def test_survives_a_cross_filesystem_move(self):
+        # os.replace raises EXDEV when state lives on another filesystem.
+        import errno, io
+        self._legacy_file("tokens.json", "secret", 0o600)
+        real_replace = os.replace
+
+        def fake_replace(src, dst, *a, **kw):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        with patch("trustmux._paths.os.replace", side_effect=fake_replace):
+            self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        target = paths.Instance().state / "tokens.json"
+        self.assertEqual(target.read_text(), "secret")
+        self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+        self.assertFalse((self.legacy / "tokens.json").exists())
+
+    def test_a_failed_move_does_not_raise(self):
+        import io
+        self._legacy_file("tokens.json")
+        buf = io.StringIO()
+        with patch("trustmux._paths._move_preserving_mode",
+                   side_effect=OSError("boom")):
+            self.assertFalse(paths.migrate_legacy_layout(stream=buf))
+        self.assertIn("could not move", buf.getvalue())
+        # Left in place for a retry rather than lost.
+        self.assertTrue((self.legacy / "tokens.json").exists())
+
+    def test_retries_only_what_is_still_pending(self):
+        import io
+        self._legacy_file("tokens.json", "tok")
+        self._legacy_file("key.pem", "key")
+        target = paths.Instance().state
+        target.mkdir(parents=True)
+        (target / "tokens.json").write_text("already there")
+        self.assertTrue(paths.migrate_legacy_layout(stream=io.StringIO()))
+        self.assertEqual((target / "tokens.json").read_text(), "already there")
+        self.assertEqual((target / "key.pem").read_text(), "key")
+
+    def test_leaves_legacy_socket_and_pidfile_alone(self):
+        # A pre-upgrade daemon may still be serving on that socket.
+        self._legacy_file("tokens.json")
+        self._legacy_file("trustmux.sock")
+        self._legacy_file("trustmux.pid", "123")
+        import io
+        paths.migrate_legacy_layout(stream=io.StringIO())
+        self.assertTrue((self.legacy / "trustmux.sock").exists())
+        self.assertTrue((self.legacy / "trustmux.pid").exists())
+
+
+
+class TestMigrationHardening(BaseDirs):
+    """Directory-migration code has a history of breaking long-time byobu
+    users (LP #674217), so exercise the ugly cases, not just the happy path."""
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
+        self.legacy = self.root / "legacy"
+        self.legacy.mkdir()
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.legacy)
+
+    def _migrate(self):
+        import io
+        buf = io.StringIO()
+        return paths.migrate_legacy_layout(stream=buf), buf.getvalue()
+
+    def test_tokens_survive_byte_for_byte(self):
+        # Losing a token means every paired phone silently stops working.
+        blob = '{"tok_%s": {"ip": "10.0.0.1", "paired_at": 1.5}}' % ("x" * 300)
+        (self.legacy / "tokens.json").write_text(blob)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(), blob)
+
+    def test_binary_keypair_survives_unchanged(self):
+        blob = bytes(range(256)) * 4
+        (self.legacy / "key.pem").write_bytes(blob)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "key.pem").read_bytes(), blob)
+
+    def test_unreadable_legacy_file_is_reported_not_fatal(self):
+        (self.legacy / "tokens.json").write_text("secret")
+        (self.legacy / "cert.pem").write_text("cert")
+        with patch("trustmux._paths._move_preserving_mode",
+                   side_effect=[None, OSError("permission denied")]):
+            moved, msg = self._migrate()
+        self.assertIn("could not move", msg)
+
+    def test_unwritable_target_parent_is_reported_not_fatal(self):
+        (self.legacy / "tokens.json").write_text("secret")
+        with patch("trustmux._paths.Path.mkdir", side_effect=PermissionError("nope")):
+            moved, msg = self._migrate()
+        self.assertFalse(moved)
+        self.assertIn("cannot create", msg)
+        # The original is untouched, so a fixed-up retry still works.
+        self.assertEqual((self.legacy / "tokens.json").read_text(), "secret")
+
+    def test_a_legacy_symlink_is_followed_to_its_content(self):
+        real = self.root / "elsewhere.json"
+        real.write_text("via symlink")
+        (self.legacy / "tokens.json").symlink_to(real)
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(),
+                         "via symlink")
+
+    def test_partial_migration_completes_on_the_next_run(self):
+        (self.legacy / "tokens.json").write_text("tok")
+        (self.legacy / "key.pem").write_text("key")
+        calls = {"n": 0}
+        real = paths._move_preserving_mode
+
+        def flaky(src, dst):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("transient")
+            real(src, dst)
+
+        with patch("trustmux._paths._move_preserving_mode", side_effect=flaky):
+            self._migrate()
+        self._migrate()                      # retry picks up what was left
+        state = paths.Instance().state
+        self.assertEqual((state / "tokens.json").read_text(), "tok")
+        self.assertEqual((state / "key.pem").read_text(), "key")
+
+    def test_nothing_is_moved_twice_over_a_repeated_run(self):
+        (self.legacy / "tokens.json").write_text("first")
+        self._migrate()
+        # A daemon writes new tokens after the upgrade...
+        (paths.Instance().state / "tokens.json").write_text("second")
+        # ...and a stray legacy file reappears somehow.
+        (self.legacy / "tokens.json").write_text("resurrected")
+        self._migrate()
+        self.assertEqual((paths.Instance().state / "tokens.json").read_text(),
+                         "second")
+
+    def test_config_only_install_migrates_nothing(self):
+        # machines.json is config and must stay exactly where it is.
+        (self.legacy / "machines.json").write_text("[]")
+        moved, _ = self._migrate()
+        self.assertFalse(moved)
+        self.assertTrue((self.legacy / "machines.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -351,13 +351,28 @@ class TestMigrationHardening(BaseDirs):
         # The original is untouched, so a fixed-up retry still works.
         self.assertEqual((self.legacy / "tokens.json").read_text(), "secret")
 
-    def test_a_legacy_symlink_is_followed_to_its_content(self):
+    def test_a_legacy_symlink_is_dereferenced_not_relinked(self):
+        # Renaming the link itself would leave the state directory holding a
+        # pointer back to the old location rather than owning the secret --
+        # and reading through it would still return the right bytes, so the
+        # content assertion alone does not catch it.
         real = self.root / "elsewhere.json"
         real.write_text("via symlink")
         (self.legacy / "tokens.json").symlink_to(real)
         self._migrate()
-        self.assertEqual((paths.Instance().state / "tokens.json").read_text(),
-                         "via symlink")
+        moved = paths.Instance().state / "tokens.json"
+        self.assertFalse(moved.is_symlink())
+        self.assertEqual(moved.read_text(), "via symlink")
+        self.assertFalse((self.legacy / "tokens.json").exists())
+
+    def test_a_dereferenced_symlink_keeps_the_targets_mode(self):
+        real = self.root / "secret.pem"
+        real.write_text("key")
+        real.chmod(0o600)
+        (self.legacy / "key.pem").symlink_to(real)
+        self._migrate()
+        moved = paths.Instance().state / "key.pem"
+        self.assertEqual(moved.stat().st_mode & 0o777, 0o600)
 
     def test_partial_migration_completes_on_the_next_run(self):
         (self.legacy / "tokens.json").write_text("tok")

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -111,7 +111,7 @@ class TestInstancePaths(BaseDirs):
 
     def test_label_only_set_for_non_default(self):
         self.assertEqual(paths.Instance().label(), "")
-        self.assertEqual(paths.Instance("work").label(), " --instance work")
+        self.assertEqual(paths.Instance("work").label(), " --name work")
 
 
 class TestResolveInstance(BaseDirs):

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -95,8 +95,16 @@ class TestInstancePaths(BaseDirs):
     def test_two_instances_share_nothing(self):
         a, b = paths.Instance("a"), paths.Instance("b")
         for attr in ("sock", "pid_file", "tokens_file", "log_file",
-                     "cert_file", "key_file"):
+                     "cert_file", "key_file", "config_file"):
             self.assertNotEqual(getattr(a, attr), getattr(b, attr), attr)
+
+    def test_config_file_is_user_authored_config_not_state(self):
+        # It holds intent (an advertise source), not a result, and is the one
+        # per-instance file the user edits by hand.
+        os.environ["TRUSTMUX_CONFIG_DIR"] = str(self.root / "config")
+        inst = paths.Instance("work")
+        self.assertEqual(inst.config_file,
+                         self.root / "config" / "instances" / "work.json")
 
     def test_ensure_dirs_is_private(self):
         inst = paths.Instance("perms")

--- a/mobile/tests/test_paths.py
+++ b/mobile/tests/test_paths.py
@@ -168,7 +168,6 @@ class TestKnownInstances(BaseDirs):
     def setUp(self):
         super().setUp()
         os.environ["TRUSTMUX_STATE_DIR"] = str(self.root / "state")
-        os.environ["TRUSTMUX_RUN_DIR"] = str(self.root / "run")
 
     def test_empty_before_anything_exists(self):
         self.assertEqual(paths.known_instances(), [])

--- a/mobile/trustmux/_advertise.py
+++ b/mobile/trustmux/_advertise.py
@@ -1,0 +1,345 @@
+"""Advertised addresses — what a phone connects to, and what the cert covers.
+
+The address a daemon discovers for itself is not always one a phone can reach.
+Behind cloud NAT it only ever sees an internal address, so both the URL
+`trustmux pair` prints and the names in the self-signed certificate describe a
+host nothing outside can route to.  An advertise *source* overrides that:
+
+    34.1.2.3            a literal address
+    tmux.example.com    a literal name
+    host:8443           a literal with a port
+    https://name/       a full URL, for a proxy terminating TLS on 443
+    cmd:/path/to/prog   run prog; one value per line of its stdout
+
+Sources are resolved afresh on every daemon start, which is what makes them
+safe to keep in a config file: on a cloud instance with an ephemeral public
+address a literal would quietly go stale across a stop/start cycle, while a
+cmd: source re-asks each time.
+
+Resolution is strict, and a failure stops the daemon rather than falling back
+to the address it would have guessed.  Advertising is not decoration -- it
+decides what the certificate attests -- and a browser rejects a certificate
+that omits the name in the URL outright rather than offering the click-through
+a self-signed one gets.  There is no useful "warning" outcome here.
+"""
+import ipaddress
+import json
+import os
+import re
+import shlex
+import subprocess
+import time
+from typing import NamedTuple
+from urllib.parse import urlsplit
+
+from trustmux._paths import Instance
+
+ADVERTISE_ENV = "TRUSTMUX_ADVERTISE"
+CMD_PREFIX = "cmd:"
+
+# Every cmd: source shares one budget, because this runs on the daemon's
+# startup path ahead of the admin socket being bound and _ctl._launch() waits
+# for that socket to decide whether the daemon came up.  One bounded total
+# keeps that wait bounded however many sources there are.
+CMD_BUDGET = 5.0
+MAX_VALUES = 16
+MAX_OUTPUT = 64 * 1024
+
+# cmd: is split into argv and never handed to a shell, so these characters
+# would reach the program as literal arguments rather than doing what they
+# look like.  Rejecting them beats letting curl receive a '|' as a URL.
+_SHELL_CHARS = frozenset("|&;<>$()`\n\r")
+
+# Per RFC 1035 plus the usual leading-digit allowance.
+_LABEL_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+
+class AdvertiseError(Exception):
+    """A source could not be resolved, or resolved to something unusable."""
+
+
+class Advertised(NamedTuple):
+    """One address to advertise."""
+    url: str    # what pair and status print, always ending in '/'
+    host: str   # what goes in the certificate, without IPv6 brackets
+
+
+def _is_hostname(value: str) -> bool:
+    if not value or len(value) > 253:
+        return False
+    return all(_LABEL_RE.match(label) for label in value.split("."))
+
+
+def _as_port(text: str, whole: str) -> int:
+    try:
+        port = int(text)
+    except ValueError:
+        raise AdvertiseError(f"invalid port {text!r} in {whole!r}") from None
+    if not 1 <= port <= 65535:
+        raise AdvertiseError(f"invalid port {port} in {whole!r} — expected 1-65535")
+    return port
+
+
+def _split_host_port(value: str) -> tuple[str, int | None]:
+    """(host, port) from host, host:port, [v6] or [v6]:port."""
+    if value.startswith("["):
+        host, sep, rest = value[1:].partition("]")
+        if not sep:
+            raise AdvertiseError(f"unbalanced '[' in {value!r}")
+        if rest.startswith(":"):
+            return host, _as_port(rest[1:], value)
+        if rest:
+            raise AdvertiseError(f"trailing {rest!r} after ']' in {value!r}")
+        return host, None
+    # A bare IPv6 literal has several colons, so only a single one can be a
+    # port separator; anything else is a host in its own right.
+    if value.count(":") == 1:
+        host, _, port = value.partition(":")
+        return host, _as_port(port, value)
+    return value, None
+
+
+def _build(host: str, port: int | None, scheme: str, whole: str) -> Advertised:
+    if host.endswith(".") and len(host) > 1:
+        host = host[:-1]     # legal in DNS, not in a certificate SAN
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+        if not _is_hostname(host):
+            raise AdvertiseError(f"invalid host {host!r} in {whole!r}") from None
+    if ip is not None and ip.is_unspecified:
+        raise AdvertiseError(f"{whole!r}: {host} is a wildcard, not an address "
+                             "anything can connect to")
+    default = 443 if scheme == "https" else 80
+    port = default if port is None else port
+    shown = "" if port == default else f":{port}"
+    literal = f"[{host}]" if ip is not None and ip.version == 6 else host
+    return Advertised(url=f"{scheme}://{literal}{shown}/", host=host)
+
+
+def normalize(value: str, scheme: str = "https", port: int | None = None) -> Advertised:
+    """One advertise value as (url, host), or AdvertiseError if it is not one.
+
+    scheme and port supply what a bare host omits -- the daemon's own, so that
+    `--advertise 34.1.2.3` on a daemon serving https on 7432 advertises
+    https://34.1.2.3:7432/.  A full URL overrides both, which is how a proxy
+    terminating TLS on 443 in front of the daemon is expressed.
+    """
+    if not value:
+        raise AdvertiseError("empty value — a blank line is not an address")
+    if value.startswith(CMD_PREFIX):
+        # Only reachable for a value a cmd: source printed: resolve() routes
+        # sources themselves to _run().  One level, so nothing recurses.
+        raise AdvertiseError(f"{value!r}: a cmd: source cannot produce another one")
+    if "://" in value:
+        return _from_url(value)
+    host, explicit = _split_host_port(value)
+    return _build(host, port if explicit is None else explicit, scheme, value)
+
+
+def _from_url(value: str) -> Advertised:
+    parts = urlsplit(value)
+    if parts.scheme not in ("http", "https"):
+        raise AdvertiseError(f"unsupported scheme {parts.scheme!r} in {value!r} — "
+                             "expected http or https")
+    if parts.path not in ("", "/"):
+        raise AdvertiseError(f"{value!r} has a path — trustmux serves from the "
+                             "root only, so a subpath could not work")
+    if parts.query or parts.fragment:
+        raise AdvertiseError(f"{value!r} has a query or fragment — the pairing "
+                             "code is carried in the fragment")
+    if parts.username or parts.password:
+        raise AdvertiseError(f"{value!r} carries credentials")
+    try:
+        host, port = parts.hostname, parts.port
+    except ValueError:
+        raise AdvertiseError(f"invalid port in {value!r}") from None
+    if not host:
+        raise AdvertiseError(f"no host in {value!r}")
+    return _build(host, port, parts.scheme, value)
+
+
+def _argv(source: str) -> list[str]:
+    """argv for a cmd: source, or AdvertiseError if it is not one we would run.
+
+    No shell.  The command is split with shlex, which honours quoting but
+    expands nothing, so a pipeline or a $(...) would reach the program as text
+    rather than being evaluated -- saying so is friendlier than letting curl
+    receive a '|' as a URL.
+    """
+    spec = source[len(CMD_PREFIX):]
+    bad = sorted(_SHELL_CHARS & set(spec))
+    if bad:
+        chars = " ".join(repr(c) for c in bad)
+        raise AdvertiseError(
+            f"{source!r} contains {chars}: cmd: runs a program directly and does "
+            "not use a shell, so this would be passed through as an argument. "
+            "Put the pipeline in a script and name the script instead.")
+    try:
+        argv = shlex.split(spec)
+    except ValueError as e:
+        raise AdvertiseError(f"cannot parse {source!r}: {e}") from None
+    if not argv:
+        raise AdvertiseError(f"{source!r} names no command")
+    return argv
+
+
+def _run(source: str, deadline: float) -> list[str]:
+    """Run a cmd: source, returning one value per line of its stdout.
+
+    Any failure is fatal, and that is the point: a shell would turn a failed
+    curl into an empty line and still exit 0, which is precisely the silent
+    wrong answer advertising exists to prevent.
+    """
+    argv = _argv(source)
+    budget = deadline - time.monotonic()
+    if budget <= 0:
+        raise AdvertiseError(f"out of time before running {argv[0]} — advertise "
+                             f"sources share a {CMD_BUDGET:g}s budget")
+    try:
+        proc = subprocess.run(argv, stdin=subprocess.DEVNULL,
+                              capture_output=True, text=True, timeout=budget)
+    except FileNotFoundError:
+        raise AdvertiseError(f"{argv[0]}: not found (an absolute path is safest "
+                             "here, since a daemon's PATH is whatever started "
+                             "it)") from None
+    except PermissionError:
+        raise AdvertiseError(f"{argv[0]}: not executable") from None
+    except subprocess.TimeoutExpired:
+        raise AdvertiseError(f"{argv[0]}: still running after {budget:.1f}s") from None
+    except OSError as e:
+        raise AdvertiseError(f"{argv[0]}: {e}") from None
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or "").strip().splitlines()
+        raise AdvertiseError(f"{argv[0]} exited {proc.returncode}"
+                             + (f": {detail[-1]}" if detail else ""))
+    if len(proc.stdout) > MAX_OUTPUT:
+        raise AdvertiseError(f"{argv[0]} printed more than {MAX_OUTPUT} bytes")
+
+    lines = proc.stdout.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()          # one trailing newline is how a program ends output
+    if not lines:
+        raise AdvertiseError(f"{argv[0]} printed nothing")
+    return lines
+
+
+def resolve(sources: list[str], scheme: str = "https",
+            port: int | None = None) -> list[Advertised]:
+    """Resolve sources to the addresses to advertise, in order.
+
+    The first value decides the URL that pair prints; every value becomes a
+    certificate SAN.  Repeats of a host are dropped rather than duplicated in
+    the certificate, keeping the first.
+    """
+    deadline = time.monotonic() + CMD_BUDGET
+    out: list[Advertised] = []
+    seen: set[str] = set()
+    for source in sources:
+        for value in (_run(source, deadline) if source.startswith(CMD_PREFIX)
+                      else [source]):
+            try:
+                adv = normalize(value, scheme, port)
+            except AdvertiseError as e:
+                # Name the source: which line of which program was unusable is
+                # the only thing that makes this fixable.
+                raise AdvertiseError(f"{source}: {e}" if source != value
+                                     else str(e)) from None
+            if adv.host in seen:
+                continue
+            seen.add(adv.host)
+            out.append(adv)
+            if len(out) > MAX_VALUES:
+                raise AdvertiseError(f"more than {MAX_VALUES} addresses to advertise")
+    return out
+
+
+def check_sources(sources: list[str], scheme: str = "https",
+                  port: int | None = None) -> None:
+    """Validate sources as far as is possible without running anything.
+
+    Lets the CLI reject a mistyped source itself, as the usage error it is,
+    rather than launching a daemon that exits during startup.  Whether a program
+    will actually succeed cannot be known here -- that is the daemon's business,
+    and fatal there.
+    """
+    for source in sources:
+        if source.startswith(CMD_PREFIX):
+            _argv(source)
+        else:
+            normalize(source, scheme, port)
+
+
+def _from_config(inst: Instance) -> list[str]:
+    """Advertise sources from this instance's config file, or [] if it has none."""
+    path = inst.config_file
+    try:
+        st = path.stat()
+    except OSError:
+        return []
+    # A source can name a program to run, so a file anyone else can write is a
+    # way to have this daemon run their code.
+    if st.st_mode & 0o022:
+        raise AdvertiseError(
+            f"{path} is writable by group or other (mode {st.st_mode & 0o777:04o}) "
+            "and can name a program to run — refusing to read it. chmod 600 it.")
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError) as e:
+        raise AdvertiseError(f"cannot read {path}: {e}") from None
+    if not isinstance(data, dict):
+        raise AdvertiseError(f"{path}: expected a JSON object")
+    raw = data.get("advertise")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list) or not all(isinstance(v, str) for v in raw):
+        raise AdvertiseError(f'{path}: "advertise" must be a string or a list '
+                             "of strings")
+    return raw
+
+
+def resolve_sources(explicit: list[str] | None = None, no_advertise: bool = False,
+                    inst: Instance | None = None) -> list[str]:
+    """The sources to use: --advertise, then $TRUSTMUX_ADVERTISE, then the
+    instance's config file.
+
+    Whichever is set replaces the others outright rather than adding to them.
+    With a repeatable flag an appending --advertise could never drop a name the
+    config file still lists, and a certificate attesting a host you were trying
+    to remove is the failure this exists to avoid.  --no-advertise is how to
+    resolve to nothing despite a configured source.
+    """
+    if no_advertise:
+        if explicit:
+            raise AdvertiseError("--advertise and --no-advertise are mutually exclusive")
+        return []
+    if explicit:
+        if not all(explicit):
+            raise AdvertiseError("--advertise needs a value — use --no-advertise "
+                                 "to advertise nothing")
+        return list(explicit)
+    # A single source, not a list: no delimiter is safe here, since ':' collides
+    # with both URL schemes and the cmd: prefix while ',' can appear inside a
+    # command's arguments.  A cmd: source already yields many values by itself,
+    # so nothing is out of reach.
+    env = os.environ.get(ADVERTISE_ENV, "").strip()
+    if env:
+        return [env]
+    return _from_config(inst or Instance())
+
+
+def advertised_urls(info: dict | None) -> list[str]:
+    """The URLs a running daemon reports advertising, from an admin "info" reply.
+
+    Only the daemon knows what its certificate was actually built for, so this
+    -- not a fresh local resolution -- is what the CLI should print.  Shaped
+    defensively because it crosses the socket.
+    """
+    urls = (info or {}).get("advertise")
+    if not isinstance(urls, list):
+        return []
+    return [u for u in urls if isinstance(u, str) and u]

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -662,6 +662,81 @@ def cmd_list() -> int:
     return 0
 
 
+def cmd_rm(inst: Instance | None = None, force: bool = False) -> int:
+    """Delete an instance's state directory, and its login hook if it has one.
+
+    Instances are created implicitly by the first `start` and, until now, could
+    only be removed by hand -- so a typo'd --instance stayed in `list` forever,
+    holding session tokens and a TLS key nobody meant to keep.
+
+    --force covers both refusals below: a running daemon (stopped first) and
+    the default instance (whose tokens are most likely the real ones).
+    """
+    inst = inst or Instance()
+    if not inst.state.is_dir() and not inst.state.is_symlink():
+        print(f"Error: no such instance: {inst.name}", file=sys.stderr)
+        return 1
+
+    # Belt and braces before an rm -rf: resolve_instance() already rejects
+    # names containing separators, but cmd_rm is callable directly, so confirm
+    # the target really is one instance directory inside our own tree.
+    if inst.state.parent != state_dir() / "instances":
+        print(f"Error: {inst.state} is not inside the instances directory.",
+              file=sys.stderr)
+        return 1
+
+    if inst.name == DEFAULT_INSTANCE and not force:
+        print(f"Error: refusing to remove the {DEFAULT_INSTANCE} instance "
+              "without --force.", file=sys.stderr)
+        print("  This deletes its paired device tokens and TLS keypair.",
+              file=sys.stderr)
+        return 1
+
+    port = resolve_port(None, inst)
+    running = _pid(port, inst)
+    if running and not force:
+        print(f"Error: instance {inst.name} is running (pid {running}).",
+              file=sys.stderr)
+        print(f"  Stop it first:  trustmux stop{inst.label()}", file=sys.stderr)
+        print(f"  Or force it:    trustmux rm{inst.label()} --force", file=sys.stderr)
+        return 1
+
+    if running:
+        if cmd_stop(port, inst) != 0:
+            print("Error: could not stop the daemon; nothing removed.", file=sys.stderr)
+            return 1
+        # SIGTERM is asynchronous, so wait for the daemon to actually go before
+        # pulling the directory out from under it.
+        for _ in range(20):
+            try:
+                os.kill(running, 0)
+            except OSError:
+                break
+            time.sleep(0.1)
+
+    # Otherwise the next login would start it again and recreate everything.
+    from trustmux._disable import _LOGIN_FILES, _remove_hook
+    for f in _LOGIN_FILES:
+        _remove_hook(f, inst)
+
+    had_tokens = inst.tokens_file.exists()
+    try:
+        if inst.state.is_symlink():
+            # Remove the link, never what it points at: that lives outside the
+            # instances directory and is not ours to delete.
+            inst.state.unlink()
+        else:
+            shutil.rmtree(inst.state)
+    except OSError as e:
+        print(f"Error: could not remove {inst.state}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"removed instance {inst.name} ({inst.state})")
+    if had_tokens:
+        print("  paired devices for it will have to pair again")
+    return 0
+
+
 def cmd_log(inst: Instance | None = None) -> int:
     inst = inst or Instance()
     _ensure_dir(inst)
@@ -734,6 +809,11 @@ def main() -> None:
     sub.add_parser("pair",         parents=[inst_opts], help="Generate a one-time pairing code for a new device")
     sub.add_parser("unpair",       parents=[inst_opts], help="List paired devices and revoke tokens")
     sub.add_parser("list",         help="List instances and their listeners")
+    p_rm = sub.add_parser("rm",    parents=[inst_opts],
+                          help="Delete an instance's state directory")
+    p_rm.add_argument("--force", action="store_true",
+                      help="Remove it even if it is running, or is the "
+                           f"{DEFAULT_INSTANCE} instance")
     sub.add_parser("help",         help=argparse.SUPPRESS)  # alias for -h/--help
 
     args = parser.parse_args()
@@ -772,6 +852,8 @@ def main() -> None:
         sys.exit(cmd_status(port, inst))
     elif cmd == "list":
         sys.exit(cmd_list())
+    elif cmd == "rm":
+        sys.exit(cmd_rm(inst, args.force))
     elif cmd == "log":
         sys.exit(cmd_log(inst))
     elif cmd == "enable":

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from trustmux._paths import (DEFAULT_INSTANCE, INSTANCE_ENV, Instance,
                              check_sock_path, known_instances,
                              migrate_legacy_layout, resolve_instance,
-                             state_dir)
+                             socket_is_live, state_dir)
 
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
@@ -86,7 +86,7 @@ def daemon_info(inst: Instance | None = None) -> dict | None:
             # This is a local IPC round trip to a process on the same
             # machine, not a network call -- a healthy daemon answers in low
             # milliseconds. Several call paths now consult this (resolve_port,
-            # direct_url, and _pid()'s lsof-unavailable fallback), so a
+            # direct_url, and _pid(), for which it is the primary source), so a
             # generous timeout here means an unresponsive-but-alive daemon
             # turns ordinary commands into a multi-second hang instead of an
             # instant response.
@@ -112,10 +112,13 @@ def resolve_port(explicit: int | None = None, inst: Instance | None = None) -> i
     """Return the port to operate on.
 
     Precedence: --port, then $TRUSTMUX_PORT, then whatever this instance's
-    running daemon reports, then the default.  Consulting the daemon is what
-    lets stop/status/pair find a daemon that was started on a non-default port
-    without having to repeat the flag.
+    running daemon reports, then the port it was recorded as starting on, then
+    the default.  Consulting the daemon is what lets stop/status/pair find a
+    daemon that was started on a non-default port without having to repeat the
+    flag; the recorded port keeps that working when the daemon is alive but no
+    longer answering, which is exactly when `stop` matters most.
     """
+    inst = inst or Instance()
     if explicit is not None:
         port = _valid_port(explicit)
         if port is None:
@@ -136,6 +139,13 @@ def resolve_port(explicit: int | None = None, inst: Instance | None = None) -> i
         port = _valid_port(info.get("port"))
         if port is not None:
             return port
+
+    # Not answering.  Only believe the recorded port if the socket shows a
+    # daemon still there: a pid file left by a killed daemon must not send the
+    # next `start` to some port the user did not ask for.
+    recorded = _recorded(inst)
+    if recorded and recorded[1] is not None and socket_is_live(inst.sock):
+        return recorded[1]
 
     return DEFAULT_PORT
 
@@ -180,87 +190,85 @@ def _ensure_dir(inst: Instance | None = None) -> None:
     inst.log_file.chmod(0o600)
 
 
-def _pids_on_port(port: int) -> list[int] | None:
-    """PIDs listening on port, per lsof.
+def write_pid_file(inst: Instance, pid: int, port: int) -> None:
+    """Record which pid this instance started, and on which port.
 
-    Empty list means lsof ran and genuinely found nothing -- a definitive
-    answer.  None means lsof could not answer at all (not installed, or output
-    this does not understand), which is the only case where a caller may fall
-    back to guessing.
+    The port is written alongside the pid because the pid alone cannot answer
+    the question `stop`/`status` actually asks -- "is *our* daemon on this
+    port?" -- and every way of asking the operating system that question
+    afterwards is either unportable or system-wide (see _recorded()).
     """
-    try:
-        out = subprocess.check_output(
-            ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
-        )
-    except subprocess.CalledProcessError:
-        return []          # ran fine, nothing bound to this port
-    except FileNotFoundError:
-        return None        # lsof unusable
-    lines = [x.strip() for x in out.splitlines() if x.strip()]
-    pids = [int(l) for l in lines if l.isdigit()]
-    if lines and not pids:
-        # An lsof that does not understand -ti:<port> prints a full listing
-        # rather than failing; its columns must not be misread as pids.
-        return None
-    return pids
+    inst.pid_file.write_text(f"{pid} {port}\n")
 
 
-def _recorded_pid(inst: Instance) -> int | None:
-    """Live PID from this instance's pid file, or None.
+def _recorded(inst: Instance) -> tuple[int, int | None] | None:
+    """(pid, port) from this instance's pid file, if that pid is still alive.
 
-    Says nothing about which port that pid owns -- only ever used to attribute
-    a pid that is already known to hold the port in question.
+    port is None for a file written before the port was recorded; such a file
+    can still identify the daemon but can no longer place it on a port.
+
+    Nothing here proves the pid is a trustmux daemon rather than a recycled
+    number -- callers must first establish that this instance has a live daemon
+    at all, which is what socket_is_live() is for.
     """
     if not inst.pid_file.exists():
         return None
     try:
-        pid = int(inst.pid_file.read_text().strip())
+        fields = inst.pid_file.read_text().split()
+        pid = int(fields[0])
         os.kill(pid, 0)
-        return pid
-    except (ValueError, ProcessLookupError, PermissionError, OSError):
+    except (IndexError, ValueError, ProcessLookupError, PermissionError, OSError):
         return None
+    return pid, _valid_port(fields[1]) if len(fields) > 1 else None
 
 
 def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
-    """Return the PID of this instance's daemon listening on `port`, or None.
+    """Return the PID of *this instance's* daemon listening on `port`, or None.
 
-    lsof directly observes what is bound to `port`; when it can run, its
-    answer -- found or not -- is authoritative and final.  Only when lsof
-    itself is unusable does this fall back to asking the daemon what port *it*
-    is bound to over the admin socket, and only trust the reply when the
-    reported port matches the one being asked about.
+    Everything consulted here lives inside this instance's own state directory:
+    the admin socket and the pid file.  Nothing system-wide is asked, which is
+    the whole point -- see the second invariant below.
 
-    Nothing here may return a pid without confirming it owns the *requested*
-    port: doing so is what previously let `trustmux stop --port <port nothing
-    is on>` kill an unrelated daemon.  The pid file is therefore only ever
-    used to decide *which* of the processes already known to hold the port is
-    ours -- never to conjure one up when the port is idle.
+    The admin socket answers both halves of the question at once.  Whatever
+    replies on it is by construction the daemon this instance started (the
+    socket is 0600, inside the instance's state directory, and a starting
+    daemon refuses to steal a live one), and its reply names the port it
+    actually bound.  Merely *connecting* is a weaker but still useful signal:
+    it completes off the kernel's listen backlog, so it succeeds even for a
+    daemon too wedged to reply, and fails for a socket whose daemon was killed.
+    That is what makes `stop` able to kill a hung daemon: the live socket
+    proves this instance has one, and the pid file names it and its port.
+
+    Two invariants, each from a bug that shipped:
+
+    * Never return a pid without confirming it owns the *requested* port.
+      Violating it let `trustmux stop --port <port nothing is on>` kill an
+      unrelated daemon (11bb4ca7).
+    * Never return a pid this instance does not claim.  Discovering the daemon
+      by asking the system who holds the port let a throwaway instance report
+      -- and stop -- a real daemon that merely happened to share it.
     """
     inst = inst or Instance()
-    listening = _pids_on_port(port)
 
-    if listening is None:
-        info = daemon_info(inst)
-        if info and _valid_port(info.get("port")) == port:
-            pid = info.get("pid")
-            if isinstance(pid, int) and pid > 0:
-                return pid
+    info = daemon_info(inst)
+    if info is not None:
+        pid = info.get("pid")
+        if (isinstance(pid, int) and pid > 0
+                and _valid_port(info.get("port")) == port):
+            return pid
+        # Our daemon answered, about some other port: it is not on this one.
         return None
 
-    if not listening:
+    # No reply.  If the socket still accepts connections the daemon is alive
+    # but not answering; fall back to what was recorded when it was started.
+    # If it does not, this instance has no daemon, whoever else holds the port.
+    if not socket_is_live(inst.sock):
         return None
-
-    # Something holds the port. Attribute it: with two instances bound to the
-    # same port on different addresses, "whichever pid lsof printed first" is
-    # a coin flip, so prefer this instance's own claim when it has one.
-    claimed = _recorded_pid(inst)
-    if claimed is None:
-        info = daemon_info(inst)
-        reported = info.get("pid") if info else None
-        claimed = reported if isinstance(reported, int) and reported > 0 else None
-    if claimed is not None:
-        return claimed if claimed in listening else None
-    return listening[0]
+    recorded = _recorded(inst)
+    if recorded is None:
+        return None
+    pid, recorded_port = recorded
+    return pid if recorded_port == port else None
 
 
 def _ts_host() -> str:
@@ -411,7 +419,7 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
             start_new_session=True,
             env=env,
         )
-    inst.pid_file.write_text(str(proc.pid))
+    write_pid_file(inst, proc.pid, port)
     time.sleep(0.5)
     if proc.poll() is not None:
         # Died on startup — usually the port is taken, which is easy to hit
@@ -560,7 +568,13 @@ def cmd_start(mode: str = "serve", port: int | None = None,
         return 1
 
     if not ok:
+        # _pid() only names daemons this instance claims, so a port held by
+        # someone else no longer surfaces as "already running" -- it lands here
+        # instead, as a failure to bind.  Name that as the likely cause: the
+        # daemon logged the real errno, but nobody reads a log on a hunch.
         print(f"trustmux failed to start — check {inst.log_file}")
+        print(f"  (most often port {port} is already in use — try another "
+              f"--port)", file=sys.stderr)
         return 1
     return 0
 
@@ -574,20 +588,20 @@ def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
         # "Nothing found on *this* port" does not mean the pid file is stale
         # -- it may correctly be tracking this instance's daemon on another
         # port. Only clean it up when its own recorded pid is actually dead.
-        if inst.pid_file.exists() and _recorded_pid(inst) is None:
+        if inst.pid_file.exists() and _recorded(inst) is None:
             inst.pid_file.unlink(missing_ok=True)
         return 0
 
     if inst.pid_file.exists():
         try:
-            file_pid = int(inst.pid_file.read_text().strip())
+            file_pid = int(inst.pid_file.read_text().split()[0])
             if file_pid != p:
                 print(f"Error: pid {p} owns port {port} but {inst.pid_file} contains {file_pid}.",
                       file=sys.stderr)
                 print(f"Refusing to kill. Remove {inst.pid_file} manually if trustmux is truly stopped.",
                       file=sys.stderr)
                 return 1
-        except ValueError:
+        except (IndexError, ValueError):
             pass
 
     os.kill(p, signal.SIGTERM)
@@ -631,7 +645,14 @@ def cmd_list() -> int:
     for inst in instances:
         info = daemon_info(inst) or {}
         port = _valid_port(info.get("port"))
-        p = _pid(port or DEFAULT_PORT, inst) if info else _recorded_pid(inst)
+        if info:
+            p = _pid(port or DEFAULT_PORT, inst)
+        else:
+            # No reply, but a socket still accepting connections means the
+            # daemon is there and merely not answering; the pid file then
+            # supplies both the pid and the port it was started on.
+            recorded = _recorded(inst) if socket_is_live(inst.sock) else None
+            p, port = recorded if recorded else (None, port)
         status = f"running (pid {p})" if p else "stopped"
         print(f"{inst.name:<16} {port or '-':>5}  {info.get('scheme', '-'):<6} {status}")
     return 0

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -413,7 +413,7 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
     with inst.log_file.open("a") as log:
         proc = subprocess.Popen(
             [sys.executable, "-m", "trustmux",
-             "--port", str(port), "--instance", inst.name] + extra_args,
+             "--port", str(port), "--name", inst.name] + extra_args,
             stdout=log, stderr=log,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
@@ -666,7 +666,7 @@ def cmd_rm(inst: Instance | None = None, force: bool = False) -> int:
     """Delete an instance's state directory, and its login hook if it has one.
 
     Instances are created implicitly by the first `start` and, until now, could
-    only be removed by hand -- so a typo'd --instance stayed in `list` forever,
+    only be removed by hand -- so a typo'd --name stayed in `list` forever,
     holding session tokens and a TLS key nobody meant to keep.
 
     --force covers both refusals below: a running daemon (stopped first) and
@@ -779,11 +779,11 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
-    # --instance selects which daemon's state directory to act on and so is
+    # --name selects which daemon's state directory to act on and so is
     # accepted everywhere; --port only matters to commands that address a
     # listener.
     inst_opts = argparse.ArgumentParser(add_help=False)
-    inst_opts.add_argument("--instance", metavar="NAME",
+    inst_opts.add_argument("--name", metavar="NAME",
                            help=f"Instance name (default: {DEFAULT_INSTANCE}, or ${INSTANCE_ENV})")
 
     port_opts = argparse.ArgumentParser(add_help=False)
@@ -824,7 +824,7 @@ def main() -> None:
     migrate_legacy_layout()
 
     cmd = args.cmd
-    inst = resolve_instance(getattr(args, "instance", None))
+    inst = resolve_instance(getattr(args, "name", None))
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
     port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,14 +11,11 @@ import sys
 import time
 from pathlib import Path
 
+from trustmux._paths import Instance, migrate_legacy_layout
+
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
 SERVE_PORT = 443  # tailscale serve terminates TLS on :443
-CONFIG_DIR = Path.home() / ".config" / "trustmux"
-LOGFILE    = CONFIG_DIR / "trustmux.log"
-PIDFILE    = CONFIG_DIR / "trustmux.pid"
-ADMIN_SOCK = CONFIG_DIR / "trustmux.sock"
-TOKENS_FILE = CONFIG_DIR / "tokens.json"
 
 
 def _check_tmux() -> bool:
@@ -73,12 +70,13 @@ def _valid_port(value: object) -> int | None:
     return port if 1 <= port <= 65535 else None
 
 
-def daemon_info() -> dict | None:
-    """Ask the running daemon what it is listening on.
+def daemon_info(inst: Instance | None = None) -> dict | None:
+    """Ask this instance's running daemon what it is listening on.
 
     Returns {"pid", "host", "port", "scheme"} or None if no daemon answers.
     """
-    if not ADMIN_SOCK.exists():
+    inst = inst or Instance()
+    if not inst.sock.exists():
         return None
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
@@ -90,7 +88,7 @@ def daemon_info() -> dict | None:
             # turns ordinary commands into a multi-second hang instead of an
             # instant response.
             s.settimeout(1.5)
-            s.connect(str(ADMIN_SOCK))
+            s.connect(str(inst.sock))
             s.sendall(b'{"action": "info"}\n')
             s.shutdown(socket.SHUT_WR)
             chunks = []
@@ -107,13 +105,13 @@ def daemon_info() -> dict | None:
     return info
 
 
-def resolve_port(explicit: int | None = None) -> int:
+def resolve_port(explicit: int | None = None, inst: Instance | None = None) -> int:
     """Return the port to operate on.
 
-    Precedence: --port, then $TRUSTMUX_PORT, then whatever the running daemon
-    reports, then the default.  Consulting the daemon is what lets stop/status/
-    pair find a daemon that was started on a non-default port without having to
-    repeat the flag.
+    Precedence: --port, then $TRUSTMUX_PORT, then whatever this instance's
+    running daemon reports, then the default.  Consulting the daemon is what
+    lets stop/status/pair find a daemon that was started on a non-default port
+    without having to repeat the flag.
     """
     if explicit is not None:
         port = _valid_port(explicit)
@@ -130,7 +128,7 @@ def resolve_port(explicit: int | None = None) -> int:
             sys.exit(2)
         return port
 
-    info = daemon_info()
+    info = daemon_info(inst)
     if info:
         port = _valid_port(info.get("port"))
         if port is not None:
@@ -172,13 +170,14 @@ def direct_url(port: int, info: dict | None = None) -> str:
     return f"{scheme}://{hostname}:{port}/"
 
 
-def _ensure_dir() -> None:
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    LOGFILE.touch()
-    LOGFILE.chmod(0o600)
+def _ensure_dir(inst: Instance | None = None) -> None:
+    inst = inst or Instance()
+    inst.ensure_dirs()
+    inst.log_file.touch()
+    inst.log_file.chmod(0o600)
 
 
-def _pid(port: int = DEFAULT_PORT) -> int | None:
+def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
     """Return the PID of the trustmux daemon listening on `port`, or None.
 
     lsof directly observes what is bound to `port`; when it can run, its
@@ -188,14 +187,13 @@ def _pid(port: int = DEFAULT_PORT) -> int | None:
     which is still port-scoped and authoritative since it is self-reported
     by the live process rather than inferred.
 
-    There is deliberately no further fallback to "PIDFILE's pid is alive,"
-    which cannot say anything about *which* port that pid owns: with a
-    single global PORT constant (pre-multi-port) that was an adequate proxy
-    for "is trustmux running," but once callers can ask about an arbitrary
-    port, trusting it blindly means a query for a port nothing is listening
-    on can return some *other*, unrelated daemon's pid -- which previously
-    let `trustmux stop --port <port nothing is on>` kill the wrong daemon.
+    There is deliberately no further fallback to "the pid file's pid is
+    alive," which cannot say anything about *which* port that pid owns:
+    trusting it blindly means a query for a port nothing is listening on can
+    return some other, unrelated daemon's pid -- which previously let
+    `trustmux stop --port <port nothing is on>` kill the wrong daemon.
     """
+    inst = inst or Instance()
     try:
         out = subprocess.check_output(
             ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
@@ -207,7 +205,7 @@ def _pid(port: int = DEFAULT_PORT) -> int | None:
     except (FileNotFoundError, ValueError):
         pass  # lsof unusable; fall through to the daemon's own account.
 
-    info = daemon_info()
+    info = daemon_info(inst)
     if info and _valid_port(info.get("port")) == port:
         pid = info.get("pid")
         if isinstance(pid, int) and pid > 0:
@@ -343,9 +341,10 @@ def _ensure_ts_serve(port: int = DEFAULT_PORT) -> bool:
     return False
 
 
-def _launch(port: int, extra_args: list[str]) -> int | None:
+def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> int | None:
     """Launch daemon as a detached background process. Returns PID or None."""
-    _ensure_dir()
+    inst = inst or Instance()
+    _ensure_dir(inst)
     # Ensure the package directory is on the subprocess's Python path so that
     # `python3 -m trustmux` resolves correctly regardless of how Python was
     # invoked (e.g. bare /usr/bin/python3 from a .deb shim).
@@ -353,7 +352,7 @@ def _launch(port: int, extra_args: list[str]) -> int | None:
     env = os.environ.copy()
     existing = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = f"{pkg_parent}:{existing}" if existing else pkg_parent
-    with LOGFILE.open("a") as log:
+    with inst.log_file.open("a") as log:
         proc = subprocess.Popen(
             [sys.executable, "-m", "trustmux", "--port", str(port)] + extra_args,
             stdout=log, stderr=log,
@@ -361,13 +360,21 @@ def _launch(port: int, extra_args: list[str]) -> int | None:
             start_new_session=True,
             env=env,
         )
-    PIDFILE.write_text(str(proc.pid))
+    inst.pid_file.write_text(str(proc.pid))
     time.sleep(0.5)
-    return _pid(port)
+    if proc.poll() is not None:
+        # Died on startup — usually the port is taken, which is easy to hit
+        # once more than one instance is in play.  Without this the pid file
+        # still names the (zombie) child and the caller reports success.
+        inst.pid_file.unlink(missing_ok=True)
+        return None
+    return _pid(port, inst)
 
 
-def cmd_setup(quiet: bool = False, port: int | None = None) -> int:
-    port = resolve_port(port)
+def cmd_setup(quiet: bool = False, port: int | None = None,
+              inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
     print("=== trustmux setup ===\n")
 
     # Verify package is importable
@@ -408,9 +415,11 @@ def cmd_setup(quiet: bool = False, port: int | None = None) -> int:
     return 0
 
 
-def cmd_start(mode: str = "serve", port: int | None = None) -> int:
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_start(mode: str = "serve", port: int | None = None,
+              inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if p:
         print(f"trustmux already running (pid {p})")
         return 1
@@ -435,7 +444,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         if not _ensure_ts_serve(port):
             return 1
         print("Starting trustmux (HTTPS mode)...")
-        pid = _launch(port, ["--host", "127.0.0.1", "--https"])
+        pid = _launch(port, ["--host", "127.0.0.1", "--https"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
@@ -443,7 +452,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
 
     elif mode == "start-local":
         print("Starting trustmux (loopback only — SSH tunnel access)...")
-        pid = _launch(port, ["--host", "127.0.0.1"])
+        pid = _launch(port, ["--host", "127.0.0.1"], inst)
         ok = pid is not None
         if ok:
             fqdn = socket.getfqdn()
@@ -457,7 +466,7 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         if not _check_tls():
             return 1
         print("Starting trustmux (direct HTTPS — self-signed cert)...")
-        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"])
+        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
@@ -469,35 +478,35 @@ def cmd_start(mode: str = "serve", port: int | None = None) -> int:
         return 1
 
     if not ok:
-        print(f"trustmux failed to start — check {LOGFILE}")
+        print(f"trustmux failed to start — check {inst.log_file}")
         return 1
     return 0
 
 
-def cmd_stop(port: int | None = None) -> int:
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if not p:
         print("trustmux not running")
-        # "Nothing found on *this* port" does not mean PIDFILE is globally
-        # stale -- it may correctly be tracking a different, still-alive
-        # daemon on another port. Only clean it up when its own recorded pid
-        # is actually dead, same condition that made it stale pre-multi-port.
-        if PIDFILE.exists():
+        # "Nothing found on *this* port" does not mean the pid file is stale
+        # -- it may correctly be tracking this instance's daemon on another
+        # port. Only clean it up when its own recorded pid is actually dead.
+        if inst.pid_file.exists():
             try:
-                file_pid = int(PIDFILE.read_text().strip())
+                file_pid = int(inst.pid_file.read_text().strip())
                 os.kill(file_pid, 0)
             except (ValueError, ProcessLookupError, PermissionError, OSError):
-                PIDFILE.unlink(missing_ok=True)
+                inst.pid_file.unlink(missing_ok=True)
         return 0
 
-    if PIDFILE.exists():
+    if inst.pid_file.exists():
         try:
-            file_pid = int(PIDFILE.read_text().strip())
+            file_pid = int(inst.pid_file.read_text().strip())
             if file_pid != p:
-                print(f"Error: pid {p} owns port {port} but PIDFILE contains {file_pid}.",
+                print(f"Error: pid {p} owns port {port} but {inst.pid_file} contains {file_pid}.",
                       file=sys.stderr)
-                print(f"Refusing to kill. Remove {PIDFILE} manually if trustmux is truly stopped.",
+                print(f"Refusing to kill. Remove {inst.pid_file} manually if trustmux is truly stopped.",
                       file=sys.stderr)
                 return 1
         except ValueError:
@@ -505,14 +514,15 @@ def cmd_stop(port: int | None = None) -> int:
 
     os.kill(p, signal.SIGTERM)
     print(f"trustmux stopped (pid {p})")
-    PIDFILE.unlink(missing_ok=True)
+    inst.pid_file.unlink(missing_ok=True)
     return 0
 
 
-def cmd_status(port: int | None = None) -> int:
-    info = daemon_info()
-    port = resolve_port(port)
-    p = _pid(port)
+def cmd_status(port: int | None = None, inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    info = daemon_info(inst)
+    port = resolve_port(port, inst)
+    p = _pid(port, inst)
     if not p:
         print("trustmux not running")
         return 0
@@ -534,10 +544,12 @@ def cmd_status(port: int | None = None) -> int:
     return 0
 
 
-def cmd_log() -> int:
-    _ensure_dir()
+
+def cmd_log(inst: Instance | None = None) -> int:
+    inst = inst or Instance()
+    _ensure_dir(inst)
     try:
-        subprocess.run(["tail", "-f", str(LOGFILE)])
+        subprocess.run(["tail", "-f", str(inst.log_file)])
     except KeyboardInterrupt:
         pass
     return 0
@@ -547,9 +559,9 @@ def _refuse_root() -> None:
     """Abort if running as root (e.g. via sudo).
 
     Running as root causes three distinct failure modes:
-      1. Path.home() resolves to /root/, so PIDFILE/CONFIG_DIR point to root's
-         home; the PID-mismatch safety check in cmd_stop() is silently bypassed
-         because the user's PIDFILE is invisible to root.
+      1. Path.home() resolves to /root/, so the state and runtime directories
+         point at root's home; the PID-mismatch safety check in cmd_stop() is
+         silently bypassed because the user's pid file is invisible to root.
       2. `tailscale serve` runs as root and creates a conflicting serve config,
          clobbering the user-level config and wedging tailscale.
       3. The daemon relaunches owned by root, creating a privilege-escalation
@@ -575,8 +587,6 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
-    # Shared --port, attached to every subcommand that has to know which
-    # listener it is acting on.
     port_opts = argparse.ArgumentParser(add_help=False)
     port_opts.add_argument("--port", type=int, metavar="PORT",
                            help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
@@ -592,8 +602,8 @@ def main() -> None:
     sub.add_parser("stop",         parents=[port_opts], help="Stop daemon (tailscale serve config persists)")
     sub.add_parser("restart",      parents=[port_opts], help="Restart daemon")
     sub.add_parser("status",       parents=[port_opts], help="Show running status and URL")
-    sub.add_parser("log",          help="Tail the log file")
     sub.add_parser("enable",       parents=[port_opts], help="Start daemon and install login hook for automatic start")
+    sub.add_parser("log",          help="Tail the log file")
     sub.add_parser("disable",      help="Stop daemon and remove login hook")
     sub.add_parser("pair",         help="Generate a one-time pairing code for a new device")
     sub.add_parser("unpair",       help="List paired devices and revoke tokens")
@@ -604,41 +614,44 @@ def main() -> None:
         parser.print_help()
         sys.exit(0 if args.cmd == "help" else 1)
 
+    migrate_legacy_layout()
+
     cmd = args.cmd
+    inst = Instance()
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
-    port = resolve_port(args.port) if hasattr(args, "port") else DEFAULT_PORT
+    port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT
 
     if cmd == "setup":
-        sys.exit(cmd_setup(quiet=args.quiet, port=port))
+        sys.exit(cmd_setup(quiet=args.quiet, port=port, inst=inst))
     elif cmd in ("start", "serve"):
-        sys.exit(cmd_start("serve", port))
+        sys.exit(cmd_start("serve", port, inst))
     elif cmd == "start-local":
-        sys.exit(cmd_start("start-local", port))
+        sys.exit(cmd_start("start-local", port, inst))
     elif cmd == "start-direct":
-        sys.exit(cmd_start("start-direct", port))
+        sys.exit(cmd_start("start-direct", port, inst))
     elif cmd == "stop":
-        sys.exit(cmd_stop(port))
+        sys.exit(cmd_stop(port, inst))
     elif cmd == "restart":
-        cmd_stop(port)
+        cmd_stop(port, inst)
         time.sleep(0.5)
-        sys.exit(cmd_start("serve", port))
+        sys.exit(cmd_start("serve", port, inst))
     elif cmd == "status":
-        sys.exit(cmd_status(port))
+        sys.exit(cmd_status(port, inst))
     elif cmd == "log":
-        sys.exit(cmd_log())
+        sys.exit(cmd_log(inst))
     elif cmd == "enable":
         from trustmux._enable import main as _run_enable
-        _run_enable(port)
+        _run_enable(port, inst)
     elif cmd == "disable":
         from trustmux._disable import main as _run_disable
-        _run_disable()
+        _run_disable(inst)
     elif cmd == "pair":
         from trustmux._pair import main as _run_pair
-        _run_pair()
+        _run_pair(inst)
     elif cmd == "unpair":
         from trustmux._unpair import main as _run_unpair
-        _run_unpair()
+        _run_unpair(inst)
 
 
 if __name__ == "__main__":

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -587,8 +587,12 @@ def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
         print("trustmux not running")
         # "Nothing found on *this* port" does not mean the pid file is stale
         # -- it may correctly be tracking this instance's daemon on another
-        # port. Only clean it up when its own recorded pid is actually dead.
-        if inst.pid_file.exists() and _recorded(inst) is None:
+        # port, which the live socket shows.  Without a live socket there is
+        # no daemon and the file is leftover, whether or not its pid resolves:
+        # across a reboot the state directory survives but pids restart, so a
+        # recorded pid can land on an unrelated live process.
+        if inst.pid_file.exists() and not (socket_is_live(inst.sock)
+                                           and _recorded(inst)):
             inst.pid_file.unlink(missing_ok=True)
         return 0
 

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,7 +11,10 @@ import sys
 import time
 from pathlib import Path
 
-from trustmux._paths import Instance, migrate_legacy_layout
+from trustmux._paths import (DEFAULT_INSTANCE, INSTANCE_ENV, Instance,
+                             check_sock_path, known_instances,
+                             migrate_legacy_layout, resolve_instance,
+                             state_dir)
 
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
@@ -177,40 +180,87 @@ def _ensure_dir(inst: Instance | None = None) -> None:
     inst.log_file.chmod(0o600)
 
 
-def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
-    """Return the PID of the trustmux daemon listening on `port`, or None.
+def _pids_on_port(port: int) -> list[int] | None:
+    """PIDs listening on port, per lsof.
 
-    lsof directly observes what is bound to `port`; when it can run, its
-    answer -- found or not -- is authoritative and final. Only when lsof
-    itself is unusable (e.g. not installed) does this fall back to asking
-    the running daemon what port *it* is bound to over the admin socket,
-    which is still port-scoped and authoritative since it is self-reported
-    by the live process rather than inferred.
-
-    There is deliberately no further fallback to "the pid file's pid is
-    alive," which cannot say anything about *which* port that pid owns:
-    trusting it blindly means a query for a port nothing is listening on can
-    return some other, unrelated daemon's pid -- which previously let
-    `trustmux stop --port <port nothing is on>` kill the wrong daemon.
+    Empty list means lsof ran and genuinely found nothing -- a definitive
+    answer.  None means lsof could not answer at all (not installed, or output
+    this does not understand), which is the only case where a caller may fall
+    back to guessing.
     """
-    inst = inst or Instance()
     try:
         out = subprocess.check_output(
             ["lsof", f"-ti:{port}"], stderr=subprocess.DEVNULL, text=True
-        ).strip()
-        return int(out.splitlines()[0]) if out else None
+        )
     except subprocess.CalledProcessError:
-        # lsof ran fine and found nothing bound to this port -- definitive.
+        return []          # ran fine, nothing bound to this port
+    except FileNotFoundError:
+        return None        # lsof unusable
+    lines = [x.strip() for x in out.splitlines() if x.strip()]
+    pids = [int(l) for l in lines if l.isdigit()]
+    if lines and not pids:
+        # An lsof that does not understand -ti:<port> prints a full listing
+        # rather than failing; its columns must not be misread as pids.
         return None
-    except (FileNotFoundError, ValueError):
-        pass  # lsof unusable; fall through to the daemon's own account.
+    return pids
 
-    info = daemon_info(inst)
-    if info and _valid_port(info.get("port")) == port:
-        pid = info.get("pid")
-        if isinstance(pid, int) and pid > 0:
-            return pid
-    return None
+
+def _recorded_pid(inst: Instance) -> int | None:
+    """Live PID from this instance's pid file, or None.
+
+    Says nothing about which port that pid owns -- only ever used to attribute
+    a pid that is already known to hold the port in question.
+    """
+    if not inst.pid_file.exists():
+        return None
+    try:
+        pid = int(inst.pid_file.read_text().strip())
+        os.kill(pid, 0)
+        return pid
+    except (ValueError, ProcessLookupError, PermissionError, OSError):
+        return None
+
+
+def _pid(port: int = DEFAULT_PORT, inst: Instance | None = None) -> int | None:
+    """Return the PID of this instance's daemon listening on `port`, or None.
+
+    lsof directly observes what is bound to `port`; when it can run, its
+    answer -- found or not -- is authoritative and final.  Only when lsof
+    itself is unusable does this fall back to asking the daemon what port *it*
+    is bound to over the admin socket, and only trust the reply when the
+    reported port matches the one being asked about.
+
+    Nothing here may return a pid without confirming it owns the *requested*
+    port: doing so is what previously let `trustmux stop --port <port nothing
+    is on>` kill an unrelated daemon.  The pid file is therefore only ever
+    used to decide *which* of the processes already known to hold the port is
+    ours -- never to conjure one up when the port is idle.
+    """
+    inst = inst or Instance()
+    listening = _pids_on_port(port)
+
+    if listening is None:
+        info = daemon_info(inst)
+        if info and _valid_port(info.get("port")) == port:
+            pid = info.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                return pid
+        return None
+
+    if not listening:
+        return None
+
+    # Something holds the port. Attribute it: with two instances bound to the
+    # same port on different addresses, "whichever pid lsof printed first" is
+    # a coin flip, so prefer this instance's own claim when it has one.
+    claimed = _recorded_pid(inst)
+    if claimed is None:
+        info = daemon_info(inst)
+        reported = info.get("pid") if info else None
+        claimed = reported if isinstance(reported, int) and reported > 0 else None
+    if claimed is not None:
+        return claimed if claimed in listening else None
+    return listening[0]
 
 
 def _ts_host() -> str:
@@ -354,7 +404,8 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
     env["PYTHONPATH"] = f"{pkg_parent}:{existing}" if existing else pkg_parent
     with inst.log_file.open("a") as log:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "trustmux", "--port", str(port)] + extra_args,
+            [sys.executable, "-m", "trustmux",
+             "--port", str(port), "--instance", inst.name] + extra_args,
             stdout=log, stderr=log,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
@@ -371,9 +422,35 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
     return _pid(port, inst)
 
 
+def can_use_serve(inst: Instance, stream=sys.stderr) -> bool:
+    """False (with a message) if this instance must not use serve mode.
+
+    `tailscale serve` publishes on the tailnet's port 443, which only one
+    daemon can own: a second `tailscale serve --bg` silently replaces the
+    first instance's mapping, leaving it running but unreachable.  Per-instance
+    --port does not help, since that only moves the loopback backend the proxy
+    forwards to, not the tailnet-facing port.
+    """
+    if inst.name == DEFAULT_INSTANCE:
+        return True
+    print(f"Error: instance {inst.name!r} cannot use tailscale serve mode.", file=stream)
+    print("  `tailscale serve` publishes on the tailnet's port 443, which only one",
+          file=stream)
+    print("  daemon can own — a second one would silently take over the mapping.",
+          file=stream)
+    print("  Use a mode that binds its own port instead:", file=stream)
+    print(f"    trustmux start-direct{inst.label()} --port <port>", file=stream)
+    print(f"    trustmux start-local{inst.label()} --port <port>", file=stream)
+    return False
+
+
 def cmd_setup(quiet: bool = False, port: int | None = None,
               inst: Instance | None = None) -> int:
     inst = inst or Instance()
+    # setup exists to configure tailscale serve, so there is nothing it can
+    # usefully do for an instance that is not allowed to use it.
+    if not can_use_serve(inst):
+        return 1
     port = resolve_port(port, inst)
     print("=== trustmux setup ===\n")
 
@@ -408,9 +485,10 @@ def cmd_setup(quiet: bool = False, port: int | None = None,
     warn_if_peer_blocked()
 
     if not quiet:
+        opts = f"{inst.label()}{port_opt(port)}"
         print("\nSetup complete. Next steps:\n")
-        print(f"  1. Start the daemon:      trustmux start{port_opt(port)}")
-        print("  2. Generate pairing code: trustmux pair")
+        print(f"  1. Start the daemon:      trustmux start{opts}")
+        print(f"  2. Generate pairing code: trustmux pair{inst.label()}")
         print(f"  3. Open on your phone:    https://{ts_host}")
     return 0
 
@@ -418,6 +496,10 @@ def cmd_setup(quiet: bool = False, port: int | None = None,
 def cmd_start(mode: str = "serve", port: int | None = None,
               inst: Instance | None = None) -> int:
     inst = inst or Instance()
+    if mode == "serve" and not can_use_serve(inst):
+        return 1
+    if not check_sock_path(inst):
+        return 1
     port = resolve_port(port, inst)
     p = _pid(port, inst)
     if p:
@@ -492,12 +574,8 @@ def cmd_stop(port: int | None = None, inst: Instance | None = None) -> int:
         # "Nothing found on *this* port" does not mean the pid file is stale
         # -- it may correctly be tracking this instance's daemon on another
         # port. Only clean it up when its own recorded pid is actually dead.
-        if inst.pid_file.exists():
-            try:
-                file_pid = int(inst.pid_file.read_text().strip())
-                os.kill(file_pid, 0)
-            except (ValueError, ProcessLookupError, PermissionError, OSError):
-                inst.pid_file.unlink(missing_ok=True)
+        if inst.pid_file.exists() and _recorded_pid(inst) is None:
+            inst.pid_file.unlink(missing_ok=True)
         return 0
 
     if inst.pid_file.exists():
@@ -544,6 +622,20 @@ def cmd_status(port: int | None = None, inst: Instance | None = None) -> int:
     return 0
 
 
+def cmd_list() -> int:
+    instances = known_instances()
+    if not instances:
+        print("no trustmux instances yet")
+        return 0
+    print(f"{'INSTANCE':<16} {'PORT':>5}  {'SCHEME':<6} STATUS")
+    for inst in instances:
+        info = daemon_info(inst) or {}
+        port = _valid_port(info.get("port"))
+        p = _pid(port or DEFAULT_PORT, inst) if info else _recorded_pid(inst)
+        status = f"running (pid {p})" if p else "stopped"
+        print(f"{inst.name:<16} {port or '-':>5}  {info.get('scheme', '-'):<6} {status}")
+    return 0
+
 
 def cmd_log(inst: Instance | None = None) -> int:
     inst = inst or Instance()
@@ -587,26 +679,36 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="cmd")
 
+    # --instance selects which daemon's state directory to act on and so is
+    # accepted everywhere; --port only matters to commands that address a
+    # listener.
+    inst_opts = argparse.ArgumentParser(add_help=False)
+    inst_opts.add_argument("--instance", metavar="NAME",
+                           help=f"Instance name (default: {DEFAULT_INSTANCE}, or ${INSTANCE_ENV})")
+
     port_opts = argparse.ArgumentParser(add_help=False)
     port_opts.add_argument("--port", type=int, metavar="PORT",
                            help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
 
-    p_setup = sub.add_parser("setup", parents=[port_opts],
+    both = [inst_opts, port_opts]
+
+    p_setup = sub.add_parser("setup", parents=both,
                              help="One-time setup: verify install, configure tailscale serve")
     p_setup.add_argument("--quiet", action="store_true", help="Suppress next-steps output")
 
-    sub.add_parser("start",        parents=[port_opts], help="Start daemon via tailscale serve (HTTPS — default)")
-    sub.add_parser("serve",        parents=[port_opts], help=argparse.SUPPRESS)   # alias
-    sub.add_parser("start-local",  parents=[port_opts], help="Start daemon loopback-only for SSH tunnel access")
-    sub.add_parser("start-direct", parents=[port_opts], help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
-    sub.add_parser("stop",         parents=[port_opts], help="Stop daemon (tailscale serve config persists)")
-    sub.add_parser("restart",      parents=[port_opts], help="Restart daemon")
-    sub.add_parser("status",       parents=[port_opts], help="Show running status and URL")
-    sub.add_parser("enable",       parents=[port_opts], help="Start daemon and install login hook for automatic start")
-    sub.add_parser("log",          help="Tail the log file")
-    sub.add_parser("disable",      help="Stop daemon and remove login hook")
-    sub.add_parser("pair",         help="Generate a one-time pairing code for a new device")
-    sub.add_parser("unpair",       help="List paired devices and revoke tokens")
+    sub.add_parser("start",        parents=both, help="Start daemon via tailscale serve (HTTPS — default)")
+    sub.add_parser("serve",        parents=both, help=argparse.SUPPRESS)   # alias
+    sub.add_parser("start-local",  parents=both, help="Start daemon loopback-only for SSH tunnel access")
+    sub.add_parser("start-direct", parents=both, help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
+    sub.add_parser("stop",         parents=both, help="Stop daemon (tailscale serve config persists)")
+    sub.add_parser("restart",      parents=both, help="Restart daemon")
+    sub.add_parser("status",       parents=both, help="Show running status and URL")
+    sub.add_parser("enable",       parents=both, help="Start daemon and install login hook for automatic start")
+    sub.add_parser("log",          parents=[inst_opts], help="Tail the log file")
+    sub.add_parser("disable",      parents=[inst_opts], help="Stop daemon and remove login hook")
+    sub.add_parser("pair",         parents=[inst_opts], help="Generate a one-time pairing code for a new device")
+    sub.add_parser("unpair",       parents=[inst_opts], help="List paired devices and revoke tokens")
+    sub.add_parser("list",         help="List instances and their listeners")
     sub.add_parser("help",         help=argparse.SUPPRESS)  # alias for -h/--help
 
     args = parser.parse_args()
@@ -617,7 +719,7 @@ def main() -> None:
     migrate_legacy_layout()
 
     cmd = args.cmd
-    inst = Instance()
+    inst = resolve_instance(getattr(args, "instance", None))
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
     port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT
@@ -633,11 +735,18 @@ def main() -> None:
     elif cmd == "stop":
         sys.exit(cmd_stop(port, inst))
     elif cmd == "restart":
+        # restart brings the daemon back in serve mode, so check the serve
+        # restriction before stopping anything -- otherwise a named instance
+        # gets stopped and then refused, leaving it down.
+        if not can_use_serve(inst):
+            sys.exit(1)
         cmd_stop(port, inst)
         time.sleep(0.5)
         sys.exit(cmd_start("serve", port, inst))
     elif cmd == "status":
         sys.exit(cmd_status(port, inst))
+    elif cmd == "list":
+        sys.exit(cmd_list())
     elif cmd == "log":
         sys.exit(cmd_log(inst))
     elif cmd == "enable":

--- a/mobile/trustmux/_ctl.py
+++ b/mobile/trustmux/_ctl.py
@@ -11,6 +11,8 @@ import sys
 import time
 from pathlib import Path
 
+from trustmux._advertise import (ADVERTISE_ENV, AdvertiseError, advertised_urls,
+                                 check_sources, resolve_sources)
 from trustmux._paths import (DEFAULT_INSTANCE, INSTANCE_ENV, Instance,
                              check_sock_path, known_instances,
                              migrate_legacy_layout, resolve_instance,
@@ -19,6 +21,11 @@ from trustmux._paths import (DEFAULT_INSTANCE, INSTANCE_ENV, Instance,
 DEFAULT_PORT = 7432
 PORT_ENV   = "TRUSTMUX_PORT"
 SERVE_PORT = 443  # tailscale serve terminates TLS on :443
+
+# How long to wait for a just-launched daemon to answer on its admin socket.
+# Generous because resolving a cmd: advertise source happens before the socket
+# is bound and may take seconds (trustmux._advertise.CMD_BUDGET).
+LAUNCH_TIMEOUT = 12.0
 
 
 def _check_tmux() -> bool:
@@ -175,6 +182,12 @@ def direct_url(port: int, info: dict | None = None) -> str:
     """
     if info is None:
         info = daemon_info() or {}
+    # An advertised address is the operator saying what a phone can actually
+    # reach, and it is what the daemon built its certificate for, so it outranks
+    # anything discoverable from here.
+    advertised = advertised_urls(info)
+    if advertised:
+        return advertised[0]
     # A live daemon's own port beats the caller's idea of it.
     port = _valid_port(info.get("port")) or port
     scheme = info.get("scheme") or "https"
@@ -420,14 +433,23 @@ def _launch(port: int, extra_args: list[str], inst: Instance | None = None) -> i
             env=env,
         )
     write_pid_file(inst, proc.pid, port)
-    time.sleep(0.5)
-    if proc.poll() is not None:
-        # Died on startup — usually the port is taken, which is easy to hit
-        # once more than one instance is in play.  Without this the pid file
-        # still names the (zombie) child and the caller reports success.
-        inst.pid_file.unlink(missing_ok=True)
-        return None
-    return _pid(port, inst)
+    # Wait for the daemon to answer rather than sleeping a fixed interval:
+    # resolving an advertise source runs before the admin socket is bound and
+    # may take seconds, and a healthy daemon still starting up must not be
+    # reported as a failure to start.
+    deadline = time.monotonic() + LAUNCH_TIMEOUT
+    while True:
+        time.sleep(0.1)
+        if proc.poll() is not None:
+            # Died on startup — usually the port is taken, which is easy to hit
+            # once more than one instance is in play, or an advertise source
+            # that would not resolve.  Without this the pid file still names the
+            # (zombie) child and the caller reports success.
+            inst.pid_file.unlink(missing_ok=True)
+            return None
+        pid = _pid(port, inst)
+        if pid or time.monotonic() >= deadline:
+            return pid
 
 
 def can_use_serve(inst: Instance, stream=sys.stderr) -> bool:
@@ -501,8 +523,43 @@ def cmd_setup(quiet: bool = False, port: int | None = None,
     return 0
 
 
+def advertise_args(advertise: list[str] | None = None, no_advertise: bool = False,
+                   inst: Instance | None = None) -> list[str]:
+    """Resolve advertise sources here and spell them out for the daemon.
+
+    Passing the decision explicitly -- including "none" -- means the daemon we
+    launch never re-derives it from the environment or the config file, so the
+    CLI's precedence is the only one in play.  Raises AdvertiseError.
+    """
+    sources = resolve_sources(advertise, no_advertise, inst)
+    check_sources(sources)
+    if not sources:
+        return ["--no-advertise"]
+    return [arg for source in sources for arg in ("--advertise", source)]
+
+
+def _log_error(inst: Instance, offset: int = 0) -> str:
+    """The daemon's own 'Error:' line from whatever it logged past offset.
+
+    A failure to start has more causes than a taken port now that an advertise
+    source can refuse to resolve, and the daemon already says which -- but
+    nobody reads a log on a hunch.
+    """
+    try:
+        with inst.log_file.open() as f:
+            f.seek(offset)
+            lines = f.read().splitlines()
+    except OSError:
+        return ""
+    for line in reversed(lines):
+        if line.startswith("Error:"):
+            return line
+    return ""
+
+
 def cmd_start(mode: str = "serve", port: int | None = None,
-              inst: Instance | None = None) -> int:
+              inst: Instance | None = None, advertise: list[str] | None = None,
+              no_advertise: bool = False) -> int:
     inst = inst or Instance()
     if mode == "serve" and not can_use_serve(inst):
         return 1
@@ -513,6 +570,21 @@ def cmd_start(mode: str = "serve", port: int | None = None,
     if p:
         print(f"trustmux already running (pid {p})")
         return 1
+
+    # Before anything is started: a source that cannot even be read is a usage
+    # error, and reporting it as one beats a daemon that exits during startup.
+    try:
+        adv = advertise_args(advertise, no_advertise, inst)
+    except AdvertiseError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+
+    # Where this instance's log ends now, so that a failure below is diagnosed
+    # from what this daemon logged rather than from an earlier attempt's error.
+    try:
+        log_mark = inst.log_file.stat().st_size
+    except OSError:
+        log_mark = 0
 
     if mode == "serve":
         if not _check_tmux():
@@ -534,21 +606,23 @@ def cmd_start(mode: str = "serve", port: int | None = None,
         if not _ensure_ts_serve(port):
             return 1
         print("Starting trustmux (HTTPS mode)...")
-        pid = _launch(port, ["--host", "127.0.0.1", "--https"], inst)
+        pid = _launch(port, adv + ["--host", "127.0.0.1", "--https"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
-            print(f"Connect: https://{ts_host}")
+            urls = advertised_urls(daemon_info(inst))
+            print(f"Connect: {urls[0] if urls else f'https://{ts_host}'}")
 
     elif mode == "start-local":
         print("Starting trustmux (loopback only — SSH tunnel access)...")
-        pid = _launch(port, ["--host", "127.0.0.1"], inst)
+        pid = _launch(port, adv + ["--host", "127.0.0.1"], inst)
         ok = pid is not None
         if ok:
             fqdn = socket.getfqdn()
+            urls = advertised_urls(daemon_info(inst))
             print(f"trustmux started (pid {pid})")
             print(f"Access via SSH tunnel: ssh -L {port}:localhost:{port} user@{fqdn}")
-            print(f"Then open: http://localhost:{port}")
+            print(f"Then open: {urls[0] if urls else f'http://localhost:{port}'}")
 
     elif mode == "start-direct":
         if not _check_tmux():
@@ -556,11 +630,13 @@ def cmd_start(mode: str = "serve", port: int | None = None,
         if not _check_tls():
             return 1
         print("Starting trustmux (direct HTTPS — self-signed cert)...")
-        pid = _launch(port, ["--host", "0.0.0.0", "--self-signed"], inst)
+        pid = _launch(port, adv + ["--host", "0.0.0.0", "--self-signed"], inst)
         ok = pid is not None
         if ok:
             print(f"trustmux started (pid {pid})")
-            print(f"Connect: https://{_lan_ip()}:{port}")
+            # direct_url() prefers whatever the daemon says it advertises, so
+            # this prints the reachable address rather than the local one.
+            print(f"Connect: {direct_url(port, daemon_info(inst))}")
             print(f"  (browser will warn about self-signed cert — click through to proceed)")
 
     else:
@@ -568,13 +644,17 @@ def cmd_start(mode: str = "serve", port: int | None = None,
         return 1
 
     if not ok:
-        # _pid() only names daemons this instance claims, so a port held by
-        # someone else no longer surfaces as "already running" -- it lands here
-        # instead, as a failure to bind.  Name that as the likely cause: the
-        # daemon logged the real errno, but nobody reads a log on a hunch.
         print(f"trustmux failed to start — check {inst.log_file}")
-        print(f"  (most often port {port} is already in use — try another "
-              f"--port)", file=sys.stderr)
+        reason = _log_error(inst, log_mark)
+        if reason:
+            print(f"  {reason}", file=sys.stderr)
+        else:
+            # _pid() only names daemons this instance claims, so a port held by
+            # someone else no longer surfaces as "already running" -- it lands
+            # here instead, as a failure to bind, and the daemon logs an errno
+            # rather than one of its own "Error:" lines.
+            print(f"  (most often port {port} is already in use — try another "
+                  f"--port)", file=sys.stderr)
         return 1
     return 0
 
@@ -624,18 +704,21 @@ def cmd_status(port: int | None = None, inst: Instance | None = None) -> int:
         return 0
 
     print(f"trustmux running (pid {p}) — port {port}")
-    try:
-        out = subprocess.check_output(
-            ["tailscale", "serve", "status"],
-            stderr=subprocess.DEVNULL, text=True,
-        )
-        if f":{port}" in out:
-            ts_host = _ts_host()
-            if ts_host:
-                print(f"Connect: https://{ts_host}")
-            return 0
-    except Exception:
-        pass
+    # An advertised address is what the daemon certified and what pair prints,
+    # so it wins over the tailnet name here as well.
+    if not advertised_urls(info):
+        try:
+            out = subprocess.check_output(
+                ["tailscale", "serve", "status"],
+                stderr=subprocess.DEVNULL, text=True,
+            )
+            if f":{port}" in out:
+                ts_host = _ts_host()
+                if ts_host:
+                    print(f"Connect: https://{ts_host}")
+                return 0
+        except Exception:
+            pass
     print(f"Connect: {direct_url(port, info)}")
     return 0
 
@@ -790,20 +873,33 @@ def main() -> None:
     port_opts.add_argument("--port", type=int, metavar="PORT",
                            help=f"TCP port (default: {DEFAULT_PORT}, or ${PORT_ENV})")
 
+    # Advertising changes what the daemon publishes — the URL `pair` prints and
+    # the names in its certificate — not what it binds, so only the commands
+    # that start a daemon can set it.
+    adv_opts = argparse.ArgumentParser(add_help=False)
+    adv_opts.add_argument("--advertise", metavar="SOURCE", action="append",
+                          help="Address a phone should use when it is not the one "
+                               "this host can see: HOST, HOST:PORT, a URL, or "
+                               "cmd:PROGRAM to run PROGRAM for it. Repeatable; "
+                               f"replaces ${ADVERTISE_ENV} and the config file")
+    adv_opts.add_argument("--no-advertise", action="store_true",
+                          help="Advertise nothing, ignoring any configured source")
+
     both = [inst_opts, port_opts]
+    starting = both + [adv_opts]
 
     p_setup = sub.add_parser("setup", parents=both,
                              help="One-time setup: verify install, configure tailscale serve")
     p_setup.add_argument("--quiet", action="store_true", help="Suppress next-steps output")
 
-    sub.add_parser("start",        parents=both, help="Start daemon via tailscale serve (HTTPS — default)")
-    sub.add_parser("serve",        parents=both, help=argparse.SUPPRESS)   # alias
-    sub.add_parser("start-local",  parents=both, help="Start daemon loopback-only for SSH tunnel access")
-    sub.add_parser("start-direct", parents=both, help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
+    sub.add_parser("start",        parents=starting, help="Start daemon via tailscale serve (HTTPS — default)")
+    sub.add_parser("serve",        parents=starting, help=argparse.SUPPRESS)   # alias
+    sub.add_parser("start-local",  parents=starting, help="Start daemon loopback-only for SSH tunnel access")
+    sub.add_parser("start-direct", parents=starting, help="Start daemon direct HTTPS (self-signed cert, no Tailscale)")
     sub.add_parser("stop",         parents=both, help="Stop daemon (tailscale serve config persists)")
-    sub.add_parser("restart",      parents=both, help="Restart daemon")
+    sub.add_parser("restart",      parents=starting, help="Restart daemon")
     sub.add_parser("status",       parents=both, help="Show running status and URL")
-    sub.add_parser("enable",       parents=both, help="Start daemon and install login hook for automatic start")
+    sub.add_parser("enable",       parents=starting, help="Start daemon and install login hook for automatic start")
     sub.add_parser("log",          parents=[inst_opts], help="Tail the log file")
     sub.add_parser("disable",      parents=[inst_opts], help="Stop daemon and remove login hook")
     sub.add_parser("pair",         parents=[inst_opts], help="Generate a one-time pairing code for a new device")
@@ -828,15 +924,17 @@ def main() -> None:
     # Resolve once: restart must reuse the running daemon's port after stopping
     # it, by which point the daemon can no longer be asked.
     port = resolve_port(args.port, inst) if hasattr(args, "port") else DEFAULT_PORT
+    adv = getattr(args, "advertise", None)
+    no_adv = getattr(args, "no_advertise", False)
 
     if cmd == "setup":
         sys.exit(cmd_setup(quiet=args.quiet, port=port, inst=inst))
     elif cmd in ("start", "serve"):
-        sys.exit(cmd_start("serve", port, inst))
+        sys.exit(cmd_start("serve", port, inst, adv, no_adv))
     elif cmd == "start-local":
-        sys.exit(cmd_start("start-local", port, inst))
+        sys.exit(cmd_start("start-local", port, inst, adv, no_adv))
     elif cmd == "start-direct":
-        sys.exit(cmd_start("start-direct", port, inst))
+        sys.exit(cmd_start("start-direct", port, inst, adv, no_adv))
     elif cmd == "stop":
         sys.exit(cmd_stop(port, inst))
     elif cmd == "restart":
@@ -847,7 +945,7 @@ def main() -> None:
             sys.exit(1)
         cmd_stop(port, inst)
         time.sleep(0.5)
-        sys.exit(cmd_start("serve", port, inst))
+        sys.exit(cmd_start("serve", port, inst, adv, no_adv))
     elif cmd == "status":
         sys.exit(cmd_status(port, inst))
     elif cmd == "list":
@@ -858,7 +956,7 @@ def main() -> None:
         sys.exit(cmd_log(inst))
     elif cmd == "enable":
         from trustmux._enable import main as _run_enable
-        _run_enable(port, inst)
+        _run_enable(port, inst, adv, no_adv)
     elif cmd == "disable":
         from trustmux._disable import main as _run_disable
         _run_disable(inst)

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -16,12 +16,14 @@ import socket
 import subprocess
 import sys
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 import tornado.httpserver
 import tornado.web
 import tornado.websocket
 
+from trustmux._advertise import AdvertiseError, resolve, resolve_sources
 from trustmux._paths import (Instance, check_sock_path, machines_file,
                              migrate_legacy_layout, resolve_instance,
                              socket_is_live)
@@ -1104,10 +1106,11 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
             # Lets `trustmux stop/status/pair` discover the live listener
             # instead of assuming the default port.
             resp: object = {
-                "pid":    os.getpid(),
-                "host":   _listen.get("host", ""),
-                "port":   _listen.get("port", 0),
-                "scheme": _listen.get("scheme", ""),
+                "pid":       os.getpid(),
+                "host":      _listen.get("host", ""),
+                "port":      _listen.get("port", 0),
+                "scheme":    _listen.get("scheme", ""),
+                "advertise": _listen.get("advertise", []),
             }
 
         elif action == "pair_generate":
@@ -1227,8 +1230,14 @@ def _make_app() -> tornado.web.Application:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def _ensure_self_signed_cert(lan_ip: str) -> tuple:
-    """Generate a self-signed TLS cert for lan_ip. Returns (cert_path, ssl_ctx)."""
+def _ensure_self_signed_cert(lan_ip: str, advertised: Sequence[str] = ()) -> tuple:
+    """Generate a self-signed TLS cert for lan_ip. Returns (cert_path, ssl_ctx).
+
+    advertised are hosts this daemon was told to publish.  They have to be in
+    here: a browser refuses a certificate that omits the name in the URL bar
+    outright, rather than offering the click-through a self-signed one gets, so
+    advertising an address without certifying it would be worse than useless.
+    """
     import ssl as _ssl
     import ipaddress as _ipaddress
     import datetime as _datetime
@@ -1250,6 +1259,16 @@ def _ensure_self_signed_cert(lan_ip: str) -> tuple:
     ts_ip = _tailscale_ip()
     if ts_ip and ts_ip != lan_ip:
         san_parts.append(f"IP:{ts_ip}")
+    for host in advertised:
+        try:
+            _ipaddress.ip_address(host)
+        except ValueError:
+            san_parts.append(f"DNS:{host}")
+        else:
+            san_parts.append(f"IP:{host}")
+    # An advertised host is often one of these already (the fqdn, say), and a
+    # duplicated SAN is legal but pointless.
+    san_parts = list(dict.fromkeys(san_parts))
     try:
         private_key = _ec.generate_private_key(_ec.SECP256R1())
         san_list = []
@@ -1288,11 +1307,13 @@ def _ensure_self_signed_cert(lan_ip: str) -> tuple:
     ctx = _ssl.SSLContext(_ssl.PROTOCOL_TLS_SERVER)
     ctx.minimum_version = _ssl.TLSVersion.TLSv1_3
     ctx.load_cert_chain(str(cert), str(key))
-    print(f"Trustmux: self-signed TLS cert generated for {lan_ip}", flush=True)
+    named = ", ".join(dict.fromkeys([lan_ip, *advertised]))
+    print(f"Trustmux: self-signed TLS cert generated for {named}", flush=True)
     return cert, ctx
 
 
-async def _amain(host: str, port: int, https: bool, ssl_ctx=None) -> None:
+async def _amain(host: str, port: int, https: bool, ssl_ctx=None,
+                 advertise: Sequence[str] = ()) -> None:
     global _https_mode, _listen
     _https_mode = https or ssl_ctx is not None
     _listen = {
@@ -1301,6 +1322,9 @@ async def _amain(host: str, port: int, https: bool, ssl_ctx=None) -> None:
         # --https means tailscale serve terminates TLS in front of us, so the
         # URL a client uses is https even though this socket is plain HTTP.
         "scheme": "https" if _https_mode else "http",
+        # What pair and status should print.  Only the daemon knows which hosts
+        # its certificate actually attests, so it is the one to say.
+        "advertise": list(advertise),
     }
     app = _make_app()
     # xheaders=True: trust X-Forwarded-For/Proto from tailscale serve proxy.
@@ -1341,6 +1365,12 @@ def main():
     parser.add_argument("--name", metavar="NAME", default=None,
                         help="Instance whose state and runtime files to use "
                              "(default: default)")
+    parser.add_argument("--advertise", metavar="SOURCE", action="append",
+                        help="Address to publish and to name in the TLS "
+                             "certificate: HOST, HOST:PORT, a URL, or "
+                             "cmd:PROGRAM to run PROGRAM for it (repeatable)")
+    parser.add_argument("--no-advertise", action="store_true",
+                        help="Advertise nothing, ignoring any configured source")
 
     # `trustmuxd help` is a natural guess (matches `trustmux help`'s alias for
     # -h/--help) but argparse has no subcommands here to hang a hidden alias
@@ -1382,6 +1412,24 @@ def main():
                 host = "127.0.0.1"
                 print("Trustmux: Tailscale not found, binding to localhost only")
 
+    scheme = "https" if (args.https or args.self_signed) else "http"
+
+    # Ahead of the certificate, which has to name these hosts, and ahead of the
+    # admin socket, so a source that cannot be resolved keeps the daemon from
+    # ever answering with an address it has not confirmed.  Refusing to start is
+    # the same stance taken when TLS is unavailable: an unreachable URL or a
+    # certificate for the wrong host is not something a warning would fix.
+    try:
+        advertised = resolve(resolve_sources(args.advertise, args.no_advertise, inst),
+                             scheme, args.port)
+    except AdvertiseError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print("Trustmux refuses to start rather than publish an address it "
+              "cannot confirm.", file=sys.stderr)
+        sys.exit(1)
+    if advertised:
+        print("Trustmux: advertising " + ", ".join(a.url for a in advertised), flush=True)
+
     ssl_ctx = None
     if args.self_signed:
         lan_ip = host if host not in ("0.0.0.0", None) else _tailscale_ip() or "127.0.0.1"
@@ -1392,11 +1440,11 @@ def main():
             s.close()
         except Exception:
             pass
-        _, ssl_ctx = _ensure_self_signed_cert(lan_ip)
+        _, ssl_ctx = _ensure_self_signed_cert(lan_ip, [a.host for a in advertised])
 
-    scheme = "https" if (args.https or ssl_ctx) else "http"
     print(f"Trustmux daemon on {scheme}://{host}:{args.port} — run 'trustmux-pair' to pair a device.", flush=True)
-    asyncio.run(_amain(host, args.port, args.https, ssl_ctx))
+    asyncio.run(_amain(host, args.port, args.https, ssl_ctx,
+                       [a.url for a in advertised]))
 
 
 if __name__ == "__main__":

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -23,7 +23,8 @@ import tornado.web
 import tornado.websocket
 
 from trustmux._paths import (Instance, check_sock_path, machines_file,
-                             migrate_legacy_layout, resolve_instance)
+                             migrate_legacy_layout, resolve_instance,
+                             socket_is_live)
 
 def _resolve_version() -> str:
     import subprocess as _sp
@@ -1175,20 +1176,10 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
 def _socket_is_stale(path: Path) -> bool:
     """True if path is a socket file with nothing listening on it.
 
-    The state directory persists across logout and reboot, so a socket left
-    behind by a killed daemon stays on disk.  Connecting is the only way to
-    tell that apart from one a live daemon is serving: a leftover file refuses
-    the connection, a live one accepts it.
+    Shares socket_is_live() with the CLI so that "is this instance running?"
+    cannot be answered one way here and another way by `trustmux status`.
     """
-    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    probe.settimeout(1.5)
-    try:
-        probe.connect(str(path))
-    except OSError:
-        return True
-    finally:
-        probe.close()
-    return False
+    return not socket_is_live(path)
 
 
 async def _run_admin_server() -> None:

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -1192,7 +1192,9 @@ def _socket_is_stale(path: Path) -> bool:
 
 
 async def _run_admin_server() -> None:
-    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # ensure_dirs(), not a bare mkdir: it re-asserts 0700 on a directory that
+    # already exists with looser permissions, which is what guards the socket.
+    INSTANCE.ensure_dirs()
     # Only ever remove a socket nothing is serving; main() has already refused
     # to start if a live one was there.
     if ADMIN_SOCK.exists() and _socket_is_stale(ADMIN_SOCK):

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -22,7 +22,8 @@ import tornado.httpserver
 import tornado.web
 import tornado.websocket
 
-from trustmux._paths import Instance, machines_file, migrate_legacy_layout
+from trustmux._paths import (Instance, check_sock_path, machines_file,
+                             migrate_legacy_layout, resolve_instance)
 
 def _resolve_version() -> str:
     import subprocess as _sp
@@ -66,7 +67,7 @@ _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on un
 _https_mode: bool = False             # set by --https; enables Secure cookie
 _listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
-# Which instance's files this daemon owns.
+# Which instance's files this daemon owns; repointed by --instance.
 INSTANCE      = Instance()
 STATE_DIR     = INSTANCE.state
 TOKENS_FILE   = INSTANCE.tokens_file
@@ -75,6 +76,16 @@ CERT_FILE     = INSTANCE.cert_file
 KEY_FILE      = INSTANCE.key_file
 MACHINES_FILE = machines_file()   # shared by every instance
 
+
+def _set_instance(inst: Instance) -> None:
+    """Point this daemon's files at inst. Must run before _load_tokens()."""
+    global INSTANCE, STATE_DIR, TOKENS_FILE, ADMIN_SOCK, CERT_FILE, KEY_FILE
+    INSTANCE    = inst
+    STATE_DIR   = inst.state
+    TOKENS_FILE = inst.tokens_file
+    ADMIN_SOCK  = inst.sock
+    CERT_FILE   = inst.cert_file
+    KEY_FILE    = inst.key_file
 
 
 _INSTALLED_STATIC = Path("/usr/share/trustmux/static")
@@ -1334,6 +1345,9 @@ def main():
                         help="HTTPS mode: Secure cookie + trust proxy headers (use with tailscale serve)")
     parser.add_argument("--self-signed", action="store_true",
                         help="Generate a self-signed TLS cert for direct HTTPS without Tailscale")
+    parser.add_argument("--instance", metavar="NAME", default=None,
+                        help="Instance whose state and runtime files to use "
+                             "(default: default)")
 
     # `trustmuxd help` is a natural guess (matches `trustmux help`'s alias for
     # -h/--help) but argparse has no subcommands here to hang a hidden alias
@@ -1345,6 +1359,10 @@ def main():
     args = parser.parse_args()
 
     migrate_legacy_layout()
+    inst = resolve_instance(args.instance)
+    if not check_sock_path(inst):
+        sys.exit(1)
+    _set_instance(inst)
 
     # Refuse before the event loop starts, so this surfaces as a plain message
     # rather than a traceback out of an asyncio task.  Unlinking a live socket

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -22,6 +22,8 @@ import tornado.httpserver
 import tornado.web
 import tornado.websocket
 
+from trustmux._paths import Instance, machines_file, migrate_legacy_layout
+
 def _resolve_version() -> str:
     import subprocess as _sp
     # Prefer the full Debian package version (e.g. 7.14-1~local1) when
@@ -64,10 +66,17 @@ _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on un
 _https_mode: bool = False             # set by --https; enables Secure cookie
 _listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
-CONFIG_DIR    = Path.home() / ".config" / "trustmux"
-TOKENS_FILE   = CONFIG_DIR / "tokens.json"
-ADMIN_SOCK    = CONFIG_DIR / "trustmux.sock"
-MACHINES_FILE = CONFIG_DIR / "machines.json"
+# Which instance's files this daemon owns.
+INSTANCE      = Instance()
+STATE_DIR     = INSTANCE.state
+TOKENS_FILE   = INSTANCE.tokens_file
+ADMIN_SOCK    = INSTANCE.sock
+CERT_FILE     = INSTANCE.cert_file
+KEY_FILE      = INSTANCE.key_file
+MACHINES_FILE = machines_file()   # shared by every instance
+
+
+
 _INSTALLED_STATIC = Path("/usr/share/trustmux/static")
 _DEV_STATIC       = Path(__file__).parent / "static"
 STATIC            = _INSTALLED_STATIC if _INSTALLED_STATIC.is_dir() else _DEV_STATIC
@@ -111,8 +120,8 @@ def _load_tokens() -> None:
         print(f"Warning: could not load {TOKENS_FILE}: {e} — all sessions lost", flush=True)
 
 def _save_tokens() -> None:
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-    CONFIG_DIR.chmod(0o700)
+    STATE_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    STATE_DIR.chmod(0o700)
     tmp = TOKENS_FILE.with_suffix(".tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
@@ -1152,8 +1161,30 @@ async def _handle_admin(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
         await writer.wait_closed()
 
 
+def _socket_is_stale(path: Path) -> bool:
+    """True if path is a socket file with nothing listening on it.
+
+    The state directory persists across logout and reboot, so a socket left
+    behind by a killed daemon stays on disk.  Connecting is the only way to
+    tell that apart from one a live daemon is serving: a leftover file refuses
+    the connection, a live one accepts it.
+    """
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(1.5)
+    try:
+        probe.connect(str(path))
+    except OSError:
+        return True
+    finally:
+        probe.close()
+    return False
+
+
 async def _run_admin_server() -> None:
-    if ADMIN_SOCK.exists():
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Only ever remove a socket nothing is serving; main() has already refused
+    # to start if a live one was there.
+    if ADMIN_SOCK.exists() and _socket_is_stale(ADMIN_SOCK):
         ADMIN_SOCK.unlink()
     old_mask = os.umask(0o177)  # socket created with mode 0o600
     try:
@@ -1202,9 +1233,9 @@ def _ensure_self_signed_cert(lan_ip: str) -> tuple:
     from cryptography.hazmat.primitives import hashes as _hashes, serialization as _ser
     from cryptography.hazmat.primitives.asymmetric import ec as _ec
 
-    cert = CONFIG_DIR / "cert.pem"
-    key  = CONFIG_DIR / "key.pem"
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    cert = CERT_FILE
+    key  = KEY_FILE
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
     san_parts = [f"IP:{lan_ip}", "IP:127.0.0.1", "DNS:localhost"]
     fqdn = socket.getfqdn()
     if fqdn and fqdn not in ("localhost", lan_ip):
@@ -1312,6 +1343,18 @@ def main():
         parser.print_help()
         sys.exit(0)
     args = parser.parse_args()
+
+    migrate_legacy_layout()
+
+    # Refuse before the event loop starts, so this surfaces as a plain message
+    # rather than a traceback out of an asyncio task.  Unlinking a live socket
+    # would leave the daemon already serving on it running on an unlinked
+    # inode that nothing can reach, silently stealing pair/unpair/info from it.
+    if ADMIN_SOCK.exists() and not _socket_is_stale(ADMIN_SOCK):
+        print(f"Error: another trustmux daemon is already serving {ADMIN_SOCK}",
+              file=sys.stderr)
+        print("  Stop it first, or use a different state directory.", file=sys.stderr)
+        sys.exit(1)
 
     _load_tokens()
 

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -68,7 +68,7 @@ _ws_clients: dict[str, set] = {}     # token → set[WsHandler] — closed on un
 _https_mode: bool = False             # set by --https; enables Secure cookie
 _listen: dict = {}                    # bound host/port/scheme, served by admin "info"
 
-# Which instance's files this daemon owns; repointed by --instance.
+# Which instance's files this daemon owns; repointed by --name.
 INSTANCE      = Instance()
 STATE_DIR     = INSTANCE.state
 TOKENS_FILE   = INSTANCE.tokens_file
@@ -1338,7 +1338,7 @@ def main():
                         help="HTTPS mode: Secure cookie + trust proxy headers (use with tailscale serve)")
     parser.add_argument("--self-signed", action="store_true",
                         help="Generate a self-signed TLS cert for direct HTTPS without Tailscale")
-    parser.add_argument("--instance", metavar="NAME", default=None,
+    parser.add_argument("--name", metavar="NAME", default=None,
                         help="Instance whose state and runtime files to use "
                              "(default: default)")
 
@@ -1352,7 +1352,7 @@ def main():
     args = parser.parse_args()
 
     migrate_legacy_layout()
-    inst = resolve_instance(args.instance)
+    inst = resolve_instance(args.name)
     if not check_sock_path(inst):
         sys.exit(1)
     _set_instance(inst)

--- a/mobile/trustmux/_disable.py
+++ b/mobile/trustmux/_disable.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from trustmux._ctl import cmd_stop
-from trustmux._enable import is_hook_line
+from trustmux._enable import is_hook_for
 from trustmux._paths import Instance
 
 _LOGIN_FILES = [
@@ -14,11 +14,13 @@ _LOGIN_FILES = [
 ]
 
 
-def _remove_hook(dest: Path) -> None:
+def _remove_hook(dest: Path, inst: Instance | None = None) -> None:
     if not dest.exists() or not os.access(dest, os.W_OK):
         return
+    inst = inst or Instance()
     lines = dest.read_text().splitlines(keepends=True)
-    filtered = [l for l in lines if not is_hook_line(l)]
+    # Only this instance's hook: disabling one must not un-enable the others.
+    filtered = [l for l in lines if not is_hook_for(l, inst)]
     if len(filtered) < len(lines):
         dest.write_text("".join(filtered))
 
@@ -26,7 +28,7 @@ def _remove_hook(dest: Path) -> None:
 def main(inst: Instance | None = None) -> None:
     inst = inst or Instance()
     for f in _LOGIN_FILES:
-        _remove_hook(f)
+        _remove_hook(f, inst)
 
     cmd_stop(inst=inst)
 
@@ -36,7 +38,7 @@ def main(inst: Instance | None = None) -> None:
     print(f"Paired device tokens are preserved in {inst.tokens_file}.")
     print()
     print("To re-enable later, run:")
-    print("  trustmux enable")
+    print(f"  trustmux enable{inst.label()}")
     print()
 
 

--- a/mobile/trustmux/_disable.py
+++ b/mobile/trustmux/_disable.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from trustmux._ctl import cmd_stop
 from trustmux._enable import is_hook_line
+from trustmux._paths import Instance
 
 _LOGIN_FILES = [
     Path.home() / ".profile",
@@ -22,16 +23,17 @@ def _remove_hook(dest: Path) -> None:
         dest.write_text("".join(filtered))
 
 
-def main() -> None:
+def main(inst: Instance | None = None) -> None:
+    inst = inst or Instance()
     for f in _LOGIN_FILES:
         _remove_hook(f)
 
-    cmd_stop()
+    cmd_stop(inst=inst)
 
     print()
     print("Trustmux daemon stopped. It will no longer start automatically at login.")
     print()
-    print("Paired device tokens are preserved in ~/.config/trustmux/tokens.json.")
+    print(f"Paired device tokens are preserved in {inst.tokens_file}.")
     print()
     print("To re-enable later, run:")
     print("  trustmux enable")

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -1,9 +1,11 @@
 """trustmux enable — start Trustmux daemon and enable it at login."""
+import json
 import os
 import re
 import sys
 from pathlib import Path
 
+from trustmux._advertise import ADVERTISE_ENV
 from trustmux._ctl import (DEFAULT_PORT, can_use_serve, cmd_setup, cmd_start,
                            port_opt)
 from trustmux._paths import Instance
@@ -74,7 +76,35 @@ def _install_hook(dest: Path, hook: str = _HOOK, inst: Instance | None = None) -
         f.write(f"\n{hook}")
 
 
-def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
+def _warn_transient_advertise(advertise: list[str] | None,
+                              no_advertise: bool = False,
+                              inst: Instance | None = None) -> None:
+    """Say so if the advertise source will not survive to the next login.
+
+    The hook this command writes deliberately carries no --advertise: the
+    durable home for a source is the instance's config file, which is also the
+    only one `trustmux start` from a hook will consult.  A source given on the
+    command line applies to this daemon and then vanishes, which is worth one
+    line rather than a surprise after the next reboot.
+    """
+    inst = inst or Instance()
+    if no_advertise:
+        return          # nothing was advertised, so nothing is being lost
+    origin = "--advertise" if advertise else (
+        f"${ADVERTISE_ENV}" if os.environ.get(ADVERTISE_ENV, "").strip() else "")
+    if not origin:
+        return
+    print("", file=sys.stderr)
+    print(f"Note: the advertise source came from {origin}, so the login hook "
+          "will not use it.", file=sys.stderr)
+    print(f"  To make it stick, put it in {inst.config_file}:", file=sys.stderr)
+    print('    {"advertise": ' + json.dumps(advertise or
+          [os.environ.get(ADVERTISE_ENV, "").strip()]) + "}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+
+def main(port: int = DEFAULT_PORT, inst: Instance | None = None,
+         advertise: list[str] | None = None, no_advertise: bool = False) -> None:
     inst = inst or Instance()
     # enable == setup + start in serve mode + login hook, so it inherits the
     # serve restriction. Check up front: otherwise cmd_setup refuses and the
@@ -96,7 +126,10 @@ def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
     for f in _LOGIN_FILES:
         _install_hook(f, hook, inst)
 
-    started = cmd_start("serve", port, inst) == 0
+    started = cmd_start("serve", port, inst, advertise, no_advertise) == 0
+    # Regardless of whether this invocation started it: the hook was just
+    # written either way, and it is the hook that will not carry the source.
+    _warn_transient_advertise(advertise, no_advertise, inst)
 
     print()
     if started:

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -1,5 +1,6 @@
 """trustmux enable — start Trustmux daemon and enable it at login."""
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -46,7 +47,11 @@ def is_hook_for(line: str, inst: Instance | None = None) -> bool:
     inst = inst or Instance()
     if not is_hook_line(line):
         return False
-    if any(f"{flag} {inst.name}" in line for flag in _NAME_FLAGS):
+    # A trailing \s|$ boundary, not a bare substring check: one instance name
+    # being a prefix of another's (e.g. "work" and "workstation") must not
+    # make enable/disable/rm on one clobber or drop the other's hook line.
+    if any(re.search(rf"{re.escape(flag)} {re.escape(inst.name)}(?:\s|$)", line)
+           for flag in _NAME_FLAGS):
         return True
     # A hook that names no instance is the default instance's.
     return (inst.name == Instance().name

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -3,7 +3,8 @@ import os
 import sys
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, cmd_setup, cmd_start, port_opt
+from trustmux._ctl import (DEFAULT_PORT, can_use_serve, cmd_setup, cmd_start,
+                           port_opt)
 from trustmux._paths import Instance
 
 _HOOK = "trustmux start 2>/dev/null || true\n"
@@ -17,10 +18,11 @@ if "zsh" in os.environ.get("SHELL", ""):
     _LOGIN_FILES.append(Path.home() / ".zprofile")
 
 
-def hook_line(port: int = DEFAULT_PORT) -> str:
-    """Login hook to install. Only carries --port when it is not the default,
-    so profiles written by older versions stay byte-identical."""
-    return f"trustmux start{port_opt(port)} 2>/dev/null || true\n"
+def hook_line(port: int = DEFAULT_PORT, inst: Instance | None = None) -> str:
+    """Login hook to install. Only carries --instance/--port when they are not
+    the defaults, so profiles written by older versions stay byte-identical."""
+    inst = inst or Instance()
+    return f"trustmux start{inst.label()}{port_opt(port)} 2>/dev/null || true\n"
 
 
 def is_hook_line(line: str) -> bool:
@@ -28,15 +30,30 @@ def is_hook_line(line: str) -> bool:
     return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
 
 
+def is_hook_for(line: str, inst: Instance | None = None) -> bool:
+    """True for a hook line belonging to this instance.
 
-def _install_hook(dest: Path, hook: str = _HOOK) -> None:
+    Each instance owns one line, so enabling a second instance appends rather
+    than overwriting the first.
+    """
+    inst = inst or Instance()
+    if not is_hook_line(line):
+        return False
+    if f"--instance {inst.name}" in line:
+        return True
+    # A hook with no --instance is the default instance's.
+    return inst.name == Instance().name and "--instance" not in line
+
+
+def _install_hook(dest: Path, hook: str = _HOOK, inst: Instance | None = None) -> None:
     if not dest.exists():
         return
+    inst = inst or Instance()
     lines = dest.read_text().splitlines(keepends=True)
-    if any(is_hook_line(l) for l in lines):
-        # Rewrite in place so `enable --port N` updates a hook installed
-        # earlier with a different port instead of silently keeping the old one.
-        updated = [hook if is_hook_line(l) else l for l in lines]
+    if any(is_hook_for(l, inst) for l in lines):
+        # Rewrite in place so `enable --port N` updates this instance's hook
+        # instead of silently keeping the old port.
+        updated = [hook if is_hook_for(l, inst) else l for l in lines]
         if updated != lines:
             dest.write_text("".join(updated))
         return
@@ -46,14 +63,25 @@ def _install_hook(dest: Path, hook: str = _HOOK) -> None:
 
 def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
     inst = inst or Instance()
-    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
-        print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
-        print(f"  trustmux enable{port_opt(port)}")
+    # enable == setup + start in serve mode + login hook, so it inherits the
+    # serve restriction. Check up front: otherwise cmd_setup refuses and the
+    # generic "re-run trustmux enable" hint below would just loop.
+    if not can_use_serve(inst):
+        print("", file=sys.stderr)
+        print("  To start it at login anyway, add one of the above to your shell",
+              file=sys.stderr)
+        print("  profile yourself — `enable` only manages serve-mode instances.",
+              file=sys.stderr)
         sys.exit(1)
 
-    hook = hook_line(port)
+    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
+        print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
+        print(f"  trustmux enable{inst.label()}{port_opt(port)}")
+        sys.exit(1)
+
+    hook = hook_line(port, inst)
     for f in _LOGIN_FILES:
-        _install_hook(f, hook)
+        _install_hook(f, hook, inst)
 
     started = cmd_start("serve", port, inst) == 0
 
@@ -67,13 +95,13 @@ def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
     tokens = inst.tokens_file
     if not tokens.exists() or tokens.stat().st_size == 0:
         print("Next step — pair your phone:")
-        print("  trustmux pair")
+        print(f"  trustmux pair{inst.label()}")
         print()
         print("Open the URL printed above in your phone's browser, enter the code, and tap Pair.")
         print()
 
     print("To stop and disable later, run:")
-    print("  trustmux disable")
+    print(f"  trustmux disable{inst.label()}")
     print()
 
 

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -3,7 +3,8 @@ import os
 import sys
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, TOKENS_FILE, cmd_setup, cmd_start, port_opt
+from trustmux._ctl import DEFAULT_PORT, cmd_setup, cmd_start, port_opt
+from trustmux._paths import Instance
 
 _HOOK = "trustmux start 2>/dev/null || true\n"
 
@@ -27,6 +28,7 @@ def is_hook_line(line: str) -> bool:
     return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
 
 
+
 def _install_hook(dest: Path, hook: str = _HOOK) -> None:
     if not dest.exists():
         return
@@ -42,8 +44,9 @@ def _install_hook(dest: Path, hook: str = _HOOK) -> None:
         f.write(f"\n{hook}")
 
 
-def main(port: int = DEFAULT_PORT) -> None:
-    if cmd_setup(quiet=True, port=port) != 0:
+def main(port: int = DEFAULT_PORT, inst: Instance | None = None) -> None:
+    inst = inst or Instance()
+    if cmd_setup(quiet=True, port=port, inst=inst) != 0:
         print("\nFirst-time setup did not complete. Fix the issue above, then re-run:")
         print(f"  trustmux enable{port_opt(port)}")
         sys.exit(1)
@@ -52,7 +55,7 @@ def main(port: int = DEFAULT_PORT) -> None:
     for f in _LOGIN_FILES:
         _install_hook(f, hook)
 
-    started = cmd_start("serve", port) == 0
+    started = cmd_start("serve", port, inst) == 0
 
     print()
     if started:
@@ -61,7 +64,8 @@ def main(port: int = DEFAULT_PORT) -> None:
         print("Trustmux daemon is already running and will launch automatically at each login.")
     print()
 
-    if not TOKENS_FILE.exists() or TOKENS_FILE.stat().st_size == 0:
+    tokens = inst.tokens_file
+    if not tokens.exists() or tokens.stat().st_size == 0:
         print("Next step — pair your phone:")
         print("  trustmux pair")
         print()

--- a/mobile/trustmux/_enable.py
+++ b/mobile/trustmux/_enable.py
@@ -19,7 +19,7 @@ if "zsh" in os.environ.get("SHELL", ""):
 
 
 def hook_line(port: int = DEFAULT_PORT, inst: Instance | None = None) -> str:
-    """Login hook to install. Only carries --instance/--port when they are not
+    """Login hook to install. Only carries --name/--port when they are not
     the defaults, so profiles written by older versions stay byte-identical."""
     inst = inst or Instance()
     return f"trustmux start{inst.label()}{port_opt(port)} 2>/dev/null || true\n"
@@ -28,6 +28,13 @@ def hook_line(port: int = DEFAULT_PORT, inst: Instance | None = None) -> str:
 def is_hook_line(line: str) -> bool:
     """True for a trustmux login hook in any version's format."""
     return "trustmux-ctl" in line or ("trustmux start" in line and "2>/dev/null" in line)
+
+
+# The flag that names an instance was called --instance before it was --name.
+# Hooks live in ~/.profile and are not rewritten on upgrade, so a hook written
+# by the older spelling has to stay recognisable or `disable`/`rm` would leave
+# it behind to resurrect an instance that no longer exists.
+_NAME_FLAGS = ("--name", "--instance")
 
 
 def is_hook_for(line: str, inst: Instance | None = None) -> bool:
@@ -39,10 +46,11 @@ def is_hook_for(line: str, inst: Instance | None = None) -> bool:
     inst = inst or Instance()
     if not is_hook_line(line):
         return False
-    if f"--instance {inst.name}" in line:
+    if any(f"{flag} {inst.name}" in line for flag in _NAME_FLAGS):
         return True
-    # A hook with no --instance is the default instance's.
-    return inst.name == Instance().name and "--instance" not in line
+    # A hook that names no instance is the default instance's.
+    return (inst.name == Instance().name
+            and not any(flag in line for flag in _NAME_FLAGS))
 
 
 def _install_hook(dest: Path, hook: str = _HOOK, inst: Instance | None = None) -> None:

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -8,18 +8,19 @@ import sys
 import time
 from pathlib import Path
 
-from trustmux._ctl import DEFAULT_PORT, daemon_info, direct_url, resolve_port, warn_if_peer_blocked
+from trustmux._ctl import (DEFAULT_PORT, Instance, daemon_info, direct_url,
+                           resolve_port, warn_if_peer_blocked)
 
-SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
 
 
-def admin(cmd: dict) -> object:
-    if not SOCK.exists():
+def admin(cmd: dict, inst: Instance | None = None) -> object:
+    inst = inst or Instance()
+    if not inst.sock.exists():
         print("Error: Trustmux daemon not running (socket not found)", file=sys.stderr)
         sys.exit(1)
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
         try:
-            s.connect(str(SOCK))
+            s.connect(str(inst.sock))
         except OSError as e:
             print(f"Error: cannot connect to Trustmux daemon: {e}", file=sys.stderr)
             sys.exit(1)
@@ -59,7 +60,7 @@ def _ts_url() -> str:
     return ""
 
 
-def _pair_url() -> str:
+def _pair_url(inst: Instance | None = None) -> str:
     """Return the URL a phone should open to reach this daemon.
 
     `tailscale serve` fronts the daemon only in the default start mode, which
@@ -67,7 +68,8 @@ def _pair_url() -> str:
     and start-direct the tailnet name does not answer, so use the daemon's own
     address and port instead.
     """
-    info = daemon_info() or {}
+    inst = inst or Instance()
+    info = daemon_info(inst) or {}
     served = info.get("host") in ("127.0.0.1", "localhost", "::1") \
         and info.get("scheme") == "https"
     if served or not info:
@@ -78,7 +80,7 @@ def _pair_url() -> str:
     # (possibly daemon-querying) fallback is only actually needed when info
     # has none -- avoids a second, redundant admin-socket round trip in the
     # common case where info was already fetched above.
-    port = DEFAULT_PORT if info else resolve_port()
+    port = DEFAULT_PORT if info else resolve_port(inst=inst)
     return direct_url(port, info)
 
 
@@ -104,17 +106,18 @@ def _print_qr(url: str) -> None:
         pass
 
 
-def _poll(cmd: dict) -> dict | None:
+def _poll(cmd: dict, inst: Instance | None = None) -> dict | None:
     """Like admin(), but returns None on failure instead of exiting.
 
     A daemon that goes away mid-wait should end the wait, not crash it.
     """
-    if not SOCK.exists():
+    inst = inst or Instance()
+    if not inst.sock.exists():
         return None
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.settimeout(10)
-            s.connect(str(SOCK))
+            s.connect(str(inst.sock))
             s.sendall(json.dumps(cmd).encode() + b"\n")
             s.shutdown(socket.SHUT_WR)
             chunks = []
@@ -129,14 +132,15 @@ def _poll(cmd: dict) -> dict | None:
     return resp if isinstance(resp, dict) else None
 
 
-def _wait_for_pair(timeout: float) -> str:
+def _wait_for_pair(timeout: float, inst: Instance | None = None) -> str:
     """Wait for a device to pair, up to timeout seconds.
 
     Returns the paired device's IP, or "" if nothing paired.
     """
+    inst = inst or Instance()
     deadline = time.monotonic() + timeout
     while True:
-        status = _poll({"action": "pair_status"})
+        status = _poll({"action": "pair_status"}, inst)
         if status is None:
             return ""                      # daemon gone -- nothing left to wait for
         state = status.get("state")
@@ -162,15 +166,16 @@ def _clear() -> None:
         print("\033[2J\033[H", end="", flush=True)
 
 
-def main():
-    data = admin({"action": "pair_generate"})
+def main(inst: Instance | None = None):
+    inst = inst or Instance()
+    data = admin({"action": "pair_generate"}, inst)
     if not isinstance(data, dict) or "error" in data:
         print(f"Error: {data.get('error', data)}", file=sys.stderr)
         sys.exit(1)
     code = data["code"]
     ttl = data["expires_in"]
     mins = ttl // 60
-    url = _pair_url()
+    url = _pair_url(inst)
 
     pair_url = f"{url}#{code.replace('-', '')}"
     bar = "═" * 52
@@ -185,7 +190,7 @@ def main():
     print(f"\n  [ waiting up to {ttl}s for a device to pair ]")
 
     try:
-        ip = _wait_for_pair(ttl)
+        ip = _wait_for_pair(ttl, inst)
     except KeyboardInterrupt:
         print()
         ip = ""

--- a/mobile/trustmux/_pair.py
+++ b/mobile/trustmux/_pair.py
@@ -8,6 +8,7 @@ import sys
 import time
 from pathlib import Path
 
+from trustmux._advertise import advertised_urls
 from trustmux._ctl import (DEFAULT_PORT, Instance, daemon_info, direct_url,
                            resolve_port, warn_if_peer_blocked)
 
@@ -63,13 +64,19 @@ def _ts_url() -> str:
 def _pair_url(inst: Instance | None = None) -> str:
     """Return the URL a phone should open to reach this daemon.
 
-    `tailscale serve` fronts the daemon only in the default start mode, which
-    the daemon reports as a loopback bind with an https scheme.  In start-local
-    and start-direct the tailnet name does not answer, so use the daemon's own
-    address and port instead.
+    An advertised address wins outright: it is the operator's answer to this
+    exact question, and the one the daemon's certificate was built around.
+
+    Otherwise, `tailscale serve` fronts the daemon only in the default start
+    mode, which the daemon reports as a loopback bind with an https scheme.  In
+    start-local and start-direct the tailnet name does not answer, so use the
+    daemon's own address and port instead.
     """
     inst = inst or Instance()
     info = daemon_info(inst) or {}
+    advertised = advertised_urls(info)
+    if advertised:
+        return advertised[0]
     served = info.get("host") in ("127.0.0.1", "localhost", "::1") \
         and info.get("scheme") == "https"
     if served or not info:

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -3,8 +3,8 @@
 XDG base directories, with one subdirectory per instance so that two daemons
 never share a pid file, socket or token store:
 
-    config  $XDG_CONFIG_HOME/trustmux   machines.json — the only thing the user
-                                        writes by hand
+    config  $XDG_CONFIG_HOME/trustmux   machines.json and instances/NAME.json —
+                                        the only things the user writes by hand
     state   $XDG_STATE_HOME/trustmux    tokens.json, cert.pem, key.pem, log,
                                         admin socket, pid file
 
@@ -79,6 +79,16 @@ class Instance:
     @property
     def state(self) -> Path:
         return state_dir() / "instances" / self.name
+
+    @property
+    def config_file(self) -> Path:
+        """User-authored settings for this instance; hand-edited, often absent.
+
+        Config rather than state because it holds intent, not a result: an
+        advertise source is re-resolved at every start precisely so that what
+        is written here keeps working when the address behind it changes.
+        """
+        return config_dir() / "instances" / f"{self.name}.json"
 
     @property
     def tokens_file(self) -> Path:

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -18,8 +18,8 @@ off by default.  Trustmux exists to be started and then reached later from a
 phone, so a daemon outliving the directory holding its socket -- alive but
 unreachable -- is squarely on the main path.  It also does not exist on macOS
 or in most containers.  Byobu has never used it either (usr/lib/byobu/include/
-dirs.in).  Staleness is instead detected explicitly: see _daemon's admin server
-and _ctl's _pid().
+dirs.in).  Staleness is instead detected explicitly, by socket_is_live() below:
+a socket whose daemon is gone refuses connections.
 
 Each base honours a TRUSTMUX_*_DIR override, mirroring byobu's own
 BYOBU_CONFIG_DIR.
@@ -27,6 +27,7 @@ BYOBU_CONFIG_DIR.
 import errno
 import os
 import re
+import socket
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -150,6 +151,31 @@ def check_sock_path(inst: Instance, stream=sys.stderr) -> bool:
     print("Use a shorter instance name, or set $TRUSTMUX_STATE_DIR to a shorter path.",
           file=stream)
     return False
+
+
+def socket_is_live(path: Path) -> bool:
+    """True if something is accepting connections on the unix socket at path.
+
+    The state directory outlives the daemon, so a socket file left behind by a
+    killed daemon stays on disk; connecting is the only way to tell that apart
+    from one a daemon is serving.  This answers at the kernel level -- the
+    connection completes off the listen backlog -- so a daemon that is alive
+    but too busy to reply still reads as live, which is exactly what `stop`
+    needs in order to be able to kill a wedged one.
+
+    Shared by the daemon (deciding whether it may unlink a leftover socket) and
+    the CLI (deciding whether this instance has a daemon at all), so that the
+    two can never disagree about what "running" means.
+    """
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(1.5)
+    try:
+        probe.connect(str(path))
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
 
 
 def known_instances() -> list[Instance]:

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -105,8 +105,8 @@ class Instance:
         return self.state / "trustmux.pid"
 
     def label(self) -> str:
-        """' --instance NAME' for non-default instances, for printed hints."""
-        return "" if self.name == DEFAULT_INSTANCE else f" --instance {self.name}"
+        """' --name NAME' for non-default instances, for printed hints."""
+        return "" if self.name == DEFAULT_INSTANCE else f" --name {self.name}"
 
     def ensure_dirs(self) -> None:
         self.state.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -115,8 +115,8 @@ class Instance:
 
 
 def resolve_instance(explicit: str | None = None) -> Instance:
-    """--instance, then $TRUSTMUX_INSTANCE, then 'default'. Exits 2 if invalid."""
-    # An explicitly empty --instance is an error, not a silent fall-through;
+    """--name, then $TRUSTMUX_INSTANCE, then 'default'. Exits 2 if invalid."""
+    # An explicitly empty --name is an error, not a silent fall-through;
     # a blank environment variable is treated as unset.
     if explicit is None:
         name = os.environ.get(INSTANCE_ENV, "").strip() or DEFAULT_INSTANCE

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -1,6 +1,7 @@
 """Where trustmux keeps its files.
 
-XDG base directories, under a per-instance subdirectory:
+XDG base directories, with one subdirectory per instance so that two daemons
+never share a pid file, socket or token store:
 
     config  $XDG_CONFIG_HOME/trustmux   machines.json — the only thing the user
                                         writes by hand
@@ -25,6 +26,7 @@ BYOBU_CONFIG_DIR.
 """
 import errno
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +34,11 @@ from pathlib import Path
 _PKG = "trustmux"
 
 DEFAULT_INSTANCE = "default"
+INSTANCE_ENV = "TRUSTMUX_INSTANCE"
+# Instance names are path components and are interpolated into the ~/.profile
+# hook line, so keep them to an unambiguous alphabet: no separators, no
+# leading dot.
+INSTANCE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
 
 # Pre-instances layout: everything sat directly in the config directory.
 _LEGACY_STATE_FILES = ("tokens.json", "cert.pem", "key.pem", "trustmux.log")
@@ -62,10 +69,9 @@ def machines_file() -> Path:
 
 @dataclass(frozen=True)
 class Instance:
-    """One daemon's state directory.
+    """One daemon's private state directory.
 
-    Only the default instance exists for now; the layout is already keyed by
-    name so that selecting another is purely a matter of plumbing.
+    Two daemons never share a pid file, socket or token store.
     """
     name: str = DEFAULT_INSTANCE
 
@@ -97,13 +103,66 @@ class Instance:
     def pid_file(self) -> Path:
         return self.state / "trustmux.pid"
 
+    def label(self) -> str:
+        """' --instance NAME' for non-default instances, for printed hints."""
+        return "" if self.name == DEFAULT_INSTANCE else f" --instance {self.name}"
+
     def ensure_dirs(self) -> None:
         self.state.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.state.mkdir(mode=0o700, exist_ok=True)
         self.state.chmod(0o700)
 
 
+def resolve_instance(explicit: str | None = None) -> Instance:
+    """--instance, then $TRUSTMUX_INSTANCE, then 'default'. Exits 2 if invalid."""
+    # An explicitly empty --instance is an error, not a silent fall-through;
+    # a blank environment variable is treated as unset.
+    if explicit is None:
+        name = os.environ.get(INSTANCE_ENV, "").strip() or DEFAULT_INSTANCE
+    else:
+        name = explicit
+    if not INSTANCE_RE.match(name):
+        print(f"Error: invalid instance name {name!r} — use letters, digits, "
+              "'.', '_' or '-' (max 32, not starting with '.').", file=sys.stderr)
+        sys.exit(2)
+    inst = Instance(name)
+    # Belt and braces: the regex already forbids separators, so this only fires
+    # if that alphabet is ever widened.  Compares unresolved paths, so a
+    # deliberately symlinked instance directory keeps working.
+    if inst.state.parent.name != "instances":
+        print(f"Error: instance name {name!r} escapes its directory.", file=sys.stderr)
+        sys.exit(2)
+    return inst
 
+
+def check_sock_path(inst: Instance, stream=sys.stderr) -> bool:
+    """False (with a message) if the admin socket path is too long to bind.
+
+    struct sockaddr_un caps sun_path at 108 bytes on Linux and 104 on macOS;
+    without this the failure surfaces as a bare OSError from bind().
+    """
+    limit = 104 if sys.platform == "darwin" else 108
+    encoded = len(str(inst.sock).encode())
+    if encoded < limit:
+        return True
+    print(f"Error: admin socket path is {encoded} bytes, over the {limit}-byte "
+          f"limit for unix sockets:\n  {inst.sock}", file=stream)
+    print("Use a shorter instance name, or set $TRUSTMUX_STATE_DIR to a shorter path.",
+          file=stream)
+    return False
+
+
+def known_instances() -> list[Instance]:
+    """Every instance with a state directory, default first."""
+    try:
+        names = sorted(p.name for p in (state_dir() / "instances").iterdir()
+                       if p.is_dir())
+    except OSError:
+        names = []
+    if DEFAULT_INSTANCE in names:
+        names.remove(DEFAULT_INSTANCE)
+        names.insert(0, DEFAULT_INSTANCE)
+    return [Instance(n) for n in names]
 
 
 def legacy_dir() -> Path:

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -1,0 +1,180 @@
+"""Where trustmux keeps its files.
+
+XDG base directories, under a per-instance subdirectory:
+
+    config  $XDG_CONFIG_HOME/trustmux   machines.json — the only thing the user
+                                        writes by hand
+    state   $XDG_STATE_HOME/trustmux    tokens.json, cert.pem, key.pem, log,
+                                        admin socket, pid file
+
+Everything the daemon owns lives together in the state directory, as it always
+has -- just no longer mixed in with configuration.
+
+Deliberately *not* $XDG_RUNTIME_DIR for the socket and pid file, despite that
+being where the spec puts them: systemd-logind removes /run/user/$UID when a
+user's last login session ends unless `loginctl enable-linger` is set, which is
+off by default.  Trustmux exists to be started and then reached later from a
+phone, so a daemon outliving the directory holding its socket -- alive but
+unreachable -- is squarely on the main path.  It also does not exist on macOS
+or in most containers.  Byobu has never used it either (usr/lib/byobu/include/
+dirs.in).  Staleness is instead detected explicitly: see _daemon's admin server
+and _ctl's _pid().
+
+Each base honours a TRUSTMUX_*_DIR override, mirroring byobu's own
+BYOBU_CONFIG_DIR.
+"""
+import errno
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PKG = "trustmux"
+
+DEFAULT_INSTANCE = "default"
+
+# Pre-instances layout: everything sat directly in the config directory.
+_LEGACY_STATE_FILES = ("tokens.json", "cert.pem", "key.pem", "trustmux.log")
+
+
+def _env_dir(name: str) -> Path | None:
+    value = os.environ.get(name, "").strip()
+    return Path(value).expanduser() if value else None
+
+
+def config_dir() -> Path:
+    """User-authored configuration."""
+    return (_env_dir("TRUSTMUX_CONFIG_DIR")
+            or (_env_dir("XDG_CONFIG_HOME") or Path.home() / ".config") / _PKG)
+
+
+def state_dir() -> Path:
+    """Data that must survive a reboot: tokens, TLS keypair, logs."""
+    return (_env_dir("TRUSTMUX_STATE_DIR")
+            or (_env_dir("XDG_STATE_HOME") or Path.home() / ".local" / "state") / _PKG)
+
+
+
+def machines_file() -> Path:
+    """Sibling-machine list for the in-app selector; shared by all instances."""
+    return config_dir() / "machines.json"
+
+
+@dataclass(frozen=True)
+class Instance:
+    """One daemon's state directory.
+
+    Only the default instance exists for now; the layout is already keyed by
+    name so that selecting another is purely a matter of plumbing.
+    """
+    name: str = DEFAULT_INSTANCE
+
+    @property
+    def state(self) -> Path:
+        return state_dir() / "instances" / self.name
+
+    @property
+    def tokens_file(self) -> Path:
+        return self.state / "tokens.json"
+
+    @property
+    def cert_file(self) -> Path:
+        return self.state / "cert.pem"
+
+    @property
+    def key_file(self) -> Path:
+        return self.state / "key.pem"
+
+    @property
+    def log_file(self) -> Path:
+        return self.state / "trustmux.log"
+
+    @property
+    def sock(self) -> Path:
+        return self.state / "trustmux.sock"
+
+    @property
+    def pid_file(self) -> Path:
+        return self.state / "trustmux.pid"
+
+    def ensure_dirs(self) -> None:
+        self.state.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.state.mkdir(mode=0o700, exist_ok=True)
+        self.state.chmod(0o700)
+
+
+
+
+
+def legacy_dir() -> Path:
+    """Where the pre-instances layout kept everything: the config directory.
+
+    Derived from config_dir() rather than hardcoding ~/.config/trustmux, so
+    that overriding the base directories fully isolates a run — otherwise a
+    test or a dev-tree invocation would reach into the real one.
+    """
+    return config_dir()
+
+
+def _move_preserving_mode(src: Path, dst: Path) -> None:
+    """Move src to dst without ever widening its permissions.
+
+    os.replace is atomic but fails across filesystems, which is easy to hit now
+    that state lives under a different base directory than config.  The
+    fallback recreates the file with the source's mode from the outset rather
+    than copying and chmod-ing after, so a 0600 secret is never briefly world
+    readable.
+    """
+    mode = src.stat().st_mode & 0o777
+    try:
+        os.replace(src, dst)
+        return
+    except OSError as e:
+        if e.errno != errno.EXDEV:
+            raise
+    data = src.read_bytes()
+    fd = os.open(dst, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    os.chmod(dst, mode)
+    src.unlink()
+
+
+def migrate_legacy_layout(stream=sys.stderr) -> bool:
+    """Move pre-instances files into the default instance's state directory.
+
+    Per-file and idempotent, so a partial failure can be retried.  Returns True
+    if anything moved.  Never raises: a migration problem must not stop the
+    command the user actually asked for.
+
+    The stale top-level pid file and socket are left alone rather than removed:
+    a daemon from before the upgrade may still be serving on that socket.
+    """
+    legacy = legacy_dir()
+    target = Instance().state
+    pending = [n for n in _LEGACY_STATE_FILES
+               if (legacy / n).exists() and not (target / n).exists()]
+    if not pending:
+        return False
+
+    moved, failed = [], []
+    try:
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target.mkdir(mode=0o700, exist_ok=True)
+    except OSError as e:
+        print(f"trustmux: cannot create {target}: {e}", file=stream)
+        return False
+
+    for name in pending:
+        try:
+            _move_preserving_mode(legacy / name, target / name)
+            moved.append(name)
+        except OSError as e:
+            failed.append(f"{name} ({e})")
+
+    if moved:
+        print(f"trustmux: moved {', '.join(moved)} to {target}", file=stream)
+    if failed:
+        print(f"trustmux: could not move {', '.join(failed)} out of {legacy} — "
+              "move them by hand or they will be ignored.", file=stream)
+    return bool(moved)

--- a/mobile/trustmux/_paths.py
+++ b/mobile/trustmux/_paths.py
@@ -183,14 +183,19 @@ def _move_preserving_mode(src: Path, dst: Path) -> None:
     fallback recreates the file with the source's mode from the outset rather
     than copying and chmod-ing after, so a 0600 secret is never briefly world
     readable.
+
+    A symlink is copied through rather than renamed: os.replace would move the
+    link itself, leaving the state directory owning a pointer back to the old
+    location instead of the secret.  st_mode is the target's, not the link's.
     """
     mode = src.stat().st_mode & 0o777
-    try:
-        os.replace(src, dst)
-        return
-    except OSError as e:
-        if e.errno != errno.EXDEV:
-            raise
+    if not src.is_symlink():
+        try:
+            os.replace(src, dst)
+            return
+        except OSError as e:
+            if e.errno != errno.EXDEV:
+                raise
     data = src.read_bytes()
     fd = os.open(dst, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
     with os.fdopen(fd, "wb") as f:

--- a/mobile/trustmux/_unpair.py
+++ b/mobile/trustmux/_unpair.py
@@ -2,18 +2,19 @@
 import json
 import socket
 import sys
-from pathlib import Path
 
-SOCK = Path.home() / ".config" / "trustmux" / "trustmux.sock"
+from trustmux._ctl import Instance
 
 
-def admin(cmd: dict) -> object:
-    if not SOCK.exists():
+
+def admin(cmd: dict, inst: Instance | None = None) -> object:
+    inst = inst or Instance()
+    if not inst.sock.exists():
         print("Error: Trustmux daemon not running (socket not found)", file=sys.stderr)
         sys.exit(1)
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
         try:
-            s.connect(str(SOCK))
+            s.connect(str(inst.sock))
         except OSError as e:
             print(f"Error: cannot connect to Trustmux daemon: {e}", file=sys.stderr)
             sys.exit(1)
@@ -46,8 +47,9 @@ def _ua_short(label: str) -> str:
     return label[:30]
 
 
-def main():
-    sessions = admin({"action": "sessions_list"})
+def main(inst: Instance | None = None):
+    inst = inst or Instance()
+    sessions = admin({"action": "sessions_list"}, inst)
     if not isinstance(sessions, list):
         print(f"Error: {sessions}", file=sys.stderr)
         sys.exit(1)
@@ -77,7 +79,7 @@ def main():
         print("Cancelled.")
 
     elif choice.upper() == "A":
-        result = admin({"action": "sessions_delete"})
+        result = admin({"action": "sessions_delete"}, inst)
         if isinstance(result, dict) and result.get("ok"):
             print(f"Removed {result.get('removed', 0)} paired client(s).")
         else:
@@ -88,7 +90,7 @@ def main():
         idx = int(choice) - 1
         token = sessions[idx]["token_full"]
         ip = sessions[idx]["ip"]
-        result = admin({"action": "sessions_delete", "token": token})
+        result = admin({"action": "sessions_delete", "token": token}, inst)
         if isinstance(result, dict) and result.get("ok"):
             print(f"Client {ip} unpaired.")
         else:


### PR DESCRIPTION
**Note** - this sits on top of https://github.com/dustinkirkland/byobu/pull/123

Behind NAT -- a cloud instance, most often -- the daemon only ever sees an
internal address.  Both the URL `trustmux pair` prints and the SANs in the
self-signed certificate then name a host nothing outside can route to, so
pairing a phone over the public address was not possible at all: the URL was
wrong, and even given the right one by hand the certificate would not cover it.

--advertise takes a *source*, resolved afresh at every daemon start:

    203.0.113.45        a literal address
    tmux.example.com    a literal name
    host:8443           a literal with a port
    https://name/       a full URL, for a proxy terminating TLS on 443
    cmd:/path/to/prog   run prog, one address per line of its stdout

Re-resolving is what makes a source safe to write down.  A cloud instance with
an ephemeral public address gets a different one across a stop/start cycle, so a
literal recorded once would quietly go stale -- and a certificate minted for an
address that no longer exists is worse than no configuration at all, because it
looks configured.  cmd: re-asks each time, which is the case this is for.

cmd: is split into argv with shlex and never handed to a shell: a pipeline or a
$(...) would reach the program as text, so those characters are refused with a
message saying to put the pipeline in a script.  That is also why every failure
is fatal rather than a warning.  A shell wrapper whose curl fails prints an
empty line and still exits 0 -- exactly the silent wrong answer this exists to
prevent -- so a non-zero exit, no output, a blank line, a value that does not
parse as an address, or more than 5s across all sources stops the daemon.  It
already refuses to start without TLS; an unreachable URL is the same kind of
thing, and no warning would fix either.

Resolution happens in the daemon, ahead of both the certificate and the admin
socket, because only the daemon can say what its certificate actually attests.
It reports the resolved URLs over the admin socket, and direct_url(),
_pair_url() and cmd_status() prefer them over anything they could discover --
so pair, status, list and the start commands all print the same reachable
address, and the certificate covers every one of them.

Precedence mirrors resolve_port(): --advertise (repeatable, first supplies the
URL), then $TRUSTMUX_ADVERTISE (a single source -- no delimiter is safe when
':' collides with URL schemes and ',' can appear in a command's arguments),
then the instance's config file.  Whichever is set replaces the others outright;
appending would leave a repeatable flag unable to drop a name the config file
still lists.  --no-advertise resolves to nothing despite a configured source.

The config file is the per-instance work this branch already added, extended by
one path: config rather than state because it records intent, not a result.  It
is refused when group- or world-writable, since a source can name a program to
run.  `enable` deliberately writes no --advertise into its login hook and says
so when the source came from the flag or the environment, the config file being
the only place a hook will look.

Two things this forced:

  * _launch() waited a fixed 0.5s before asking whether the daemon had come up.
    Resolving a cmd: source runs before the admin socket is bound, so a healthy
    daemon was still starting at that mark and got reported as having failed.
    It now polls for the socket instead.
  * "failed to start" always blamed a taken port.  Startup can now fail for a
    second reason that the daemon has already explained, so cmd_start prints
    the daemon's own Error: line from the log when there is one, and keeps the
    port hint for when there is not.

Also fixes trustmuxd.1, which still documented --instance after 7cbfef25
renamed the flag to --name.
