### PR TITLE
feat(trustmux): make the context picker a per-level drill-down

### DIFF
--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -323,6 +323,16 @@ function connect() {
       if (msg.new_session) forcedSessionId = msg.new_session;
       if (msg.new_pane) forcedPaneId = msg.new_pane;
       rebuildPaneTree();
+      // An open picker must track topology: without this, rows for a window
+      // that just died stay tappable and navigate to a dead pane, and
+      // _ctxResolveLevel's fallback never runs until the next interaction.
+      // Refocus only when a picker row had focus: focus() can scroll the
+      // list, which would yank a touch user's position on unrelated updates.
+      if (ctxPickerActive()) {
+        const ae = document.activeElement;
+        if (ae && ae.closest('#ctx-list')) _ctxRerender(ae.dataset.ctxId);
+        else renderCtxList();
+      }
     } else if (msg.type === 'snapshot') {
       if (msg.pane_id === currentPane) {
         const forceTop = _scrollTopOnNextSnapshot;
@@ -382,14 +392,6 @@ function paneDisplayName(p) {
   if (!p) return 'shell';
   const title = isDefaultPaneTitle(p.title) ? '' : p.title;
   return getPaneName(p.id, '') || title || p.command || 'shell';
-}
-
-function contextPath() {
-  const s = currentSession();
-  const w = currentWindow();
-  const p = currentPaneObj();
-  if (!s || !w || !p) return '';
-  return `${s.name} / ${w.index}:${w.name} / ${paneDisplayName(p)}`;
 }
 
 // ── position label ────────────────────────────────────────────────────────
@@ -509,9 +511,46 @@ function navigateTo(sessionId, windowId, paneId) {
 }
 
 // ── context name ──────────────────────────────────────────────────────────
+// The breadcrumb is three tap targets, one per picker level: the session
+// segment opens the sessions list, the window segment the current session's
+// windows, the pane segment the current window's panes. A tap that misses
+// every segment falls through to the container listener, which keeps the
+// windows-level default.
+function _ctxSeg(text, cls, level) {
+  const el = document.createElement('span');
+  el.className = 'ctx-seg ' + cls;
+  el.textContent = text;
+  // No stopPropagation: the document-level closers for the info and escape
+  // popups must keep seeing the click; the container listener skips segment
+  // targets itself.
+  el.addEventListener('click', () => showCtxOverlayAt(level));
+  return el;
+}
+
+function _ctxSegSep() {
+  const el = document.createElement('span');
+  el.className = 'ctx-seg-sep';
+  el.textContent = '/';
+  return el;
+}
+
 function updateContextName() {
-  if (!currentPane) { ctxName.textContent = ''; return; }
-  ctxName.textContent = contextPath() || getPaneName(currentPane, '') || 'shell';
+  ctxName.textContent = '';
+  if (!currentPane) return;
+  const s = currentSession();
+  const w = currentWindow();
+  const p = currentPaneObj();
+  if (!s || !w || !p) {
+    ctxName.textContent = getPaneName(currentPane, '') || 'shell';
+    return;
+  }
+  ctxName.append(
+    _ctxSeg(s.name, 'ctx-seg-session', 'sessions'),
+    _ctxSegSep(),
+    _ctxSeg(`${w.index}:${w.name}`, 'ctx-seg-window', 'windows'),
+    _ctxSegSep(),
+    _ctxSeg(paneDisplayName(p), 'ctx-seg-pane', 'panes'),
+  );
 }
 
 // ── output rendering ───────────────────────────────────────────────────────
@@ -924,61 +963,124 @@ btnNext.addEventListener('click', () => navigateRelative(1));
 document.getElementById('btn-create').addEventListener('click', showCreateOverlay);
 
 // ── context jump list (tap context name in header) ─────────────────────────
-// Hierarchical picker: sessions first, then windows inside each session, then
-// panes inside each window. This keeps tmux's session/window/pane model visible
-// instead of reducing everything to a long pane list.
+// Drill-down picker: one list per level (sessions, windows, panes) instead of
+// one flat indented tree, which turned into a giant scroll with many contexts.
+// _ctxLevel/_ctxSessionId/_ctxWindowId hold where the picker is;
+// showCtxOverlayAt resets them to the requested level on every open.
+let _ctxLevel     = 'windows'; // 'sessions' | 'windows' | 'panes'
+let _ctxSessionId = null;
+let _ctxWindowId  = null;
+
+function liveWindowsInSession(s) {
+  return (s?.windows || []).filter(w => firstLivePaneInWindow(w));
+}
+
+function _ctxSessionObj() {
+  return sessions.find(s => s.id === _ctxSessionId) || null;
+}
+
+function _ctxWindowObj() {
+  return (_ctxSessionObj()?.windows || []).find(w => w.id === _ctxWindowId) || null;
+}
+
+// A snapshot update can leave the picker pointing at a session or
+// window that no longer has live panes; fall back to the level above.
+function _ctxResolveLevel() {
+  if (_ctxLevel === 'panes' && !livePanesInWindow(_ctxWindowObj()).length) _ctxLevel = 'windows';
+  if (_ctxLevel === 'windows' && !liveWindowsInSession(_ctxSessionObj()).length) _ctxLevel = 'sessions';
+}
+
+function _ctxAddRow(label, isCurrent, onClick) {
+  const btn = document.createElement('button');
+  btn.className = 'ctx-btn' + (isCurrent ? ' ctx-current' : '');
+  btn.textContent = (isCurrent ? '✓ ' : '') + label;
+  btn.addEventListener('click', onClick);
+  ctxList.appendChild(btn);
+  return btn;
+}
+
+function _ctxAddTitle(text) {
+  const el = document.createElement('div');
+  el.className = 'ctx-title';
+  el.textContent = text;
+  ctxList.appendChild(el);
+}
+
+function _ctxAddBackRow(label, onClick) {
+  const btn = _ctxAddRow('← ' + label, false, onClick);
+  btn.classList.add('ctx-dim');
+  const sep = document.createElement('div');
+  sep.className = 'ctx-sep';
+  ctxList.appendChild(sep);
+}
+
+// Re-render after a level change and move real DOM focus so prefix+w j/k
+// keeps working: prefer the row we came from, then the current-context row.
+function _ctxRerender(focusId) {
+  renderCtxList();
+  const rows = pickerRows();
+  const target = (focusId && rows.find(b => b.dataset.ctxId === focusId))
+    || rows.filter(b => b.classList.contains('ctx-current')).pop()
+    // In a non-current session or window nothing is ctx-current; prefer the
+    // first real entry over the back row so Enter keeps drilling down.
+    || rows.find(b => b.dataset.ctxId)
+    || rows[0];
+  if (target) target.focus();
+}
+
 function renderCtxList() {
   ctxList.innerHTML = '';
-  for (const s of sessions) {
-    const sessionHasLivePane = (s.windows || []).some(w => firstLivePaneInWindow(w));
-    if (!sessionHasLivePane) continue;
+  _ctxResolveLevel();
 
-    if (ctxList.children.length) {
-      const sep = document.createElement('div');
-      sep.className = 'ctx-sep';
-      ctxList.appendChild(sep);
-    }
-
-    const sBtn = document.createElement('button');
-    sBtn.className = 'ctx-btn' + (s.id === currentSessionId ? ' ctx-current' : '');
-    sBtn.textContent = (s.id === currentSessionId ? '✓ ' : '') + s.name;
-    sBtn.addEventListener('click', () => {
-      const firstWindow = (s.windows || []).find(w => firstLivePaneInWindow(w));
-      const firstPane = firstLivePaneInWindow(firstWindow);
-      hideCtxOverlay();
-      if (firstWindow && firstPane) navigateTo(s.id, firstWindow.id, firstPane.id);
-    });
-    ctxList.appendChild(sBtn);
-
-    for (const w of (s.windows || [])) {
-      const livePanes = livePanesInWindow(w);
-      if (!livePanes.length) continue;
-      const isCurrentWindow = s.id === currentSessionId && w.id === currentWindowId;
-      const wBtn = document.createElement('button');
-      wBtn.className = 'ctx-btn ctx-window-btn' + (isCurrentWindow ? ' ctx-current' : '');
-      wBtn.textContent = `${isCurrentWindow ? '✓ ' : ''}${w.index}:${w.name}`;
-      wBtn.addEventListener('click', () => {
-        const p = firstLivePaneInWindow(w);
-        hideCtxOverlay();
-        if (p) navigateTo(s.id, w.id, p.id);
+  if (_ctxLevel === 'sessions') {
+    _ctxAddTitle('Sessions');
+    for (const s of sessions) {
+      if (!liveWindowsInSession(s).length) continue;
+      const btn = _ctxAddRow(s.name, s.id === currentSessionId, () => {
+        _ctxSessionId = s.id;
+        _ctxLevel = 'windows';
+        _ctxRerender(null);
       });
-      ctxList.appendChild(wBtn);
-
-      for (const p of livePanes) {
-        const isCurrent = p.id === currentPane;
-        const btn = document.createElement('button');
-        btn.className = 'ctx-btn ctx-pane-btn' + (isCurrent ? ' ctx-current' : '');
-        const name = paneDisplayName(p);
-        btn.textContent = (isCurrent ? '✓ ' : '') + name;
-        btn.addEventListener('click', () => {
-          hideCtxOverlay();
-          if (!isCurrent) navigateTo(s.id, w.id, p.id);
-        });
-        ctxList.appendChild(btn);
-      }
+      btn.dataset.ctxId = s.id;
+      btn.dataset.descend = '1';
+    }
+  } else if (_ctxLevel === 'windows') {
+    const s = _ctxSessionObj();
+    _ctxAddBackRow('Sessions', () => {
+      _ctxLevel = 'sessions';
+      _ctxRerender(s.id);
+    });
+    _ctxAddTitle(s.name);
+    for (const w of liveWindowsInSession(s)) {
+      const isCurrent = s.id === currentSessionId && w.id === currentWindowId;
+      const btn = _ctxAddRow(`${w.index}:${w.name}`, isCurrent, () => {
+        _ctxWindowId = w.id;
+        _ctxLevel = 'panes';
+        _ctxRerender(null);
+      });
+      btn.dataset.ctxId = w.id;
+      btn.dataset.descend = '1';
+    }
+  } else {
+    const s = _ctxSessionObj();
+    const w = _ctxWindowObj();
+    _ctxAddBackRow(s.name, () => {
+      _ctxLevel = 'windows';
+      _ctxRerender(w.id);
+    });
+    _ctxAddTitle(`${w.index}:${w.name}`);
+    for (const p of livePanesInWindow(w)) {
+      const isCurrent = p.id === currentPane;
+      const btn = _ctxAddRow(paneDisplayName(p), isCurrent, () => {
+        hideCtxOverlay();
+        if (!isCurrent) navigateTo(s.id, w.id, p.id);
+      });
+      btn.dataset.ctxId = p.id;
     }
   }
-  if (!ctxList.children.length) {
+
+  if (!pickerRows().length) {
+    ctxList.innerHTML = '';
     const empty = document.createElement('div');
     empty.className = 'ctx-dim';
     empty.style.padding = '16px';
@@ -987,16 +1089,35 @@ function renderCtxList() {
   }
 }
 
-function showCtxOverlay() {
+// Open at an explicit level: 'sessions' lists all sessions, 'windows' the
+// current session's windows, 'panes' the current window's panes. No
+// persistence across opens.
+function showCtxOverlayAt(level) {
+  // Like navigateTo: the keydown dispatch checks scroll mode before the
+  // picker, so an open picker under scroll mode would have a dead keyboard.
+  if (_scrollMode) exitScrollMode();
+  _ctxLevel     = level;
+  _ctxSessionId = currentSessionId;
+  _ctxWindowId  = level === 'panes' ? currentWindowId : null;
   renderCtxList();
   ctxListView.style.display = '';
   ctxRenameForm.style.display = 'none';
   ctxOverlay.style.display = 'flex';
 }
+
+function showCtxOverlay() {
+  // Windows is the middle ground: sessions are one Back away and the current
+  // window's panes one tap away.
+  showCtxOverlayAt('windows');
+}
 function hideCtxOverlay() {
   ctxOverlay.style.display = 'none';
 }
-ctxName.addEventListener('click', showCtxOverlay);
+ctxName.addEventListener('click', e => {
+  // Segment clicks open their own level; only a miss keeps the default.
+  if (e.target.closest('.ctx-seg')) return;
+  showCtxOverlay();
+});
 ctxCancel.addEventListener('click', hideCtxOverlay);
 ctxOverlay.addEventListener('click', e => { if (e.target === ctxOverlay) hideCtxOverlay(); });
 
@@ -1029,8 +1150,9 @@ function showRenameForm() {
 }
 function backToCtxList() {
   ctxRenameForm.style.display = 'none';
-  renderCtxList();
+  // List visible before _ctxRerender: focus() on a hidden element is a no-op.
   ctxListView.style.display = '';
+  _ctxRerender(null);
 }
 ctxRenameOpen.addEventListener('click', showRenameForm);
 ctxRenameBack.addEventListener('click', backToCtxList);
@@ -1542,7 +1664,7 @@ function handleScrollKey(e) {
   if (step !== null) output.scrollTop += step;
 }
 
-// ── context picker keyboard navigation (prefix+w) ──────────────────────────
+// ── context picker keyboard navigation (prefix+w, prefix+s) ────────────────
 function ctxPickerActive() {
   return ctxOverlay.style.display !== 'none' && ctxRenameForm.style.display === 'none';
 }
@@ -1562,23 +1684,30 @@ function movePickerFocus(delta) {
   next.scrollIntoView({ block: 'nearest' });
 }
 
-function openCtxPickerKeyboard() {
-  showCtxOverlay();
-  // Land on the last ctx-current row rather than the first: the first is the
-  // session row, so prefix+w then Enter would jump to the session's first
-  // live pane instead of staying put (the pane row's click handler is the
-  // real no-op). Fall back to the first row.
+function openCtxPickerKeyboard(level) {
+  showCtxOverlayAt(level || 'windows');
+  // The ctx-current row is the current window at the windows level and the
+  // current session at the sessions level: Enter descends into it. Fall back
+  // to the first row.
   const rows = pickerRows();
   const marked = rows.filter(b => b.classList.contains('ctx-current'));
   const start = marked[marked.length - 1] || rows[0];
   if (start) start.focus();
 }
 
+// Esc or h at a deeper picker level goes up one; returns false at the top so
+// the caller closes instead.
+function ctxPickerUp() {
+  if (_ctxLevel === 'panes')   { _ctxLevel = 'windows';  _ctxRerender(_ctxWindowId);  return true; }
+  if (_ctxLevel === 'windows') { _ctxLevel = 'sessions'; _ctxRerender(_ctxSessionId); return true; }
+  return false;
+}
+
 function handlePickerKey(e) {
   if (e.key === 'Escape') {
     e.preventDefault();
     e.stopPropagation();
-    hideCtxOverlay();
+    if (!ctxPickerUp()) hideCtxOverlay();
     return;
   }
   const ae = document.activeElement;
@@ -1597,7 +1726,13 @@ function handlePickerKey(e) {
   // With a text field focused (picker opened by tap while typing), only Esc
   // acts; j/k keep typing and arrows keep moving the caret.
   if (isField) return;
-  if (e.key === 'j' || e.key === 'ArrowDown') {
+  if (e.key === 'q') {
+    // Close outright from any depth, like scroll mode and tmux choose-tree;
+    // Esc walks up a level first, so q is the one-keystroke close.
+    e.preventDefault();
+    e.stopPropagation();
+    hideCtxOverlay();
+  } else if (e.key === 'j' || e.key === 'ArrowDown') {
     e.preventDefault();
     e.stopPropagation();
     movePickerFocus(1);
@@ -1605,6 +1740,16 @@ function handlePickerKey(e) {
     e.preventDefault();
     e.stopPropagation();
     movePickerFocus(-1);
+  } else if (e.key === 'h' || e.key === 'ArrowLeft') {
+    e.preventDefault();
+    e.stopPropagation();
+    ctxPickerUp();
+  } else if (e.key === 'l' || e.key === 'ArrowRight') {
+    // Descend only: pane rows and footer buttons have no descend flag, so l
+    // never navigates or closes by accident.
+    e.preventDefault();
+    e.stopPropagation();
+    if (ae && ae.dataset.descend) ae.click();
   }
   // Enter falls through: the focused button's native activation fires its
   // existing click handler.
@@ -1621,6 +1766,7 @@ function handlePrefixKey(e) {
   // Modified keys are unbound: Ctrl+W while armed must not open the picker.
   const k = (e.ctrlKey || e.altKey || e.metaKey) ? '' : e.key;
   if      (k === 'w') openCtxPickerKeyboard();
+  else if (k === 's') openCtxPickerKeyboard('sessions'); // tmux choose-session analog
   else if (k === 'n') navigateRelativeWindow(1);
   else if (k === 'p') navigateRelativeWindow(-1);
   else if (k === 'o') navigateRelativePane(1);

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -476,6 +476,10 @@ function navigateTo(sessionId, windowId, paneId) {
     _saveKbdMode(currentPane, kbdMode);
     _saveKeybar(currentPane, keybarVisible());
   }
+  // Scroll mode is a per-view state: switching panes while in it would leave
+  // the new pane top-anchored under a stale SCROLL chip, since the bottom
+  // re-anchor stays suppressed.
+  if (_scrollMode) exitScrollMode();
 
   currentSessionId = sessionId;
   currentWindowId  = windowId;
@@ -512,6 +516,9 @@ function updateContextName() {
 
 // ── output rendering ───────────────────────────────────────────────────────
 function scrollOutputToBottom() {
+  // Scroll mode owns the viewport: a one-line j/k step stays inside the 60px
+  // bottom-snap zone, so re-anchoring here would yank a live pane back down.
+  if (_scrollMode) return;
   requestAnimationFrame(() => { output.scrollTop = output.scrollHeight; });
 }
 
@@ -889,6 +896,19 @@ function navigateRelativePane(delta) {
   const idx = panes.findIndex(p => p.id === currentPane);
   const nextPane = panes[((idx < 0 ? 0 : idx) + delta + panes.length) % panes.length];
   navigateTo(currentSessionId, w.id, nextPane.id);
+}
+
+// Next/previous window within the current session, wrapping; lands on the
+// window's first live pane. Used by the hardware prefix+n / prefix+p bindings.
+function navigateRelativeWindow(delta) {
+  const s = currentSession();
+  if (!s) return;
+  const windows = (s.windows || []).filter(w => firstLivePaneInWindow(w));
+  if (windows.length < 2) return;
+  const idx = windows.findIndex(w => w.id === currentWindowId);
+  const next = windows[((idx < 0 ? 0 : idx) + delta + windows.length) % windows.length];
+  const p = firstLivePaneInWindow(next);
+  if (p) navigateTo(s.id, next.id, p.id);
 }
 
 // ── touch swipe tracking (used for swipe nav) ─────────────────────────────
@@ -1420,6 +1440,222 @@ document.getElementById('lock-unlock-btn').addEventListener('click', async () =>
   }
 });
 
+
+// ── hardware-keyboard tmux bindings (Ctrl+B prefix) ────────────────────────
+// Local capture for hardware keyboards: Ctrl+B arms a 2s pending-prefix state
+// (chip in the statusbar, Esc cancels), then w opens the context picker with
+// j/k navigation, n/p cycle windows, [ enters a client-side scroll mode on
+// the snapshot div. byobu's remote prefix stays F12/Ctrl-A and the key bar's
+// sticky Ctrl still sends a literal C-b, so capturing Ctrl+B here strands no
+// one. Everything is inert until a hardware Ctrl+B actually arrives, so
+// touch-only users see zero UI change. In scroll mode, unhandled keys
+// (printable or not) are swallowed and ignored so nothing leaks into the
+// inputs; q or Esc exits.
+const kbdModeChip = document.getElementById('kbd-mode-chip');
+const PREFIX_TIMEOUT_MS = 2000;
+let _prefixArmed = false;
+let _prefixTimer = null;
+let _scrollMode  = false;
+
+function _showKbdChip(text) {
+  kbdModeChip.textContent = text;
+  kbdModeChip.style.display = '';
+}
+function _hideKbdChip() { kbdModeChip.style.display = 'none'; }
+
+// The one definition of the prefix chord, used by every mode: unshifted
+// plain Ctrl+B (Ctrl+Shift+B is the browser's bookmarks-bar toggle). Four
+// call sites once drifted apart; keep them on this predicate.
+function isPrefixChord(e) {
+  return e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
+      && e.key.toLowerCase() === 'b';
+}
+
+function armPrefix() {
+  _prefixArmed = true;
+  clearTimeout(_prefixTimer);
+  _prefixTimer = setTimeout(disarmPrefix, PREFIX_TIMEOUT_MS);
+  _showKbdChip('C-b');
+}
+function disarmPrefix() {
+  _prefixArmed = false;
+  clearTimeout(_prefixTimer);
+  _prefixTimer = null;
+  _hideKbdChip();
+}
+
+// ── scroll mode (prefix+[) ── pure scrollTop manipulation of #output
+function enterScrollMode() {
+  _scrollMode = true;
+  // Move focus off the inputs so nothing types into them while scrolling.
+  const ae = document.activeElement;
+  if (ae && typeof ae.blur === 'function') ae.blur();
+  _showKbdChip('SCROLL');
+}
+function exitScrollMode() {
+  _scrollMode = false;
+  _hideKbdChip();
+  // Entry blurred the input, so q/Esc would strand focus on body and the
+  // next keystrokes would go nowhere. Scroll mode is only reachable via a
+  // hardware Ctrl+B, so refocusing cannot pop a soft keyboard.
+  activeInput().focus();
+}
+
+function handleScrollKey(e) {
+  // Bare modifier keydowns pass; the chord they start is judged on its own.
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+  const line = parseFloat(getComputedStyle(output).lineHeight) || 18;
+  const page = Math.max(line, output.clientHeight - line);
+  const half = Math.max(line, Math.round(output.clientHeight / 2));
+  let step = null;
+  if (!e.ctrlKey && !e.altKey && !e.metaKey) {
+    const k = e.key;
+    if (k === 'q' || k === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      exitScrollMode();
+      return;
+    }
+    if      (k === 'j' || k === 'ArrowDown') step = line;
+    else if (k === 'k' || k === 'ArrowUp')   step = -line;
+    else if (k === 'PageDown')               step = page;
+    else if (k === 'PageUp')                 step = -page;
+  } else if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
+    const k = e.key.toLowerCase();
+    if      (k === 'd') step = half;
+    else if (k === 'u') step = -half;
+    else if (isPrefixChord(e)) {
+      // Never let Ctrl+B reach the browser (Firefox opens the bookmarks
+      // sidebar): leave scroll mode and re-arm the prefix instead.
+      e.preventDefault();
+      e.stopPropagation();
+      exitScrollMode();
+      armPrefix();
+      return;
+    }
+    else return; // other Ctrl chords (reload, tab switch, ...) pass through
+  } else {
+    return; // Alt/Meta chords pass through
+  }
+  e.preventDefault();
+  e.stopPropagation();
+  if (step !== null) output.scrollTop += step;
+}
+
+// ── context picker keyboard navigation (prefix+w) ──────────────────────────
+function ctxPickerActive() {
+  return ctxOverlay.style.display !== 'none' && ctxRenameForm.style.display === 'none';
+}
+
+function pickerRows() {
+  return [...ctxList.querySelectorAll('.ctx-btn')];
+}
+
+function movePickerFocus(delta) {
+  const rows = pickerRows();
+  if (!rows.length) return;
+  const idx = rows.indexOf(document.activeElement);
+  const next = idx < 0
+    ? rows[delta > 0 ? 0 : rows.length - 1]
+    : rows[(idx + delta + rows.length) % rows.length];
+  next.focus();
+  next.scrollIntoView({ block: 'nearest' });
+}
+
+function openCtxPickerKeyboard() {
+  showCtxOverlay();
+  // Land on the last ctx-current row rather than the first: the first is the
+  // session row, so prefix+w then Enter would jump to the session's first
+  // live pane instead of staying put (the pane row's click handler is the
+  // real no-op). Fall back to the first row.
+  const rows = pickerRows();
+  const marked = rows.filter(b => b.classList.contains('ctx-current'));
+  const start = marked[marked.length - 1] || rows[0];
+  if (start) start.focus();
+}
+
+function handlePickerKey(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    e.stopPropagation();
+    hideCtxOverlay();
+    return;
+  }
+  const ae = document.activeElement;
+  const isField = ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA');
+  if (isPrefixChord(e)) {
+    // Never let Ctrl+B reach the browser (Firefox opens the bookmarks
+    // sidebar): close the picker and re-arm the prefix, with the same
+    // foreign-field exemption as the neutral-state capture below.
+    if (isField && ae !== cmdInput && ae !== pwdInput) return;
+    e.preventDefault();
+    e.stopPropagation();
+    hideCtxOverlay();
+    armPrefix();
+    return;
+  }
+  // With a text field focused (picker opened by tap while typing), only Esc
+  // acts; j/k keep typing and arrows keep moving the caret.
+  if (isField) return;
+  if (e.key === 'j' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    e.stopPropagation();
+    movePickerFocus(1);
+  } else if (e.key === 'k' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    e.stopPropagation();
+    movePickerFocus(-1);
+  }
+  // Enter falls through: the focused button's native activation fires its
+  // existing click handler.
+}
+
+// ── prefix key dispatch ─────────────────────────────────────────────────────
+function handlePrefixKey(e) {
+  // Bare modifier keydowns (Ctrl going down for a chord) keep the prefix armed.
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+  e.preventDefault();
+  e.stopPropagation();
+  if (isPrefixChord(e)) { armPrefix(); return; } // key repeat re-arms
+  disarmPrefix();
+  // Modified keys are unbound: Ctrl+W while armed must not open the picker.
+  const k = (e.ctrlKey || e.altKey || e.metaKey) ? '' : e.key;
+  if      (k === 'w') openCtxPickerKeyboard();
+  else if (k === 'n') navigateRelativeWindow(1);
+  else if (k === 'p') navigateRelativeWindow(-1);
+  else if (k === 'o') navigateRelativePane(1);
+  else if (k === 'O') navigateRelativePane(-1); // no tmux default for backward; mirrors o
+  // tmux binds prefix+arrows to directional pane selection; the PWA shows one
+  // pane at a time, so down/j means next and up/k means previous.
+  else if (k === 'ArrowDown' || k === 'j') navigateRelativePane(1);
+  else if (k === 'ArrowUp'   || k === 'k') navigateRelativePane(-1);
+  else if (k === '[') enterScrollMode();
+  // Esc and any unbound key: prefix cancelled, keystroke swallowed (tmux-like).
+}
+
+// Capture phase so the bindings run ahead of the input handlers; a handled
+// key calls preventDefault, which also stops the direct-mode input event
+// from ever firing (Ctrl+B itself produces no input event at all).
+document.addEventListener('keydown', e => {
+  // Same IME guard as the input handlers above.
+  if (e.isComposing || e.keyCode === 229) return;
+  if (_isLocked) return;
+
+  if (_scrollMode)       { handleScrollKey(e); return; }
+  if (ctxPickerActive()) { handlePickerKey(e); return; }
+  if (_prefixArmed)      { handlePrefixKey(e); return; }
+
+  if (isPrefixChord(e)) {
+    // Arm from anywhere except foreign text fields (pairing code, rename and
+    // create forms); cmdInput and pwdInput are where keyboard users live.
+    const ae = document.activeElement;
+    const isField = ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA');
+    if (isField && ae !== cmdInput && ae !== pwdInput) return;
+    e.preventDefault(); // Ctrl+B is bold/bookmark-ish in some browser contexts
+    e.stopPropagation();
+    armPrefix();
+  }
+}, true);
 
 // ── keyboard-aware viewport (visualViewport) ───────────────────────────────
 // iOS/Android don't resize the layout viewport when the on-screen keyboard

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -148,6 +148,12 @@
     .ctx-window-btn { padding-left: 28px; }
     .ctx-pane-btn { padding-left: 40px; font-size: 13px; }
     .ctx-btn.ctx-current { color: var(--accent); }
+    /* keyboard highlight for prefix+w navigation: real DOM focus moved from a
+       keydown handler matches :focus-visible, so touch taps stay outline-free */
+    .ctx-btn:focus-visible {
+      outline: 2px solid var(--accent); outline-offset: -2px;
+      background: var(--bg3);
+    }
 
     .icon-btn {
       background: var(--bg3); color: var(--text);
@@ -230,6 +236,16 @@
       border-bottom: 1px solid var(--border); flex-shrink: 0;
     }
     #btn-create { margin-left: auto; }
+
+    /* ── hardware-keyboard mode chip (prefix armed / scroll mode) ──
+       hidden until a hardware Ctrl+B arrives, so touch-only users never see it */
+    #kbd-mode-chip {
+      display: inline-block; padding: 1px 7px; border-radius: 8px;
+      /* var(--bg), not #fff: white on the dark accent is 2.91:1; the page
+         background clears 7:1 on the accent in both themes */
+      background: var(--accent); color: var(--bg);
+      font-size: 10px; letter-spacing: 0.05em; flex-shrink: 0;
+    }
 
     /* ── output area ── */
     #output {
@@ -603,6 +619,7 @@
 
   <div id="statusbar">
     <span id="ctx-name"></span>
+    <span id="kbd-mode-chip" style="display:none"></span>
     <button class="icon-btn" id="btn-create" title="New pane / window / session">+</button>
     <button class="icon-btn" id="btn-prev" title="Previous pane">‹</button>
     <span id="xyz-label" title="Tap for next pane in this window">-/-</span>

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -63,13 +63,31 @@
       overflow: hidden; white-space: nowrap; flex-shrink: 1; min-width: 0;
     }
     #ctx-name {
-      max-width: 48vw; overflow: hidden;
-      text-overflow: ellipsis; white-space: nowrap;
+      display: flex; align-items: center;
+      max-width: 48vw; white-space: nowrap;
       color: var(--accent); font-size: 11px;
       letter-spacing: 0.03em; padding: 0 4px;
       cursor: pointer; user-select: none; flex-shrink: 0;
     }
-    #ctx-name:active { opacity: 0.7; }
+    /* breadcrumb segments: each ellipsizes on its own; flex-shrink ratios
+       make the pane shrink fastest (all three shrink at once, so this only
+       approximates the old end-of-string truncation). Vertical padding
+       pulled back with a negative margin grows the touch target above the
+       bar without growing it; #ctx-name must not clip (overflow: hidden
+       also clips hit testing). The band below loses to #output's opaque
+       background in hit testing; the band above overlaps the bottom edge of
+       whatever precedes the statusbar and wins there, shaving those targets
+       slightly. min-width floors each segment so a long sibling cannot
+       shrink its tap target away. */
+    .ctx-seg {
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      min-width: 1.5em; padding: 10px 2px; margin: -10px 0;
+    }
+    .ctx-seg:active { opacity: 0.7; }
+    .ctx-seg-session { flex-shrink: 1; }
+    .ctx-seg-window  { flex-shrink: 2; }
+    .ctx-seg-pane    { flex-shrink: 4; }
+    .ctx-seg-sep { flex-shrink: 0; padding: 0 3px; opacity: 0.65; }
     #xyz-label {
       min-width: 86px; text-align: center; flex-shrink: 0;
       color: var(--text); font-size: 11px; letter-spacing: 0.03em;
@@ -142,11 +160,14 @@
                        font-family: var(--font); text-align: center; }
 
     /* ── context jump list (tap context name in header) ── */
-    /* capped + scrollable so a long session/window/pane tree doesn't push the
+    /* capped + scrollable so a long window/pane list doesn't push the
        Rename/Cancel buttons off-screen or grow the box past the viewport */
     #ctx-list { max-height: 58vh; overflow-y: auto; }
-    .ctx-window-btn { padding-left: 28px; }
-    .ctx-pane-btn { padding-left: 40px; font-size: 13px; }
+    /* level title of the drill-down picker: which session/window is open */
+    .ctx-title {
+      padding: 10px 16px 2px; color: var(--text); font-size: 11px;
+      letter-spacing: 0.08em; text-transform: uppercase; font-family: var(--font);
+    }
     .ctx-btn.ctx-current { color: var(--accent); }
     /* keyboard highlight for prefix+w navigation: real DOM focus moved from a
        keydown handler matches :focus-visible, so touch taps stay outline-free */


### PR DESCRIPTION
Closes #139.

Depends on #138: this branch stacks on the keyboard-bindings branch
because the picker's keyboard layer extends that prefix machinery. The
reviewable delta is the last commit; once #138 merges, this rebases to
a single commit.

## What

- The context picker becomes a three-level drill-down: sessions, the
  chosen session's windows, the chosen window's panes. Session and
  window rows descend; only pane rows navigate. Deeper levels get a
  back row and a level title, Rename/Cancel work at every level, and
  the picker opens at the current session's windows level (each open
  resets to that depth).
- The header breadcrumb is now three tappable segments (per-segment
  ellipsis, pane shrinking fastest, enlarged tap bands with a minimum
  width). Each segment opens the picker at its level; the session
  segment is the dedicated session selector. A tap between segments
  keeps the windows default.
- An open picker tracks topology: sessions updates re-render it in
  place, so rows for a just-died window cannot navigate to a dead pane,
  and a removed window or session falls back a level. Refocus happens
  only if a picker row had focus, so touch users mid-scroll keep their
  place.
- Keyboard: prefix s opens at sessions, prefix w at windows; j/k and
  arrows move via real DOM focus, Enter descends on session/window rows
  and navigates on pane rows, Esc walks up one level and closes only
  from the top, q closes outright from any depth, h goes back, l or
  right-arrow descends (descend-only). Opening the picker exits scroll
  mode so its keyboard is never dead under the overlay.

## Why

The flat indented tree (from #130) made the hierarchy visible but
became one giant scroll at real-world scale, and its session/window
rows navigated on tap, which was easy to trigger by accident. The
drill-down keeps the common jump at two taps while making every level
directly reachable.

## Notes for reviewers

- Enter on a session row descends rather than switching sessions
  directly (tmux choose-session switches); descend keeps drill-down
  semantics consistent. Easy to revisit if users expect tmux's
  behavior.
- Merge note: overlaps with open PRs #134 and #136 only at file-region
  boundaries; whichever lands later resolves small conflicts.
- Tested on-device and in a desktop browser: touch drill and back at
  all levels, breadcrumb segment taps, prefix s and w, rename from a
  deep level, live re-render when the viewed window dies, keyboard
  chains. JS is syntax-checked (node --check); the repo has no JS test
  harness.