### PR TITLE
feat(trustmux): add key bar with direct input mode for TUIs

### DIFF
--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -269,6 +269,11 @@ function _getKbdMode(paneId) {
 }
 function _saveKbdMode(paneId, mode) { localStorage.setItem(_kbdModeKey(paneId), mode); }
 
+// ── key-bar visibility per pane (persisted like kbdMode, restored on switch) ─
+function _keybarKey(paneId) { return `keybar:${location.hostname}:${paneId}`; }
+function _getKeybar(paneId) { return localStorage.getItem(_keybarKey(paneId)) === 'true'; }
+function _saveKeybar(paneId, on) { localStorage.setItem(_keybarKey(paneId), on); }
+
 // ── status ─────────────────────────────────────────────────────────────────
 function setStatus(msg, cls) {
   connIndicator.title = msg;
@@ -413,16 +418,20 @@ function navigateTo(sessionId, windowId, paneId) {
     _paneCache.set(currentPane, { html: output.innerHTML, scrollTop: output.scrollTop });
     if (_paneCache.size > _PANE_CACHE_MAX) _paneCache.delete(_paneCache.keys().next().value);
   }
-  if (currentPane) _saveKbdMode(currentPane, kbdMode);
+  if (currentPane) {
+    _saveKbdMode(currentPane, kbdMode);
+    _saveKeybar(currentPane, keybarVisible());
+  }
 
   currentSessionId = sessionId;
   currentWindowId  = windowId;
   currentPane      = paneId;
   _saveLastPane(paneId);
 
-  // Restore keyboard mode for the arriving pane.
+  // Restore keyboard mode and key-bar visibility for the arriving pane.
+  // setKeybarVisible applies the keyboard mode itself.
   kbdMode = _getKbdMode(paneId);
-  applyKbdMode();
+  setKeybarVisible(_getKeybar(paneId));
   cmdInput.disabled = false;
   pwdInput.disabled = false;
   btnSend.disabled  = false;
@@ -551,14 +560,30 @@ function sendKeys() {
 // ── events ─────────────────────────────────────────────────────────────────
 xyzLabel.addEventListener('click', () => send({ type: 'list_sessions' }));
 cmdInput.addEventListener('keydown', e => {
-  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendKeys(); }
+  // The Enter that commits an IME composition arrives here with
+  // isComposing=true (or as Android keyCode 229); it must not reach the pane.
+  if (e.isComposing || e.keyCode === 229) return;
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    keybarVisible() ? sendNamedKey('Enter') : sendKeys();
+  } else if (e.key === 'Backspace' && keybarVisible() && !cmdInput.value) {
+    e.preventDefault();
+    sendNamedKey('BSpace');
+  }
 });
 cmdInput.addEventListener('input', () => {
   cmdInput.style.height = 'auto';
   cmdInput.style.height = Math.min(cmdInput.scrollHeight, 160) + 'px';
 });
 pwdInput.addEventListener('keydown', e => {
-  if (e.key === 'Enter') { e.preventDefault(); sendKeys(); }
+  if (e.isComposing || e.keyCode === 229) return;
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    keybarVisible() ? sendNamedKey('Enter') : sendKeys();
+  } else if (e.key === 'Backspace' && keybarVisible() && !pwdInput.value) {
+    e.preventDefault();
+    sendNamedKey('BSpace');
+  }
 });
 btnSend.addEventListener('click', sendKeys);
 
@@ -572,14 +597,24 @@ function applyKbdMode() {
   cmdInput.style.display = inPwd ? 'none' : '';
   pwdInput.style.display = inPwd ? 'block' : 'none';
 
+  // Direct mode needs raw keystrokes: under spell-check Gboard composes
+  // plain typing and only commits whole words, so force terminal attributes
+  // while the key bar is visible; hiding it restores the user's mode.
+  const direct = keybarVisible();
+
   if (kbdMode === 1) {
-    cmdInput.setAttribute('spellcheck', 'true');
-    cmdInput.setAttribute('autocorrect', 'on');
-    cmdInput.setAttribute('autocapitalize', 'sentences');
+    cmdInput.setAttribute('spellcheck', direct ? 'false' : 'true');
+    cmdInput.setAttribute('autocorrect', direct ? 'off' : 'on');
+    cmdInput.setAttribute('autocapitalize', direct ? 'none' : 'sentences');
     output.style.whiteSpace = 'pre-wrap';
     btnKbdMode.textContent = 'Aa';
     btnKbdMode.title = 'Text mode — tap for terminal mode';
     btnKbdMode.style.color = 'var(--accent)';
+    // Don't advertise spell check while direct mode has it forced off.
+    if (direct) {
+      btnKbdMode.title = 'Text mode: spell check suspended in direct mode';
+      btnKbdMode.style.color = '';
+    }
   } else if (kbdMode === 0) {
     cmdInput.setAttribute('spellcheck', 'false');
     cmdInput.setAttribute('autocorrect', 'off');
@@ -633,12 +668,141 @@ document.getElementById('escape-popup-ctrlc').addEventListener('click', () => {
   hideEscapePopup();
 });
 
+document.getElementById('escape-popup-keys').addEventListener('click', () => {
+  toggleKeybar();
+  hideEscapePopup();
+});
+
 document.addEventListener('click', () => hideEscapePopup());
 document.addEventListener('touchstart', e => {
   if (!escapePopup.contains(e.target) && e.target !== btnEscape) hideEscapePopup();
 }, { passive: true });
 
-// ── pane list — all live panes across all windows and sessions ────────────
+// ── key bar (Esc, Ctrl, Tab, arrows; direct key mode for TUIs like vi) ─────
+// While the bar is visible the text box drains on every input event: a
+// single typed character reaches the pane immediately without Enter, so
+// modal editors get bare keystrokes like "i". Named keys on the bar go out
+// as tmux key names (literal:false). Ctrl is a sticky modifier: it combines
+// with the next typed character or the next named key (C-c, C-Up, ...) and
+// then releases. Hiding the bar restores the normal chunked text-box flow.
+const keybar     = document.getElementById('keybar');
+const keybarCtrl = document.getElementById('keybar-ctrl');
+const _cmdPlaceholder = cmdInput.placeholder;
+const _pwdPlaceholder = pwdInput.placeholder;
+const _directPlaceholder = 'Direct mode: keys go straight to the pane';
+// The password box keeps its keyboard-privacy hint in direct mode too.
+const _directPwdPlaceholder = 'Direct mode: not saved by keyboard';
+let _ctrlArmed = false;
+
+function keybarVisible() { return keybar.style.display !== 'none'; }
+
+function setCtrlArmed(on) {
+  _ctrlArmed = on;
+  keybarCtrl.classList.toggle('armed', on);
+}
+
+function setKeybarVisible(show) {
+  // No-op when the state is unchanged (the common pane-switch case), so the
+  // blur + refocus dance below does not bounce the keyboard on every switch.
+  if (show === keybarVisible()) { applyKbdMode(); return; }
+  keybar.style.display = show ? '' : 'none';
+  // Persistent direct-mode cues: accent border on the input row and a dimmed
+  // Send button, driven by CSS off this class. Unlike the placeholder these
+  // survive typing.
+  document.body.classList.toggle('keybar-on', show);
+  if (!show) setCtrlArmed(false);
+  cmdInput.placeholder = show ? _directPlaceholder : _cmdPlaceholder;
+  pwdInput.placeholder = show ? _directPwdPlaceholder : _pwdPlaceholder;
+  // Re-apply so direct mode forces terminal input attributes and hiding
+  // the bar restores the user's mode. Also scrolls output to bottom.
+  applyKbdMode();
+  // Like btnKbdMode: Android keyboards only re-evaluate input attributes on
+  // refocus, so toggling the bar while the box is focused needs the same
+  // blur + refocus dance for the forced attributes to take effect.
+  const inp = activeInput();
+  if (document.activeElement === inp) {
+    inp.blur();
+    setTimeout(() => inp.focus(), 50);
+  }
+}
+
+function toggleKeybar() {
+  const show = !keybarVisible();
+  setKeybarVisible(show);
+  if (currentPane) _saveKeybar(currentPane, show);
+}
+
+function sendNamedKey(name) {
+  if (!currentPane) return;
+  if (_ctrlArmed) { name = 'C-' + name; setCtrlArmed(false); }
+  send({ type: 'send_keys', pane_id: currentPane, keys: name, enter: false, literal: false });
+}
+
+keybar.querySelectorAll('button[data-key]').forEach(btn => {
+  btn.addEventListener('click', () => sendNamedKey(btn.dataset.key));
+  // Keep focus (and the soft keyboard) in the text box on browsers that
+  // focus buttons on tap; Android and iOS mostly do not, so defensive only.
+  btn.addEventListener('pointerdown', e => e.preventDefault());
+});
+
+keybarCtrl.addEventListener('click', () => setCtrlArmed(!_ctrlArmed));
+keybarCtrl.addEventListener('pointerdown', e => e.preventDefault());
+
+// The X on the bar itself: same toggle path as the escape popup entry, so
+// per-pane persistence stays in one place.
+document.getElementById('keybar-close').addEventListener('click', toggleKeybar);
+
+function drainDirectInput(inp) {
+  const text = inp.value;
+  if (!text) return;
+  inp.value = '';
+  if (inp === cmdInput) cmdInput.style.height = 'auto';
+  if (!currentPane) return;
+  if (_ctrlArmed) {
+    setCtrlArmed(false);
+    // Ctrl combines with the characters tmux can ctrl-modify (letters plus
+    // @ [ \ ] ^ _ and space); iterate by code point so an emoji first
+    // character stays intact instead of splitting its surrogate pair into a
+    // bogus C-<half> key. Anything else falls through and is sent literally.
+    const first = [...text][0];
+    if (/^[a-z@\[\\\]^_ ]$/i.test(first)) {
+      const key = first === ' ' ? 'C-Space' : 'C-' + first.toLowerCase();
+      send({ type: 'send_keys', pane_id: currentPane,
+             keys: key, enter: false, literal: false });
+      const rest = text.slice(first.length);
+      if (rest) send({ type: 'send_keys', pane_id: currentPane, keys: rest, enter: false, literal: true });
+      return;
+    }
+  }
+  send({ type: 'send_keys', pane_id: currentPane, keys: text, enter: false, literal: true });
+}
+
+// IME guard: mobile keyboards fire input events mid-composition; draining
+// (which clears the box) then would duplicate or drop characters. Skip
+// while composing and drain once on compositionend.
+for (const inp of [cmdInput, pwdInput]) {
+  inp.addEventListener('input', e => {
+    if (keybarVisible() && !e.isComposing) drainDirectInput(inp);
+  });
+  inp.addEventListener('compositionend', () => {
+    if (keybarVisible()) drainDirectInput(inp);
+  });
+  // Gboard reports empty-field backspace as keyCode 229, so the keydown
+  // path misses it; catch it here instead. When keydown does handle a
+  // backspace it calls preventDefault, which cancels this event, so one
+  // physical backspace never sends two BSpace. A keyboard that emits
+  // neither event on an empty field gets a dead backspace; the bar's
+  // backspace button covers that, and the sentinel-character trick is the
+  // known fix if it ever matters.
+  inp.addEventListener('beforeinput', e => {
+    if (keybarVisible() && e.inputType === 'deleteContentBackward' && !inp.value) {
+      e.preventDefault();
+      sendNamedKey('BSpace');
+    }
+  });
+}
+
+// ── pane list: all live panes across all windows and sessions ─────────────
 // Deduplicated by pane ID: byobu exposes the same windows/panes under multiple
 // sessions (linked windows / multi-client attach), so skip any already seen.
 function flatPaneList() {

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -323,7 +323,42 @@
       letter-spacing: 0.04em;
     }
     #escape-popup button:active { background: var(--bg3); }
-    #escape-popup-sep { height: 1px; background: var(--border); margin: 2px 0; }
+    .escape-popup-sep { height: 1px; background: var(--border); margin: 2px 0; }
+
+    /* ── key bar (Esc, Ctrl, Tab, arrows for TUIs like vi) ── */
+    #keybar {
+      display: flex; gap: 4px; padding: 6px 10px;
+      background: var(--bg2); border-top: 1px solid var(--border);
+      flex-shrink: 0; overflow-x: auto; scrollbar-width: none;
+    }
+    #keybar::-webkit-scrollbar { display: none; }
+    #keybar button {
+      background: var(--bg3); color: var(--text);
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 7px 0; font-size: 13px; font-family: var(--font);
+      cursor: pointer; flex: 1; min-width: 34px;
+    }
+    #keybar button:active { background: var(--border); }
+    #keybar-ctrl.armed { color: var(--accent); border-color: var(--accent); }
+    /* close button: dismisses the bar, does not send a key.
+       #keybar prefix keeps these rules above #keybar button in the cascade */
+    #keybar #keybar-close {
+      flex: 0 0 auto; min-width: 44px; min-height: 44px; padding: 10px 0;
+      /* pin to the scrollport edge: the bar's content is ~435px wide, so on
+         360-412px phones it overflows with the scrollbar hidden; without
+         sticky the ✕ (the bar's exit) starts off-screen. Opaque background
+         so keys scroll under it instead of showing through */
+      position: sticky; right: 0; background: var(--bg2);
+      border-color: transparent;
+      /* var(--text), not --dim: --dim over --bg2 is ~2.9:1, the contrast
+         class e894f3db removed, and this X is the bar's exit path */
+      color: var(--text); font-size: 15px;
+    }
+    #keybar #keybar-close:active { background: var(--bg3); color: var(--text); }
+    /* direct mode cues on the input row: accent border on the row, Send
+       recedes (it still sends a chunk, but keystrokes bypass it) */
+    body.keybar-on #inputbar { border-top: 1px solid var(--accent); }
+    body.keybar-on #btn-send:not(:disabled) { opacity: 0.45; }
 
 
     /* ── pairing overlay ── */
@@ -590,6 +625,20 @@
     <div id="statusline-right"></div>
   </div>
 
+  <!-- ── key bar (toggled from the ⎋ popup; direct key mode for TUIs) ── -->
+  <div id="keybar" style="display:none">
+    <button data-key="Escape" title="Escape">Esc</button>
+    <button id="keybar-ctrl" title="Ctrl: combines with the next key">Ctrl</button>
+    <button data-key="Tab" title="Tab">Tab</button>
+    <button data-key="Left" title="Left">←</button>
+    <button data-key="Down" title="Down">↓</button>
+    <button data-key="Up" title="Up">↑</button>
+    <button data-key="Right" title="Right">→</button>
+    <button data-key="BSpace" title="Backspace">⌫</button>
+    <button data-key="Enter" title="Enter">⏎</button>
+    <button id="keybar-close" title="Close key bar: back to chunked input">✕</button>
+  </div>
+
   <div id="inputbar">
     <textarea id="cmd" rows="2" placeholder="Send keys to pane… (Enter = send, Shift+Enter = newline)"
               autocomplete="off" autocorrect="off" autocapitalize="none"
@@ -599,17 +648,19 @@
            spellcheck="false" placeholder="Password — not saved by keyboard"
            disabled>
     <div id="btn-right-col">
-      <button id="btn-escape" class="icon-btn" title="Esc / Ctrl-C">⎋</button>
+      <button id="btn-escape" class="icon-btn" title="Esc / Ctrl-C / key bar">⎋</button>
       <button id="btn-kbd-mode" class="icon-btn" title="Terminal mode — tap to enable spell check">$_</button>
     </div>
     <button id="btn-send" title="Send" disabled>↵</button>
   </div>
 
-  <!-- ── escape / ctrl-c popup ── -->
+  <!-- ── escape / ctrl-c / key bar popup ── -->
   <div id="escape-popup" style="display:none">
     <button id="escape-popup-esc">⎋&nbsp; Esc</button>
-    <div id="escape-popup-sep"></div>
+    <div class="escape-popup-sep"></div>
     <button id="escape-popup-ctrlc">^C&nbsp; Ctrl-C</button>
+    <div class="escape-popup-sep"></div>
+    <button id="escape-popup-keys">⌨&nbsp; Key bar</button>
   </div>
 
 </div>


### PR DESCRIPTION
Closes #131.

## What

Adds a key bar and a per-keystroke direct input mode to the trustmux PWA,
so modal TUIs (vi, less, htop) can be driven from a phone.

- A key bar, toggled from the escape popup, with Esc, Tab, arrows,
  backspace, and a sticky Ctrl modifier, sent as tmux named keys over the
  existing send_keys message (enter:false, literal:false).
- While the bar is visible the text box is in direct mode: it drains on
  every input event, so each keystroke reaches the pane without Enter.
  Enter sends the tmux Enter key; backspace on an empty box sends BSpace.
- Ctrl combines with the next typed character or named key for the
  characters tmux can ctrl-modify (letters plus @ [ \ ] ^ _ and space),
  split by code point so multibyte input passes through literally.
- Mode cues that survive typing: an accent border on the input row and a
  dimmed Send button while direct mode is on, plus a close button pinned
  to the bar's right edge (sticky, so it survives horizontal overflow on
  narrow phones). Bar visibility persists per pane.

## Why

The PWA sends input as literal strings with Enter appended. Modal TUIs
need bare keystrokes, Escape, Ctrl combos, and arrows, none of which the
chunked model can express; the escape popup's hardcoded Escape and Ctrl-C
were the only exceptions.

## Notes for reviewers

- Mobile IMEs are the hard part. The drain skips isComposing input events
  and runs once on compositionend; the Enter/Backspace keydown paths
  early-return on isComposing or keyCode 229; a beforeinput listener
  catches Gboard's empty-field backspace; direct mode forces terminal
  input attributes (spellcheck/autocorrect off) with a blur and refocus so
  Android keyboards pick them up, and restores the user's keyboard mode on
  exit.
- No daemon changes: keys ride the existing send_keys flags.
- Tested on-device (Android PWA) against vi: insert/normal round trips,
  Ctrl combos, arrows, backspace, mode cues, and per-pane restore. JS is
  syntax-checked (node --check); the repo has no JS test harness.