### PR TITLE
fix(trustmux): keep join flag on resubscribe

### DIFF
--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -1669,7 +1669,10 @@ function applyTheme() {
 function rerenderTerminal() {
   _paneCache.clear();
   if (currentPane) {
-    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true });
+    // join must ride every resubscribe: without it the daemon captures this
+    // pane unjoined, and with wrap on the re-render hard-breaks long lines
+    // at the tmux pane width until the next pane switch.
+    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
   }
 }
 


### PR DESCRIPTION
Closes #144.

One line: rerenderTerminal's resubscribe now carries `join: wrapOn`, matching the pane-switch and wrap-toggle subscribe paths.

Without it the daemon captures the pane unjoined after a theme switch, so with wrap on (#134), long lines re-render hard-broken at the tmux pane width (mid-word at 160-column boundaries) until the next pane switch. Only lines longer than the tmux pane width are affected, which is why it slipped through: the flag was dropped when the display-settings branch (#136) was rebased onto a pre-wrap master, and the merges never conflicted on this line.

Reproduced and verified end to end on trustmux-v7.18rc4 (Android PWA): repro steps in #144; with this fix the wrapped paragraph stays continuous through theme switches. Worth picking into the 7.18 release branch since rc4 ships the bug.
