### PR TITLE
feat(trustmux): add per-pane line-wrap toggle for phone-width output

### DIFF
--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -458,6 +458,39 @@ class TestCapturePaneAnsiFlag(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# tmux_capture_pane join flag (-J: reflow soft-wrapped lines on the client)
+# ---------------------------------------------------------------------------
+
+class TestCapturePaneJoinFlag(unittest.TestCase):
+    def test_join_true_passes_j_flag(self):
+        captured_args = []
+        def fake_tmux(*args):
+            captured_args.extend(args)
+            return ''
+        with patch.object(bm, '_tmux', side_effect=fake_tmux):
+            bm.tmux_capture_pane('%0', join=True)
+        self.assertIn('-J', captured_args)
+
+    def test_join_false_omits_j_flag(self):
+        captured_args = []
+        def fake_tmux(*args):
+            captured_args.extend(args)
+            return ''
+        with patch.object(bm, '_tmux', side_effect=fake_tmux):
+            bm.tmux_capture_pane('%0', join=False)
+        self.assertNotIn('-J', captured_args)
+
+    def test_default_omits_j_flag(self):
+        captured_args = []
+        def fake_tmux(*args):
+            captured_args.extend(args)
+            return ''
+        with patch.object(bm, '_tmux', side_effect=fake_tmux):
+            bm.tmux_capture_pane('%0')
+        self.assertNotIn('-J', captured_args)
+
+
+# ---------------------------------------------------------------------------
 # main() -- help discoverability
 # ---------------------------------------------------------------------------
 

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -358,11 +358,17 @@ def tmux_list_panes(window_id: str) -> list[dict]:
         })
     return panes
 
-def tmux_capture_pane(pane_id: str, history_lines: int = 200, ansi: bool = False) -> str:
+def tmux_capture_pane(pane_id: str, history_lines: int = 200, ansi: bool = False,
+                      join: bool = False) -> str:
+    args = ["capture-pane", "-t", pane_id, "-p"]
     if ansi:
-        raw = _tmux("capture-pane", "-t", pane_id, "-p", "-e", "-S", f"-{history_lines}")
-    else:
-        raw = _tmux("capture-pane", "-t", pane_id, "-p", "-S", f"-{history_lines}")
+        args.append("-e")
+    if join:
+        # -J joins lines tmux soft-wrapped at the pane width, so the client
+        # can reflow them at its own width.
+        args.append("-J")
+    raw = _tmux(*args, "-S", f"-{history_lines}")
+    if not ansi:
         raw = strip_ansi(raw)
     return raw
 
@@ -863,14 +869,15 @@ class WsHandler(tornado.websocket.WebSocketHandler):
             except Exception:
                 pass
 
-    async def _stream_pane(self, pane_id: str, history_lines: int, ansi: bool = False):
+    async def _stream_pane(self, pane_id: str, history_lines: int, ansi: bool = False,
+                           join: bool = False):
         try:
-            content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi)
+            content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
             self._send({"type": "snapshot", "pane_id": pane_id, "data": content})
             last = content
             while True:
                 await asyncio.sleep(0.5)
-                content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi)
+                content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
                 if content != last:
                     self._send({"type": "update", "pane_id": pane_id, "data": content})
                     last = content
@@ -952,11 +959,12 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                     except (ValueError, TypeError):
                         lines = 300
                     ansi = bool(msg.get("ansi", False))
+                    join = bool(msg.get("join", False))
                     if self._stream_task:
                         self._stream_task.cancel()
                         await asyncio.gather(self._stream_task, return_exceptions=True)
                     self._stream_task = asyncio.ensure_future(
-                        self._stream_pane(pane_id, lines, ansi)
+                        self._stream_pane(pane_id, lines, ansi, join)
                     )
 
             elif mtype == "new_session":

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -275,6 +275,11 @@ function _keybarKey(paneId) { return `keybar:${location.hostname}:${paneId}`; }
 function _getKeybar(paneId) { return localStorage.getItem(_keybarKey(paneId)) === 'true'; }
 function _saveKeybar(paneId, on) { localStorage.setItem(_keybarKey(paneId), on); }
 
+// ── line wrap per pane (persisted like kbdMode, restored on switch) ────────
+function _wrapKey(paneId) { return `wrap:${location.hostname}:${paneId}`; }
+function _getWrap(paneId) { return localStorage.getItem(_wrapKey(paneId)) === 'true'; }
+function _saveWrap(paneId, on) { localStorage.setItem(_wrapKey(paneId), on); }
+
 // ── status ─────────────────────────────────────────────────────────────────
 function setStatus(msg, cls) {
   connIndicator.title = msg;
@@ -296,7 +301,7 @@ function connect() {
     _connectedAt = Date.now();
     startClock();
     send({ type: 'list_sessions' });
-    if (currentPane) send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true });
+    if (currentPane) send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
   };
   ws.onclose = (evt) => {
     stopClock();
@@ -475,6 +480,7 @@ function navigateTo(sessionId, windowId, paneId) {
   if (currentPane) {
     _saveKbdMode(currentPane, kbdMode);
     _saveKeybar(currentPane, keybarVisible());
+    _saveWrap(currentPane, wrapOn);
   }
 
   currentSessionId = sessionId;
@@ -482,9 +488,11 @@ function navigateTo(sessionId, windowId, paneId) {
   currentPane      = paneId;
   _saveLastPane(paneId);
 
-  // Restore keyboard mode and key-bar visibility for the arriving pane.
-  // setKeybarVisible applies the keyboard mode itself.
+  // Restore keyboard mode, wrap state and key-bar visibility for the
+  // arriving pane. setKeybarVisible applies the keyboard mode itself.
   kbdMode = _getKbdMode(paneId);
+  wrapOn  = _getWrap(paneId);
+  applyWrap();
   setKeybarVisible(_getKeybar(paneId));
   cmdInput.disabled = false;
   pwdInput.disabled = false;
@@ -499,7 +507,7 @@ function navigateTo(sessionId, windowId, paneId) {
     output.textContent = 'loading…';
   }
 
-  send({ type: 'subscribe', pane_id: paneId, lines: 300, ansi: true });
+  send({ type: 'subscribe', pane_id: paneId, lines: 300, ansi: true, join: wrapOn });
   updateXYZLabel();
   updateContextName();
 }
@@ -659,7 +667,6 @@ function applyKbdMode() {
     cmdInput.setAttribute('spellcheck', direct ? 'false' : 'true');
     cmdInput.setAttribute('autocorrect', direct ? 'off' : 'on');
     cmdInput.setAttribute('autocapitalize', direct ? 'none' : 'sentences');
-    output.style.whiteSpace = 'pre-wrap';
     btnKbdMode.textContent = 'Aa';
     btnKbdMode.title = 'Text mode — tap for terminal mode';
     btnKbdMode.style.color = 'var(--accent)';
@@ -672,12 +679,10 @@ function applyKbdMode() {
     cmdInput.setAttribute('spellcheck', 'false');
     cmdInput.setAttribute('autocorrect', 'off');
     cmdInput.setAttribute('autocapitalize', 'none');
-    output.style.whiteSpace = 'pre';
     btnKbdMode.textContent = '$_';
     btnKbdMode.title = 'Terminal mode — tap to enable spell check';
     btnKbdMode.style.color = '';
   } else {
-    output.style.whiteSpace = 'pre';
     btnKbdMode.textContent = '**';
     btnKbdMode.title = 'Password mode — keyboard will not learn this text';
     btnKbdMode.style.color = 'var(--accent)';
@@ -723,6 +728,33 @@ document.getElementById('escape-popup-ctrlc').addEventListener('click', () => {
 
 document.getElementById('escape-popup-keys').addEventListener('click', () => {
   toggleKeybar();
+  hideEscapePopup();
+});
+
+// ── line wrap toggle ───────────────────────────────────────────────────────
+// Off (default): tmux's own line breaks, pre with horizontal scroll. On: the
+// daemon captures with -J so soft-wrapped lines come back joined, and
+// pre-wrap reflows them at the phone width. Decoupled from kbdMode.
+let wrapOn = false;
+const escapePopupWrap = document.getElementById('escape-popup-wrap');
+
+function applyWrap() {
+  output.style.whiteSpace = wrapOn ? 'pre-wrap' : 'pre';
+  // Checkmark prefix like the context picker: on-state must not rely on
+  // color alone.
+  escapePopupWrap.textContent = (wrapOn ? '✓ ' : '⤶ ') + 'Wrap';
+  escapePopupWrap.style.color = wrapOn ? 'var(--accent)' : '';
+}
+
+escapePopupWrap.addEventListener('click', () => {
+  wrapOn = !wrapOn;
+  if (currentPane) {
+    _saveWrap(currentPane, wrapOn);
+    // Resubscribe so the snapshot is re-captured with the new join flag.
+    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
+  }
+  applyWrap();
+  scrollOutputToBottom();
   hideEscapePopup();
 });
 

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -659,6 +659,8 @@
     <button id="escape-popup-ctrlc">^C&nbsp; Ctrl-C</button>
     <div class="escape-popup-sep"></div>
     <button id="escape-popup-keys">⌨&nbsp; Key bar</button>
+    <div class="escape-popup-sep"></div>
+    <button id="escape-popup-wrap">⤶&nbsp; Wrap</button>
   </div>
 
 </div>


### PR DESCRIPTION
Closes #133.

## What

Adds a Wrap entry to the escape popup. When on, the client resubscribes
with a join flag and the daemon captures with capture-pane -J, which
rejoins the lines tmux soft-wrapped; the output renders with pre-wrap
and reflows at the phone's width. When off, the grid-faithful rendering
with horizontal scroll is unchanged. The entry shows a checkmark prefix
when active, so the state does not rely on color alone.

Wrap is a per-pane setting persisted like the keyboard mode, since
wrapping helps shell output but breaks column-aligned TUIs.

The keyboard text mode (Aa) no longer sets pre-wrap as a side effect;
white-space is driven only by the wrap toggle. The old coupling was
accidental, and it could only ever mid-word-wrap lines tmux had already
hard-broken.

## Why

tmux panes are sized by the desktop client (~160 columns), while a phone
fits ~50. Without rejoining on the server side, no client-side wrapping
can reflow at the right points.

## Notes for reviewers

- The join flag defaults to false in the subscribe handler, so old
  clients get byte-identical behavior.
- A resubscribe replaces the pane's poll loop (the handler cancels and
  awaits the previous stream task), so toggling does not leak or double
  the 0.5s loop.
- capture-pane -J preserves trailing spaces; if wrap-on rendering ever
  looks ragged on space-padded output, that is the first suspect.
- Tested on-device (Android PWA): reflow with wrap on, grid intact with
  wrap off, per-pane restore. Daemon tests cover the join flag at the
  capture level (matching the existing ansi flag's coverage shape).