### PR TITLE
feat(trustmux): hierarchical session navigation with pane titles

### DIFF
--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -95,27 +95,40 @@ class TestTmuxListPanes(unittest.TestCase):
             return bm.tmux_list_panes('@0')
 
     def test_parses_two_panes(self):
-        out = '%0\t0\t1\tbash\t1234\t0\n%1\t1\t0\tvim\t5678\t1\n'
+        out = '%0\t0\t1\tbash\t1234\t0\tmain task\n%1\t1\t0\tvim\t5678\t1\t\n'
         panes = self._run(out)
         self.assertEqual(len(panes), 2)
-        self.assertEqual(panes[0], {'id': '%0', 'index': 0, 'active': True,  'command': 'bash', 'dead': False})
-        self.assertEqual(panes[1], {'id': '%1', 'index': 1, 'active': False, 'command': 'vim',  'dead': True})
+        self.assertEqual(panes[0], {
+            'id': '%0', 'index': 0, 'active': True,
+            'command': 'bash', 'title': 'main task', 'dead': False,
+        })
+        self.assertEqual(panes[1], {
+            'id': '%1', 'index': 1, 'active': False,
+            'command': 'vim', 'title': '', 'dead': True,
+        })
+
+    def test_tab_in_title_does_not_shift_fields(self):
+        out = '%0\t0\t1\tbash\t1234\t0\tfoo\tbar\n'
+        panes = self._run(out)
+        self.assertEqual(len(panes), 1)
+        self.assertEqual(panes[0]['title'], 'foo\tbar')
+        self.assertFalse(panes[0]['dead'])
 
     def test_empty_output(self):
         self.assertEqual(self._run(''), [])
 
     def test_skips_malformed_lines(self):
-        out = 'garbage\n%0\t0\t1\tbash\t123\n'
+        out = 'garbage\n%0\t0\t1\tbash\t123\t0\ttitle\n'
         panes = self._run(out)
         self.assertEqual(len(panes), 1)
         self.assertEqual(panes[0]['id'], '%0')
 
     def test_active_flag_parsing(self):
-        out = '%5\t0\t1\tzsh\t999\n'
+        out = '%5\t0\t1\tzsh\t999\t0\ttitle\n'
         panes = self._run(out)
         self.assertTrue(panes[0]['active'])
 
-        out = '%5\t0\t0\tzsh\t999\n'
+        out = '%5\t0\t0\tzsh\t999\t0\ttitle\n'
         panes = self._run(out)
         self.assertFalse(panes[0]['active'])
 
@@ -123,7 +136,7 @@ class TestTmuxListPanes(unittest.TestCase):
 class TestTmuxListWindows(unittest.TestCase):
     def test_parses_windows_with_panes(self):
         window_output = '@0\t0\tmain\t1\n@1\t1\twork\t0\n'
-        pane_output   = '%0\t0\t1\tbash\t111\n'
+        pane_output   = '%0\t0\t1\tbash\t111\t0\ttitle\n'
         call_count = 0
 
         def fake_tmux(*args):

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -327,11 +327,13 @@ def tmux_list_windows(session_id: str) -> list[dict]:
     return windows
 
 def tmux_list_panes(window_id: str) -> list[dict]:
+    # pane_title is program-controlled (OSC 2) and may contain tabs, so it
+    # goes last and the split is bounded to keep it from shifting pid/dead.
     raw = _tmux("list-panes", "-t", window_id, "-F",
-                "#{pane_id}\t#{pane_index}\t#{pane_active}\t#{pane_current_command}\t#{pane_pid}\t#{pane_dead}")
+                "#{pane_id}\t#{pane_index}\t#{pane_active}\t#{pane_current_command}\t#{pane_pid}\t#{pane_dead}\t#{pane_title}")
     panes = []
     for line in raw.splitlines():
-        parts = line.split("\t")
+        parts = line.split("\t", 6)
         if len(parts) < 3:
             continue
         pane_id_str = parts[0]
@@ -343,6 +345,7 @@ def tmux_list_panes(window_id: str) -> list[dict]:
         cmd     = parts[3] if len(parts) > 3 else ""
         pid_str = parts[4] if len(parts) > 4 else ""
         dead    = parts[5] == "1" if len(parts) > 5 else False
+        title   = parts[6] if len(parts) > 6 else ""
         if not dead and pid_str:
             cmd = _smarter_pane_name(pid_str, cmd)
         panes.append({
@@ -350,6 +353,7 @@ def tmux_list_panes(window_id: str) -> list[dict]:
             "index": idx,
             "active": active,
             "command": cmd,
+            "title": title,
             "dead": dead,
         })
     return panes

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -163,7 +163,8 @@ const machineSelect    = document.getElementById('machine-select');
 const btnInstall       = document.getElementById('btn-install');
 const iosInstallTip    = document.getElementById('ios-install-tip');
 const hostnameDisplay  = document.getElementById('hostname-display');
-function setHostnameDisplay(name) { hostnameDisplay.textContent = '🖥️ ' + name; }
+let serverHostname = '';
+function setHostnameDisplay(name) { serverHostname = name; hostnameDisplay.textContent = '🖥️ ' + name; }
 const headerClock      = document.getElementById('header-clock');
 const updateBadge      = document.getElementById('update-badge');
 const infoPopup       = document.getElementById('info-popup');
@@ -339,12 +340,65 @@ function send(obj) {
   if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
 }
 
-// ── xyz label ─────────────────────────────────────────────────────────────
+// ── current context helpers ───────────────────────────────────────────────
+function currentSession() {
+  return sessions.find(s => s.id === currentSessionId) || null;
+}
+
+function currentWindow() {
+  const s = currentSession();
+  if (!s) return null;
+  return (s.windows || []).find(w => w.id === currentWindowId) || null;
+}
+
+function currentPaneObj() {
+  const w = currentWindow();
+  if (!w) return null;
+  return (w.panes || []).find(p => p.id === currentPane) || null;
+}
+
+function livePanesInWindow(w) {
+  return (w?.panes || []).filter(p => !p.dead);
+}
+
+function firstLivePaneInWindow(w) {
+  return livePanesInWindow(w)[0] || null;
+}
+
+// tmux defaults pane_title to the hostname when no program set one; that is
+// noise, so such a title falls through to the running command instead.
+function isDefaultPaneTitle(title) {
+  if (!title || !serverHostname) return false;
+  const short = s => s.split('.')[0].toLowerCase();
+  return short(title) === short(serverHostname);
+}
+
+function paneDisplayName(p) {
+  if (!p) return 'shell';
+  const title = isDefaultPaneTitle(p.title) ? '' : p.title;
+  return getPaneName(p.id, '') || title || p.command || 'shell';
+}
+
+function contextPath() {
+  const s = currentSession();
+  const w = currentWindow();
+  const p = currentPaneObj();
+  if (!s || !w || !p) return '';
+  return `${s.name} / ${w.index}:${w.name} / ${paneDisplayName(p)}`;
+}
+
+// ── position label ────────────────────────────────────────────────────────
 function activePaneXYZ() {
-  const list = flatPaneList();
-  if (!currentPane || list.length === 0) return '-/-';
-  const idx = list.findIndex(e => e.paneId === currentPane);
-  return idx < 0 ? '-/-' : `${idx + 1}/${list.length}`;
+  const s = currentSession();
+  const w = currentWindow();
+  if (!s || !w || !currentPane) return '-/-';
+  const windows = (s.windows || []).filter(win => firstLivePaneInWindow(win));
+  const wIdx = windows.findIndex(win => win.id === currentWindowId);
+  const panes = livePanesInWindow(w);
+  const pIdx = panes.findIndex(p => p.id === currentPane);
+  const wText = wIdx < 0 ? 'W-/-' : `W${wIdx + 1}/${windows.length}`;
+  const pText = pIdx < 0 ? 'P-/-' : `P${pIdx + 1}/${panes.length}`;
+  return `${wText} ${pText}`;
 }
 
 function updateXYZLabel() {
@@ -441,11 +495,10 @@ function navigateTo(sessionId, windowId, paneId) {
   updateContextName();
 }
 
-// ── context name (custom label or command fallback) ───────────────────────
+// ── context name ──────────────────────────────────────────────────────────
 function updateContextName() {
   if (!currentPane) { ctxName.textContent = ''; return; }
-  const custom = getPaneName(currentPane, '');
-  ctxName.textContent = '🪟 ' + (custom || currentPaneCommand() || 'shell');
+  ctxName.textContent = contextPath() || getPaneName(currentPane, '') || 'shell';
 }
 
 // ── output rendering ───────────────────────────────────────────────────────
@@ -549,7 +602,7 @@ function sendKeys() {
 }
 
 // ── events ─────────────────────────────────────────────────────────────────
-xyzLabel.addEventListener('click', () => send({ type: 'list_sessions' }));
+xyzLabel.addEventListener('click', () => navigateRelativePane(1));
 cmdInput.addEventListener('keydown', e => {
   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendKeys(); }
 });
@@ -638,7 +691,7 @@ document.addEventListener('touchstart', e => {
   if (!escapePopup.contains(e.target) && e.target !== btnEscape) hideEscapePopup();
 }, { passive: true });
 
-// ── pane list — all live panes across all windows and sessions ────────────
+// ── pane list: all live panes across all windows and sessions ─────────────
 // Deduplicated by pane ID: byobu exposes the same windows/panes under multiple
 // sessions (linked windows / multi-client attach), so skip any already seen.
 function flatPaneList() {
@@ -665,6 +718,15 @@ function navigateRelative(delta) {
   navigateTo(next.sessionId, next.windowId, next.paneId);
 }
 
+function navigateRelativePane(delta) {
+  const w = currentWindow();
+  const panes = livePanesInWindow(w);
+  if (!w || panes.length < 2) return;
+  const idx = panes.findIndex(p => p.id === currentPane);
+  const nextPane = panes[((idx < 0 ? 0 : idx) + delta + panes.length) % panes.length];
+  navigateTo(currentSessionId, w.id, nextPane.id);
+}
+
 // ── touch swipe tracking (used for swipe nav) ─────────────────────────────
 let _touchX = 0, _touchY = 0;
 
@@ -678,23 +740,51 @@ btnNext.addEventListener('click', () => navigateRelative(1));
 document.getElementById('btn-create').addEventListener('click', showCreateOverlay);
 
 // ── context jump list (tap context name in header) ─────────────────────────
-// Lists every live pane across every session/window, grouped, so jumping to
-// a specific context is one tap instead of cycling through ‹ › one at a time.
+// Hierarchical picker: sessions first, then windows inside each session, then
+// panes inside each window. This keeps tmux's session/window/pane model visible
+// instead of reducing everything to a long pane list.
 function renderCtxList() {
   ctxList.innerHTML = '';
   for (const s of sessions) {
+    const sessionHasLivePane = (s.windows || []).some(w => firstLivePaneInWindow(w));
+    if (!sessionHasLivePane) continue;
+
+    if (ctxList.children.length) {
+      const sep = document.createElement('div');
+      sep.className = 'ctx-sep';
+      ctxList.appendChild(sep);
+    }
+
+    const sBtn = document.createElement('button');
+    sBtn.className = 'ctx-btn' + (s.id === currentSessionId ? ' ctx-current' : '');
+    sBtn.textContent = (s.id === currentSessionId ? '✓ ' : '') + s.name;
+    sBtn.addEventListener('click', () => {
+      const firstWindow = (s.windows || []).find(w => firstLivePaneInWindow(w));
+      const firstPane = firstLivePaneInWindow(firstWindow);
+      hideCtxOverlay();
+      if (firstWindow && firstPane) navigateTo(s.id, firstWindow.id, firstPane.id);
+    });
+    ctxList.appendChild(sBtn);
+
     for (const w of (s.windows || [])) {
-      const livePanes = (w.panes || []).filter(p => !p.dead);
+      const livePanes = livePanesInWindow(w);
       if (!livePanes.length) continue;
-      const label = document.createElement('div');
-      label.className = 'ctx-group-label';
-      label.textContent = `${s.name} › ${w.name}`;
-      ctxList.appendChild(label);
+      const isCurrentWindow = s.id === currentSessionId && w.id === currentWindowId;
+      const wBtn = document.createElement('button');
+      wBtn.className = 'ctx-btn ctx-window-btn' + (isCurrentWindow ? ' ctx-current' : '');
+      wBtn.textContent = `${isCurrentWindow ? '✓ ' : ''}${w.index}:${w.name}`;
+      wBtn.addEventListener('click', () => {
+        const p = firstLivePaneInWindow(w);
+        hideCtxOverlay();
+        if (p) navigateTo(s.id, w.id, p.id);
+      });
+      ctxList.appendChild(wBtn);
+
       for (const p of livePanes) {
         const isCurrent = p.id === currentPane;
         const btn = document.createElement('button');
-        btn.className = 'ctx-btn' + (isCurrent ? ' ctx-current' : '');
-        const name = getPaneName(p.id, '') || p.command || 'shell';
+        btn.className = 'ctx-btn ctx-pane-btn' + (isCurrent ? ' ctx-current' : '');
+        const name = paneDisplayName(p);
         btn.textContent = (isCurrent ? '✓ ' : '') + name;
         btn.addEventListener('click', () => {
           hideCtxOverlay();
@@ -729,26 +819,25 @@ ctxOverlay.addEventListener('click', e => { if (e.target === ctxOverlay) hideCtx
 // ── rename sub-form (reached via "Rename current" inside the jump list) ────
 let _pendingRenameId = null;
 
-function currentPaneCommand() {
-  if (!currentPane) return '';
+function currentPaneDisplayName() {
   for (const s of sessions) {
     for (const w of (s.windows || [])) {
       for (const p of (w.panes || [])) {
-        if (p.id === currentPane) return p.command || '';
+        if (p.id === currentPane) return paneDisplayName(p);
       }
     }
   }
-  return '';
+  return paneDisplayName(null);
 }
 
 function showRenameForm() {
   if (!currentPane) return;
   _pendingRenameId = currentPane;
   const custom = getPaneName(currentPane, '');
-  const cmd = currentPaneCommand();
+  const name = currentPaneDisplayName();
   ctxRenameLabel.textContent = custom
     ? `Rename "${custom}":`
-    : `Name this context (${cmd || 'shell'}):`;
+    : `Name this context (${name}):`;
   ctxRenameInput.value = custom;
   ctxListView.style.display = 'none';
   ctxRenameForm.style.display = '';

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -63,7 +63,7 @@
       overflow: hidden; white-space: nowrap; flex-shrink: 1; min-width: 0;
     }
     #ctx-name {
-      max-width: 120px; overflow: hidden;
+      max-width: 48vw; overflow: hidden;
       text-overflow: ellipsis; white-space: nowrap;
       color: var(--accent); font-size: 11px;
       letter-spacing: 0.03em; padding: 0 4px;
@@ -71,8 +71,8 @@
     }
     #ctx-name:active { opacity: 0.7; }
     #xyz-label {
-      width: 44px; text-align: center; flex-shrink: 0;
-      color: var(--text); font-size: 13px; letter-spacing: 0.05em;
+      min-width: 86px; text-align: center; flex-shrink: 0;
+      color: var(--text); font-size: 11px; letter-spacing: 0.03em;
       cursor: pointer; user-select: none;
     }
     #xyz-label:active { color: var(--accent); }
@@ -142,13 +142,11 @@
                        font-family: var(--font); text-align: center; }
 
     /* ── context jump list (tap context name in header) ── */
-    /* capped + scrollable so a long pane list doesn't push the Rename/Cancel
-       buttons off-screen or grow the box past the viewport */
-    #ctx-list { max-height: 50vh; overflow-y: auto; }
-    .ctx-group-label {
-      padding: 10px 16px 4px; color: var(--text); font-size: 11px;
-      letter-spacing: 0.04em; text-transform: uppercase;
-    }
+    /* capped + scrollable so a long session/window/pane tree doesn't push the
+       Rename/Cancel buttons off-screen or grow the box past the viewport */
+    #ctx-list { max-height: 58vh; overflow-y: auto; }
+    .ctx-window-btn { padding-left: 28px; }
+    .ctx-pane-btn { padding-left: 40px; font-size: 13px; }
     .ctx-btn.ctx-current { color: var(--accent); }
 
     .icon-btn {
@@ -572,7 +570,7 @@
     <span id="ctx-name"></span>
     <button class="icon-btn" id="btn-create" title="New pane / window / session">+</button>
     <button class="icon-btn" id="btn-prev" title="Previous pane">‹</button>
-    <span id="xyz-label" title="Tap to refresh">-/-</span>
+    <span id="xyz-label" title="Tap for next pane in this window">-/-</span>
     <button class="icon-btn" id="btn-next" title="Next pane">›</button>
   </div>
 


### PR DESCRIPTION
Closes #129.

## What

Makes the tmux session/window/pane hierarchy visible and navigable in the
trustmux PWA, and labels unnamed panes with their tmux pane title.

- The header shows a breadcrumb of session / window / pane.
- The position label shows window and pane position in the current session
  (`W2/3 P1/2`); tapping it cycles panes inside the current window.
- The context picker is hierarchical: sessions, then windows, then panes,
  with indentation marking each level.
- The previous/next arrows keep their existing behavior: they cycle all
  live panes across sessions, deduplicated by pane ID (linked windows and
  multi-client attach expose the same panes under multiple sessions).
- The daemon reports each pane's tmux title (`pane_title`); the display
  name falls back through user-saved name, title, command, then "shell".
  Titles matching the server hostname (short name, case-insensitive) are
  skipped, since tmux defaults the title to the hostname.

## Why

On hosts with several sessions, windows, and panes, a flat pane list hides
where the current pane sits. Most panes are unnamed, so users had to infer
each pane's place from its command alone. Pane titles (set by ssh, vim,
and friends) identify panes far better than `pane_current_command`.

## Notes for reviewers

- `pane_title` is program-controlled and may contain tabs, so it sits last
  in the `list-panes` format string with a bounded split; a test covers a
  tabbed title.
- Daemon tests: 477 pass (`python -m unittest discover -s mobile/tests`).
  The JS is syntax-checked (`node --check`); there is no JS test harness.
- Manual device testing of the touch flows has not been done yet.