### PR TITLE
trustmux: interactive latency (event-driven stream, predictive echo)

### DIFF
--- a/mobile/tests/conftest.py
+++ b/mobile/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Isolate the suite from the developer's real trustmux state.
+
+test_ctl exercises Instance directories, pid files and the legacy-layout
+cleanup against whatever the path helpers resolve; without isolation a
+suite run rmtrees the real ~/.local/state/trustmux, taking the live
+daemon's socket, log and pairing tokens with it. Point every base the
+helpers consult at a per-run temp dir before any test module imports the
+package (module-level so it precedes collection-time imports; the daemon
+module snapshots Instance() at import). test_paths overrides these vars
+itself where the resolution order is the thing under test.
+"""
+import os
+import tempfile
+
+_tmp = tempfile.mkdtemp(prefix="trustmux-tests-")
+for _var in ("XDG_STATE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME"):
+    os.environ[_var] = os.path.join(_tmp, _var.lower())

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -573,13 +573,104 @@ class _StreamPaneHarness(unittest.TestCase):
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
             return result
+        async def no_session(pane_id):
+            # Keep the stream on the subprocess fallback: a live control
+            # client would capture the developer's real tmux instead of the
+            # fakes patched below.
+            return None
         with patch.object(bm, 'tmux_capture_pane', side_effect=fake_capture), \
              patch.object(bm, 'tmux_cursor',
                           side_effect=fake_cursor or (lambda pane_id: None)), \
+             patch.object(bm._MONITOR, 'ensure', new=no_session), \
              patch.object(bm, '_POLL_IDLE', 60.0), \
              patch.object(bm, '_POLL_ACTIVE', 60.0), \
              patch.object(bm, '_KEYSTROKE_SETTLE', settle):
             return asyncio.run(main())
+
+
+class TestControlClient(unittest.TestCase):
+    """Reply-block parsing and %output wake dispatch of _ControlClient,
+    driven through a fake proc whose stdout is a plain StreamReader."""
+
+    def _fake_client(self):
+        client = bm._ControlClient('$9')
+        reader = asyncio.StreamReader()
+        client.proc = SimpleNamespace(stdout=reader, returncode=None,
+                                      terminate=lambda: None)
+        return client, reader
+
+    def test_reply_pairing_wake_error_and_eof(self):
+        async def main():
+            client, reader = self._fake_client()
+            loop = asyncio.get_event_loop()
+            first, second, third = (loop.create_future() for _ in range(3))
+            client._pending.extend([first, second, third])
+            woke = asyncio.Event()
+            bm._MONITOR.watch('%9', woke)
+            try:
+                task = asyncio.ensure_future(client._read_loop())
+                # Reply 1: an %end with mismatched ids is content, the
+                # matching one closes the block.
+                reader.feed_data(b'%begin 100 7 1\n'
+                                 b'alpha\n'
+                                 b'%end 999 8 1\n'
+                                 b'%end 100 7 1\n')
+                # A notification between blocks wakes the pane watcher.
+                reader.feed_data(b'%output %9 abc\n')
+                # Reply 2: %error resolves to "".
+                reader.feed_data(b'%begin 101 8 1\n'
+                                 b'no such pane\n'
+                                 b'%error 101 8 1\n')
+                self.assertEqual(await first, 'alpha\n%end 999 8 1\n')
+                self.assertEqual(await second, '')
+                await asyncio.wait_for(woke.wait(), 1)
+                # EOF: the leftover pending future resolves to None and the
+                # client reports itself gone.
+                reader.feed_eof()
+                self.assertIsNone(await third)
+                await task
+                self.assertFalse(client.alive)
+            finally:
+                bm._MONITOR.unwatch('%9', woke)
+        asyncio.run(main())
+
+    def test_wrong_pane_output_does_not_wake(self):
+        async def main():
+            client, reader = self._fake_client()
+            woke = asyncio.Event()
+            bm._MONITOR.watch('%9', woke)
+            try:
+                task = asyncio.ensure_future(client._read_loop())
+                reader.feed_data(b'%output %8 abc\n')
+                reader.feed_eof()
+                await task
+                self.assertFalse(woke.is_set())
+            finally:
+                bm._MONITOR.unwatch('%9', woke)
+        asyncio.run(main())
+
+    def test_cm_capture_falls_back_to_subprocess(self):
+        async def main():
+            async def no_client(session_id, cmd):
+                return None
+            with patch.object(bm._MONITOR, 'run', new=no_client), \
+                 patch.object(bm, 'tmux_capture_pane',
+                              return_value='fallback') as sub:
+                out = await bm.cm_capture_pane('$1', '%0', 100, False, False)
+            self.assertEqual(out, 'fallback')
+            sub.assert_called_once_with('%0', 100, False, False)
+        asyncio.run(main())
+
+    def test_cm_capture_strips_ansi_like_subprocess_path(self):
+        async def main():
+            async def reply(session_id, cmd):
+                return '\x1b[31mred\x1b[0m\n'
+            with patch.object(bm._MONITOR, 'run', new=reply):
+                plain = await bm.cm_capture_pane('$1', '%0', 100, False, False)
+                ansi = await bm.cm_capture_pane('$1', '%0', 100, True, False)
+            self.assertEqual(plain, 'red\n')
+            self.assertEqual(ansi, '\x1b[31mred\x1b[0m\n')
+        asyncio.run(main())
 
 
 class TestStreamPaneWake(_StreamPaneHarness):

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -500,16 +500,16 @@ class TestTmuxCursor(unittest.TestCase):
     def test_maps_cursor_y_to_from_end_index(self):
         # Cursor on row 2 of a 10-row pane: 7 lines above the capture's last
         # line (a piped capture keeps trailing blank screen rows).
-        with patch.object(bm, '_tmux', return_value='47\t2\t10\n'):
+        with patch.object(bm, '_tmux', return_value='47 2 10 80\n'):
             self.assertEqual(bm.tmux_cursor('%0'),
                              {'cursor_x': 47, 'cursor_from_end': 7})
 
     def test_bottom_row_maps_to_zero(self):
-        with patch.object(bm, '_tmux', return_value='0\t9\t10\n'):
+        with patch.object(bm, '_tmux', return_value='0 9 10 80\n'):
             self.assertEqual(bm.tmux_cursor('%0')['cursor_from_end'], 0)
 
     def test_malformed_output_returns_none(self):
-        for raw in ('', 'garbage', '1\t2', 'a\tb\tc', '0\t10\t10'):
+        for raw in ('', 'garbage', '1 2', 'a b c d', '0 10 10 80', '1 2 10'):
             with patch.object(bm, '_tmux', return_value=raw):
                 self.assertIsNone(bm.tmux_cursor('%0'), raw)
 
@@ -563,7 +563,7 @@ class _StreamPaneHarness(unittest.TestCase):
         return conn
 
     def _run_stream(self, conn, fake_capture, driver, settle, fake_cursor=None,
-                    join=False, patch_mode=False):
+                    join=False, patch_mode=False, cursor_fields=''):
         async def main():
             task = asyncio.ensure_future(
                 bm.WsHandler._stream_pane(conn, '%0', 100, False, join,
@@ -581,11 +581,48 @@ class _StreamPaneHarness(unittest.TestCase):
         with patch.object(bm, 'tmux_capture_pane', side_effect=fake_capture), \
              patch.object(bm, 'tmux_cursor',
                           side_effect=fake_cursor or (lambda pane_id: None)), \
+             patch.object(bm, '_cursor_fields', return_value=cursor_fields), \
              patch.object(bm._MONITOR, 'ensure', new=no_session), \
              patch.object(bm, '_POLL_IDLE', 60.0), \
              patch.object(bm, '_POLL_ACTIVE', 60.0), \
              patch.object(bm, '_KEYSTROKE_SETTLE', settle):
             return asyncio.run(main())
+
+
+class TestJoinCursor(unittest.TestCase):
+    """_join_cursor maps a screen cursor into joined (-J) capture
+    coordinates: line index from the end plus an offset into the joined
+    line."""
+
+    def test_prompt_with_blank_rows_below(self):
+        # 3 screen rows: prompt row, two blank rows; cursor at column 8.
+        c = bm._join_cursor('prompt$ \n\n\n', 8, 0, 3, 80)
+        self.assertEqual(c, {'cursor_x': 8, 'cursor_from_end': 2})
+
+    def test_soft_wrapped_line_second_row(self):
+        # A 15-cell line at width 10 occupies 2 rows; cursor on its second
+        # row at column 5 is offset 15 into the joined line.
+        c = bm._join_cursor('abcdefghijklmno\n\n\n', 5, 1, 4, 10)
+        self.assertEqual(c, {'cursor_x': 15, 'cursor_from_end': 2})
+
+    def test_tui_cursor_mid_screen(self):
+        content = 'top\ninput> \n--border--\nstatus\n'
+        c = bm._join_cursor(content, 7, 1, 4, 80)
+        self.assertEqual(c, {'cursor_x': 7, 'cursor_from_end': 2})
+
+    def test_ansi_escapes_do_not_inflate_widths(self):
+        # The styled prompt is 8 visible cells; escapes must not add rows.
+        content = '\x1b[1;32mprompt$\x1b[0m \n\n\n'
+        c = bm._join_cursor(content, 8, 0, 3, 80)
+        self.assertEqual(c, {'cursor_x': 8, 'cursor_from_end': 2})
+
+    def test_unusable_geometry_returns_none(self):
+        self.assertIsNone(bm._join_cursor('x\n', 0, 0, 2, 0))   # width 0
+        self.assertIsNone(bm._join_cursor('x\n', 0, 5, 3, 80))  # y >= height
+
+    def test_capture_shorter_than_screen_returns_none(self):
+        # Cursor row lies above every captured line: no mapping.
+        self.assertIsNone(bm._join_cursor('only\n', 0, 0, 10, 80))
 
 
 class TestEnterSettle(unittest.TestCase):
@@ -866,14 +903,14 @@ class TestStreamPaneWake(_StreamPaneHarness):
         self.assertEqual(conn.sent[1], {'type': 'cursor', 'pane_id': '%0'})
         self.assertEqual(len(cursor_calls), 3)
 
-    def test_join_subscribers_get_no_cursor(self):
-        # A -J (wrap) capture merges soft-wrapped lines, so the from-the-end
-        # mapping is unusable and the client falls back anyway; the daemon
-        # never even reads the cursor.
+    def test_join_subscribers_get_a_mapped_cursor(self):
+        # A -J (wrap) capture merges soft-wrapped lines, so the daemon skips
+        # tmux_cursor and sends a joined-coordinate mapping computed by
+        # _join_cursor from the raw cursor fields instead.
         conn = self._make_conn()
         cursor_calls = []
         def fake_capture(pane_id, lines, ansi, join):
-            return 'content'
+            return 'prompt$ \n\n\n'
         def fake_cursor(pane_id):
             cursor_calls.append(None)
             return {'cursor_x': 0, 'cursor_from_end': 0}
@@ -882,10 +919,14 @@ class TestStreamPaneWake(_StreamPaneHarness):
             conn._stream_wake.set()
             await asyncio.sleep(0.1)
 
+        # x=8 y=0 height=3 width=80: cursor on the prompt row, two blank
+        # rows below it.
         self._run_stream(conn, fake_capture, driver, settle=0.01,
-                         fake_cursor=fake_cursor, join=True)
-        self.assertEqual(cursor_calls, [])
-        self.assertNotIn('cursor_from_end', conn.sent[0])
+                         fake_cursor=fake_cursor, join=True,
+                         cursor_fields='8 0 3 80')
+        self.assertEqual(cursor_calls, [])   # tmux_cursor stays unused
+        self.assertEqual(conn.sent[0]['cursor_from_end'], 2)
+        self.assertEqual(conn.sent[0]['cursor_x'], 8)
 
     def test_cursor_beyond_capture_is_dropped_in_stream(self):
         # A trimming tmux (fewer capture lines than cursor_from_end + 1

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -493,6 +493,59 @@ class TestCapturePaneJoinFlag(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# tmux_cursor: cursor position mapped to a from-the-end capture line index
+# ---------------------------------------------------------------------------
+
+class TestTmuxCursor(unittest.TestCase):
+    def test_maps_cursor_y_to_from_end_index(self):
+        # Cursor on row 2 of a 10-row pane: 7 lines above the capture's last
+        # line (a piped capture keeps trailing blank screen rows).
+        with patch.object(bm, '_tmux', return_value='47\t2\t10\n'):
+            self.assertEqual(bm.tmux_cursor('%0'),
+                             {'cursor_x': 47, 'cursor_from_end': 7})
+
+    def test_bottom_row_maps_to_zero(self):
+        with patch.object(bm, '_tmux', return_value='0\t9\t10\n'):
+            self.assertEqual(bm.tmux_cursor('%0')['cursor_from_end'], 0)
+
+    def test_malformed_output_returns_none(self):
+        for raw in ('', 'garbage', '1\t2', 'a\tb\tc', '0\t10\t10'):
+            with patch.object(bm, '_tmux', return_value=raw):
+                self.assertIsNone(bm.tmux_cursor('%0'), raw)
+
+
+# ---------------------------------------------------------------------------
+# _clamp_cursor: defense against a tmux that trims trailing blank rows
+# ---------------------------------------------------------------------------
+
+class TestClampCursor(unittest.TestCase):
+    def test_cursor_within_capture_passes(self):
+        cursor = {'cursor_x': 0, 'cursor_from_end': 2}
+        self.assertEqual(bm._clamp_cursor(cursor, 'a\nb\nc'), cursor)
+
+    def test_trailing_newline_closes_the_last_line(self):
+        # 'a\nb\nc\n' is three lines, not four: from_end 2 is the first line.
+        cursor = {'cursor_x': 0, 'cursor_from_end': 2}
+        self.assertEqual(bm._clamp_cursor(cursor, 'a\nb\nc\n'), cursor)
+        self.assertIsNone(
+            bm._clamp_cursor({'cursor_x': 0, 'cursor_from_end': 3}, 'a\nb\nc\n'))
+
+    def test_cursor_beyond_capture_drops(self):
+        # A tmux that trims trailing blank screen rows would leave the
+        # from-the-end index pointing into scrollback; drop the fields so
+        # the client keeps its end-of-buffer anchor.
+        self.assertIsNone(
+            bm._clamp_cursor({'cursor_x': 0, 'cursor_from_end': 5}, 'a\nb'))
+
+    def test_empty_capture_drops(self):
+        self.assertIsNone(
+            bm._clamp_cursor({'cursor_x': 0, 'cursor_from_end': 0}, ''))
+
+    def test_none_stays_none(self):
+        self.assertIsNone(bm._clamp_cursor(None, 'a\nb'))
+
+
+# ---------------------------------------------------------------------------
 # Pane stream: keystroke wake and burst coalescing
 # ---------------------------------------------------------------------------
 
@@ -509,16 +562,19 @@ class TestStreamPaneWake(unittest.TestCase):
         conn._send = conn.sent.append
         return conn
 
-    def _run_stream(self, conn, fake_capture, driver, settle):
+    def _run_stream(self, conn, fake_capture, driver, settle, fake_cursor=None,
+                    join=False):
         async def main():
             task = asyncio.ensure_future(
-                bm.WsHandler._stream_pane(conn, '%0', 100))
+                bm.WsHandler._stream_pane(conn, '%0', 100, False, join))
             await asyncio.sleep(0.05)  # let the initial snapshot land
             result = await driver()
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
             return result
         with patch.object(bm, 'tmux_capture_pane', side_effect=fake_capture), \
+             patch.object(bm, 'tmux_cursor',
+                          side_effect=fake_cursor or (lambda pane_id: None)), \
              patch.object(bm, '_POLL_IDLE', 60.0), \
              patch.object(bm, '_POLL_ACTIVE', 60.0), \
              patch.object(bm, '_KEYSTROKE_SETTLE', settle):
@@ -579,6 +635,155 @@ class TestStreamPaneWake(unittest.TestCase):
         # Only the snapshot: the no-change suppression still holds on wakes.
         self.assertEqual(len(conn.sent), 1)
         self.assertEqual(conn.sent[0]['type'], 'snapshot')
+
+    def test_cursor_fields_ride_snapshot_and_update(self):
+        conn = self._make_conn()
+        captures = []
+        def fake_capture(pane_id, lines, ansi, join):
+            captures.append(None)
+            return f'a\nb\nc\nd\ncontent-{len(captures)}'
+        def fake_cursor(pane_id):
+            return {'cursor_x': 5, 'cursor_from_end': 3}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor)
+        # A content change keeps the combined message: cursor fields ride
+        # the full snapshot/update, never a separate cursor message.
+        self.assertEqual([m['type'] for m in conn.sent],
+                         ['snapshot', 'update'])
+        for msg in conn.sent:
+            self.assertEqual(msg['cursor_x'], 5)
+            self.assertEqual(msg['cursor_from_end'], 3)
+
+    def test_no_cursor_omits_the_fields(self):
+        conn = self._make_conn()
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'content'
+
+        async def driver():
+            return None
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01)
+        self.assertEqual(conn.sent[0]['type'], 'snapshot')
+        self.assertNotIn('cursor_x', conn.sent[0])
+        self.assertNotIn('cursor_from_end', conn.sent[0])
+
+    def test_cursor_move_alone_sends_a_cursor_message(self):
+        # vi h/j/k/l moves the cursor without changing content; the client's
+        # ghost anchor must follow without resending the unchanged capture,
+        # so the daemon emits a data-less cursor message.
+        conn = self._make_conn()
+        cursors = []
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'l1\nl2\nl3\nsame'
+        def fake_cursor(pane_id):
+            cursors.append(None)
+            return {'cursor_x': 0, 'cursor_from_end': len(cursors)}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor)
+        self.assertEqual(len(conn.sent), 2)
+        self.assertEqual(conn.sent[1]['type'], 'cursor')
+        self.assertEqual(conn.sent[1]['pane_id'], '%0')
+        self.assertNotIn('data', conn.sent[1])
+        self.assertEqual(conn.sent[1]['cursor_from_end'], 2)
+
+    def test_unchanged_content_and_cursor_send_nothing(self):
+        conn = self._make_conn()
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'l1\nsame'
+        def fake_cursor(pane_id):
+            return {'cursor_x': 0, 'cursor_from_end': 1}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor)
+        # Only the snapshot: no-change suppression covers the cursor too.
+        self.assertEqual(len(conn.sent), 1)
+
+    def test_cursor_going_unreadable_sends_one_fieldless_message(self):
+        # The cursor read can start failing mid-stream (tmux hiccup): the
+        # client must revert to its end-of-buffer anchor, so the daemon sends
+        # one cursor message with the fields absent, then stays quiet while
+        # the cursor remains unreadable.
+        conn = self._make_conn()
+        cursor_calls = []
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'l1\nl2\nsame'
+        def fake_cursor(pane_id):
+            cursor_calls.append(None)
+            if len(cursor_calls) == 1:
+                return {'cursor_x': 0, 'cursor_from_end': 1}
+            return None
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor)
+        # Snapshot with cursor fields, then exactly one field-less cursor
+        # message; the second wake repeats nothing (last_cursor advanced).
+        self.assertEqual(len(conn.sent), 2)
+        self.assertEqual(conn.sent[0]['type'], 'snapshot')
+        self.assertEqual(conn.sent[0]['cursor_from_end'], 1)
+        self.assertEqual(conn.sent[1], {'type': 'cursor', 'pane_id': '%0'})
+        self.assertEqual(len(cursor_calls), 3)
+
+    def test_join_subscribers_get_no_cursor(self):
+        # A -J (wrap) capture merges soft-wrapped lines, so the from-the-end
+        # mapping is unusable and the client falls back anyway; the daemon
+        # never even reads the cursor.
+        conn = self._make_conn()
+        cursor_calls = []
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'content'
+        def fake_cursor(pane_id):
+            cursor_calls.append(None)
+            return {'cursor_x': 0, 'cursor_from_end': 0}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor, join=True)
+        self.assertEqual(cursor_calls, [])
+        self.assertNotIn('cursor_from_end', conn.sent[0])
+
+    def test_cursor_beyond_capture_is_dropped_in_stream(self):
+        # A trimming tmux (fewer capture lines than cursor_from_end + 1
+        # implies) degrades to the client's end-of-buffer anchor: the
+        # fields are dropped and no cursor message fires.
+        conn = self._make_conn()
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'one\ntwo'
+        def fake_cursor(pane_id):
+            return {'cursor_x': 0, 'cursor_from_end': 5}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor)
+        self.assertEqual(len(conn.sent), 1)
+        self.assertEqual(conn.sent[0]['type'], 'snapshot')
+        self.assertNotIn('cursor_x', conn.sent[0])
+        self.assertNotIn('cursor_from_end', conn.sent[0])
 
 
 # ---------------------------------------------------------------------------

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -1,5 +1,6 @@
 """Tests for Trustmux daemon — runs locally with stdlib unittest + tornado."""
 
+import asyncio
 import json
 import os
 import sys
@@ -7,6 +8,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -488,6 +490,95 @@ class TestCapturePaneJoinFlag(unittest.TestCase):
         with patch.object(bm, '_tmux', side_effect=fake_tmux):
             bm.tmux_capture_pane('%0')
         self.assertNotIn('-J', captured_args)
+
+
+# ---------------------------------------------------------------------------
+# Pane stream: keystroke wake and burst coalescing
+# ---------------------------------------------------------------------------
+
+class TestStreamPaneWake(unittest.TestCase):
+    """_stream_pane runs against a bare connection stand-in: it only touches
+    _send, _stream_wake, and _last_input_mono, plus module globals patched
+    here. Poll intervals are patched huge so only explicit wakes capture."""
+
+    def _make_conn(self):
+        conn = SimpleNamespace()
+        conn._stream_wake = asyncio.Event()
+        conn._last_input_mono = 0.0
+        conn.sent = []
+        conn._send = conn.sent.append
+        return conn
+
+    def _run_stream(self, conn, fake_capture, driver, settle):
+        async def main():
+            task = asyncio.ensure_future(
+                bm.WsHandler._stream_pane(conn, '%0', 100))
+            await asyncio.sleep(0.05)  # let the initial snapshot land
+            result = await driver()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            return result
+        with patch.object(bm, 'tmux_capture_pane', side_effect=fake_capture), \
+             patch.object(bm, '_POLL_IDLE', 60.0), \
+             patch.object(bm, '_POLL_ACTIVE', 60.0), \
+             patch.object(bm, '_KEYSTROKE_SETTLE', settle):
+            return asyncio.run(main())
+
+    def test_send_keys_wake_captures_before_poll_tick(self):
+        conn = self._make_conn()
+        captures = []
+        def fake_capture(pane_id, lines, ansi, join):
+            captures.append(time.monotonic())
+            return f'content-{len(captures)}'
+
+        async def driver():
+            woke = time.monotonic()
+            conn._last_input_mono = woke
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+            return woke
+
+        woke = self._run_stream(conn, fake_capture, driver, settle=0.01)
+        # Snapshot plus exactly one wake-triggered capture, far inside the
+        # 60s patched tick.
+        self.assertEqual(len(captures), 2)
+        self.assertLess(captures[1] - woke, 0.1)
+        self.assertEqual(conn.sent[0]['type'], 'snapshot')
+        self.assertEqual(conn.sent[1]['type'], 'update')
+        self.assertEqual(conn.sent[1]['data'], 'content-2')
+
+    def test_keystroke_burst_coalesces_into_one_capture(self):
+        conn = self._make_conn()
+        captures = []
+        def fake_capture(pane_id, lines, ansi, join):
+            captures.append(time.monotonic())
+            return f'content-{len(captures)}'
+
+        async def driver():
+            # Three keystrokes inside one settle window (0.06s).
+            for _ in range(3):
+                conn._last_input_mono = time.monotonic()
+                conn._stream_wake.set()
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.15)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.06)
+        # Snapshot plus one coalesced capture, not one per keystroke.
+        self.assertEqual(len(captures), 2)
+
+    def test_unchanged_content_sends_no_update_on_wake(self):
+        conn = self._make_conn()
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'same'
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01)
+        # Only the snapshot: the no-change suppression still holds on wakes.
+        self.assertEqual(len(conn.sent), 1)
+        self.assertEqual(conn.sent[0]['type'], 'snapshot')
 
 
 # ---------------------------------------------------------------------------

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -549,7 +549,7 @@ class TestClampCursor(unittest.TestCase):
 # Pane stream: keystroke wake and burst coalescing
 # ---------------------------------------------------------------------------
 
-class TestStreamPaneWake(unittest.TestCase):
+class _StreamPaneHarness(unittest.TestCase):
     """_stream_pane runs against a bare connection stand-in: it only touches
     _send, _stream_wake, and _last_input_mono, plus module globals patched
     here. Poll intervals are patched huge so only explicit wakes capture."""
@@ -563,10 +563,11 @@ class TestStreamPaneWake(unittest.TestCase):
         return conn
 
     def _run_stream(self, conn, fake_capture, driver, settle, fake_cursor=None,
-                    join=False):
+                    join=False, patch_mode=False):
         async def main():
             task = asyncio.ensure_future(
-                bm.WsHandler._stream_pane(conn, '%0', 100, False, join))
+                bm.WsHandler._stream_pane(conn, '%0', 100, False, join,
+                                          patch_mode))
             await asyncio.sleep(0.05)  # let the initial snapshot land
             result = await driver()
             task.cancel()
@@ -580,6 +581,8 @@ class TestStreamPaneWake(unittest.TestCase):
              patch.object(bm, '_KEYSTROKE_SETTLE', settle):
             return asyncio.run(main())
 
+
+class TestStreamPaneWake(_StreamPaneHarness):
     def test_send_keys_wake_captures_before_poll_tick(self):
         conn = self._make_conn()
         captures = []
@@ -784,6 +787,208 @@ class TestStreamPaneWake(unittest.TestCase):
         self.assertEqual(conn.sent[0]['type'], 'snapshot')
         self.assertNotIn('cursor_x', conn.sent[0])
         self.assertNotIn('cursor_from_end', conn.sent[0])
+
+
+# ---------------------------------------------------------------------------
+# _diff_line_ops: line-wise diff for patch subscribers
+# ---------------------------------------------------------------------------
+
+def _apply_ops(old, ops):
+    """Reference client: apply ops in reverse so old-array indices stay valid."""
+    new = list(old)
+    for op in reversed(ops):
+        new[op['start']:op['end']] = op.get('lines', [])
+    return new
+
+
+class TestDiffLineOps(unittest.TestCase):
+    def test_equal_lists_yield_no_ops(self):
+        self.assertEqual(bm._diff_line_ops(['a', 'b', ''], ['a', 'b', '']), [])
+
+    def test_appended_line_is_one_insert(self):
+        old = ['$ ls', '']
+        new = ['$ ls', 'a.txt', '']
+        ops = bm._diff_line_ops(old, new)
+        # difflib anchors the insert before the trailing '' rather than
+        # after it; both encodings rebuild the same list.
+        self.assertEqual(ops, [{'op': 'insert', 'start': 1, 'end': 1,
+                                'lines': ['a.txt']}])
+        self.assertEqual(_apply_ops(old, ops), new)
+
+    def test_blank_line_appended_after_tail_is_an_insert_at_old_length(self):
+        # When the old trailing '' is absorbed into a longer equal block,
+        # difflib anchors the insert after the old tail (start == end ==
+        # len(old)). The client's applyPatch must then re-render the old
+        # tail span with its newline: it stays mid-buffer otherwise.
+        old = ['a', '']
+        new = ['a', '', 'x', '']
+        ops = bm._diff_line_ops(old, new)
+        self.assertEqual(ops, [{'op': 'insert', 'start': 2, 'end': 2,
+                                'lines': ['x', '']}])
+        self.assertEqual(_apply_ops(old, ops), new)
+
+    def test_replaced_line_carries_no_neighbors(self):
+        old = ['a', 'b', 'c', '']
+        new = ['a', 'B', 'c', '']
+        ops = bm._diff_line_ops(old, new)
+        self.assertEqual(ops, [{'op': 'replace', 'start': 1, 'end': 2,
+                                'lines': ['B']}])
+        self.assertEqual(_apply_ops(old, ops), new)
+
+    def test_delete_op_has_no_lines(self):
+        old = ['a', 'b', 'c', '']
+        new = ['a', 'c', '']
+        ops = bm._diff_line_ops(old, new)
+        self.assertEqual(ops, [{'op': 'delete', 'start': 1, 'end': 2}])
+        self.assertEqual(_apply_ops(old, ops), new)
+
+    def test_scroll_is_a_delete_plus_insert_not_a_rewrite(self):
+        # The steady-state case at full history: one line appended, every
+        # line shifts up. The diff must ride the offset equal block, not
+        # replace the whole buffer.
+        old = [f'line-{i}' for i in range(50)] + ['']
+        new = [f'line-{i}' for i in range(1, 51)] + ['']
+        ops = bm._diff_line_ops(old, new)
+        self.assertEqual(_apply_ops(old, ops), new)
+        patched = sum(len(l) for op in ops for l in op.get('lines', []))
+        self.assertLess(patched, len('\n'.join(new)) // 4)
+
+    def test_repeated_blank_lines_do_not_degrade_the_diff(self):
+        # Blank lines repeat far past SequenceMatcher's autojunk threshold;
+        # with autojunk on they never match and a scroll turns into a
+        # whole-buffer replace.
+        old = [s for i in range(120) for s in (f'line-{i}', '')] + ['']
+        new = old[2:-1] + ['line-120', '', '']
+        ops = bm._diff_line_ops(old, new)
+        self.assertEqual(_apply_ops(old, ops), new)
+        patched = sum(len(l) for op in ops for l in op.get('lines', []))
+        self.assertLess(patched, len('\n'.join(new)) // 4)
+
+
+# ---------------------------------------------------------------------------
+# Pane stream: patch opt-in (line-diff updates)
+# ---------------------------------------------------------------------------
+
+def _longline(i):
+    # Realistic capture-line lengths: the fallback threshold compares the
+    # encoded ops (which carry fixed per-op overhead) against the encoded
+    # content, so toy two-character lines would always fall back to a full
+    # update.
+    return f'line-{i}-' + 'x' * 40
+
+
+class TestStreamPanePatch(_StreamPaneHarness):
+    def _run_two_captures(self, first, second, fake_cursor=None,
+                          patch_mode=True):
+        conn = self._make_conn()
+        captures = []
+        def fake_capture(pane_id, lines, ansi, join):
+            captures.append(None)
+            return first if len(captures) == 1 else second
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor, patch_mode=patch_mode)
+        return conn
+
+    def test_opted_in_change_sends_patch_ops_after_full_snapshot(self):
+        first  = f'{_longline(0)}\n{_longline(1)}\n'
+        second = f'{first}{_longline(2)}\n'
+        conn = self._run_two_captures(first, second)
+        self.assertEqual([m['type'] for m in conn.sent], ['snapshot', 'patch'])
+        self.assertEqual(conn.sent[0]['data'], first)
+        msg = conn.sent[1]
+        self.assertEqual(msg['pane_id'], '%0')
+        self.assertNotIn('data', msg)
+        self.assertEqual(msg['ops'], [{'op': 'insert', 'start': 2, 'end': 2,
+                                       'lines': [_longline(2)]}])
+        self.assertEqual(_apply_ops(first.split('\n'), msg['ops']),
+                         second.split('\n'))
+
+    def test_without_opt_in_the_full_update_is_unchanged(self):
+        conn = self._run_two_captures('l1\nl2\n', 'l1\nl2\nl3\n',
+                                      patch_mode=False)
+        self.assertEqual(conn.sent[1],
+                         {'type': 'update', 'pane_id': '%0',
+                          'data': 'l1\nl2\nl3\n'})
+
+    def test_whole_buffer_rewrite_falls_back_to_full_update(self):
+        # Every line different: the encoded ops outweigh the content, so the
+        # daemon sends a full update instead of a patch as large as one.
+        conn = self._run_two_captures('aaaa\nbbbb\ncccc\n',
+                                      'dddd\neeee\nffff\n')
+        self.assertEqual(conn.sent[1],
+                         {'type': 'update', 'pane_id': '%0',
+                          'data': 'dddd\neeee\nffff\n'})
+
+    def test_box_drawing_pane_still_patches_a_one_line_change(self):
+        # Non-ASCII escapes to \uXXXX (6 bytes per char) under json.dumps;
+        # the threshold compares encoded ops against encoded content, so the
+        # escaping inflates both sides alike. Comparing encoded ops against
+        # raw character count would tip this one-line change (one 40-char
+        # line escaped to ~285 bytes vs 123 content characters) into a full
+        # update.
+        lines = ['│' + '─' * 38 + '│' for _ in range(3)]
+        first = '\n'.join(lines) + '\n'
+        changed = '│ ok' + '─' * 35 + '│'
+        second = '\n'.join([lines[0], changed, lines[2]]) + '\n'
+        conn = self._run_two_captures(first, second)
+        msg = conn.sent[1]
+        self.assertEqual(msg['type'], 'patch')
+        self.assertEqual(_apply_ops(first.split('\n'), msg['ops']),
+                         second.split('\n'))
+
+    def test_cursor_fields_ride_the_patch(self):
+        def fake_cursor(pane_id):
+            return {'cursor_x': 5, 'cursor_from_end': 1}
+        first  = f'{_longline(0)}\n{_longline(1)}\n'
+        second = f'{first}{_longline(2)}\n'
+        conn = self._run_two_captures(first, second,
+                                      fake_cursor=fake_cursor)
+        msg = conn.sent[1]
+        self.assertEqual(msg['type'], 'patch')
+        self.assertEqual(msg['cursor_x'], 5)
+        self.assertEqual(msg['cursor_from_end'], 1)
+
+    def test_cursor_move_alone_still_sends_a_cursor_message(self):
+        conn = self._make_conn()
+        cursors = []
+        def fake_capture(pane_id, lines, ansi, join):
+            return 'l1\nl2\nsame\n'
+        def fake_cursor(pane_id):
+            cursors.append(None)
+            return {'cursor_x': 0, 'cursor_from_end': len(cursors) % 2}
+
+        async def driver():
+            conn._stream_wake.set()
+            await asyncio.sleep(0.1)
+
+        self._run_stream(conn, fake_capture, driver, settle=0.01,
+                         fake_cursor=fake_cursor, patch_mode=True)
+        self.assertEqual(conn.sent[1]['type'], 'cursor')
+        self.assertNotIn('ops', conn.sent[1])
+
+    def test_unchanged_content_sends_nothing(self):
+        conn = self._run_two_captures('same\n', 'same\n')
+        self.assertEqual([m['type'] for m in conn.sent], ['snapshot'])
+
+    def test_wake_produces_a_patch_not_a_full_update(self):
+        # The keystroke-wake path and the patch encoding compose: an echoed
+        # keystroke arrives as one replaced prompt line, which is the
+        # latency win this exists for.
+        history = '\n'.join(_longline(i) for i in range(8))
+        first  = f'{history}\n$ l\n'
+        second = f'{history}\n$ ls\n'
+        conn = self._run_two_captures(first, second)
+        self.assertEqual(conn.sent[1]['type'], 'patch')
+        self.assertEqual(conn.sent[1]['ops'],
+                         [{'op': 'replace', 'start': 8, 'end': 9,
+                           'lines': ['$ ls']}])
+        self.assertEqual(_apply_ops(first.split('\n'), conn.sent[1]['ops']),
+                         second.split('\n'))
 
 
 # ---------------------------------------------------------------------------

--- a/mobile/tests/test_daemon.py
+++ b/mobile/tests/test_daemon.py
@@ -588,6 +588,35 @@ class _StreamPaneHarness(unittest.TestCase):
             return asyncio.run(main())
 
 
+class TestEnterSettle(unittest.TestCase):
+    """The paste-burst settle before Enter is skipped for a bare shell
+    prompt and kept for anything else."""
+
+    def _send(self, reader_name, pid='123'):
+        calls = []
+        with patch.object(bm, '_tmux',
+                          side_effect=lambda *a: pid if 'display-message' in a else ''), \
+             patch.object(bm, '_smarter_pane_name', return_value=reader_name), \
+             patch.object(bm.time, 'sleep', side_effect=calls.append):
+            bm.tmux_send_keys('%1', 'echo hi', enter=True, literal=True)
+        return calls
+
+    def test_shell_prompt_skips_settle(self):
+        self.assertEqual(self._send('bash'), [])
+
+    def test_running_tui_keeps_settle(self):
+        self.assertEqual(self._send('codex'), [bm._PASTE_BURST_SETTLE])
+
+    def test_unreadable_pid_keeps_settle(self):
+        self.assertEqual(self._send('bash', pid=''), [bm._PASTE_BURST_SETTLE])
+
+    def test_non_literal_never_settles(self):
+        with patch.object(bm, '_tmux'), \
+             patch.object(bm.time, 'sleep') as slept:
+            bm.tmux_send_keys('%1', 'C-c', enter=True, literal=False)
+        slept.assert_not_called()
+
+
 class TestControlClient(unittest.TestCase):
     """Reply-block parsing and %output wake dispatch of _ControlClient,
     driven through a fake proc whose stdout is a plain StreamReader."""

--- a/mobile/tests/test_daemon_extended.py
+++ b/mobile/tests/test_daemon_extended.py
@@ -480,11 +480,14 @@ class TestTmuxWriteOps(unittest.TestCase):
         self.assertIn('split-window', calls[0])
         self.assertIn('@1', calls[0])
 
-    def test_send_keys_with_enter_makes_two_calls(self):
+    def test_send_keys_with_enter_sends_keys_then_enter(self):
+        # A shell-prompt probe (display-message) may run between the two
+        # send-keys; only the send-keys calls are the contract.
         calls = self._capture(bm.tmux_send_keys, '%0', 'ls', True)
-        self.assertEqual(len(calls), 2)
-        self.assertIn('ls', calls[0])
-        self.assertIn('Enter', calls[1])
+        sends = [c for c in calls if 'send-keys' in c]
+        self.assertEqual(len(sends), 2)
+        self.assertIn('ls', sends[0])
+        self.assertIn('Enter', sends[1])
 
     def test_send_keys_without_enter_makes_one_call(self):
         calls = self._capture(bm.tmux_send_keys, '%0', 'ls', False)

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -17,6 +17,7 @@ import socket
 import subprocess
 import sys
 import time
+from collections import deque
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -388,9 +389,12 @@ def tmux_cursor(pane_id: str) -> dict | None:
     tmux invocations, so the cursor can be one screen-state newer than the
     content it rides with; it self-corrects on the next poll.
     """
-    raw = _tmux("display-message", "-p", "-t", pane_id,
-                "#{cursor_x}\t#{cursor_y}\t#{pane_height}")
-    parts = raw.strip().split("\t")
+    return _cursor_from_raw(_tmux("display-message", "-p", "-t", pane_id, _CURSOR_FMT))
+
+_CURSOR_FMT = "#{cursor_x} #{cursor_y} #{pane_height}"
+
+def _cursor_from_raw(raw: str) -> dict | None:
+    parts = raw.split()
     if len(parts) != 3:
         return None
     try:
@@ -803,6 +807,247 @@ _TMUX_ID_RE = re.compile(r"^[$@%]\d+$")
 _WS_RATE_WINDOW = 1.0   # seconds
 _WS_RATE_LIMIT  = 20    # max messages per window
 
+# ---------------------------------------------------------------------------
+# tmux control mode: push wakes and forkless captures
+#
+# One `tmux -C attach-session` client per streamed session turns the pane
+# stream from polled into event-driven: tmux pushes an %output notification
+# the moment a pane produces bytes, which wakes the stream loop; read-only
+# commands (capture-pane, display-message) ride the same connection instead
+# of paying a fork+exec each. The client attaches with ignore-size so it
+# never influences window geometry. read-only is deliberately NOT set: tmux
+# resolves some commands through the attached client and a read-only one
+# makes external send-keys fail server-wide ("client is read-only", tmux
+# 3.7). Everything falls back to the subprocess path when the client is
+# missing or mid-respawn, so control mode is an accelerator, not a
+# dependency. Command replies over control mode are byte-identical to the
+# subprocess output, including raw ANSI from capture-pane -e (tmux 3.7).
+#
+# Control-mode commands are LINES that tmux itself parses, so values
+# interpolated into them must be injection-proof: the cm_* helpers accept
+# only _valid_tmux_id ids (falling back to the argv subprocess path
+# otherwise) and clamped ints. Anything user-typed (send-keys text) stays
+# on the argv path by design.
+# ---------------------------------------------------------------------------
+
+_CM_ATTACH_TIMEOUT = 3.0   # seconds to wait for the attach greeting block
+_CM_CMD_TIMEOUT = 5.0      # per-command reply timeout, matches _tmux's
+_CM_BACKOFF = 5.0          # seconds between attach attempts after a failure
+
+
+class _ControlClient:
+    """One control-mode tmux client attached to one session."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.proc: asyncio.subprocess.Process | None = None
+        self._pending: deque[asyncio.Future] = deque()
+        self._closing = False
+
+    @property
+    def alive(self) -> bool:
+        return self.proc is not None and self.proc.returncode is None \
+            and not self._closing
+
+    async def start(self) -> bool:
+        try:
+            self.proc = await asyncio.create_subprocess_exec(
+                "tmux", "-C", "attach-session", "-t", self.session_id,
+                "-f", "ignore-size",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError:
+            return False
+        # The attach itself is answered with an empty %begin/%end block;
+        # consume it via a sentinel future so later replies pair with their
+        # commands in FIFO order.
+        greeting: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending.append(greeting)
+        asyncio.ensure_future(self._read_loop())
+        try:
+            await asyncio.wait_for(greeting, _CM_ATTACH_TIMEOUT)
+        except asyncio.TimeoutError:
+            self.stop()
+            return False
+        return self.alive
+
+    def stop(self) -> None:
+        self._closing = True
+        if self.proc is not None and self.proc.returncode is None:
+            try:
+                self.proc.terminate()
+            except ProcessLookupError:
+                pass
+
+    async def run(self, cmd: str) -> str | None:
+        """Run one tmux command; its output, "" on %error, None if broken."""
+        if not self.alive:
+            return None
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending.append(fut)
+        try:
+            self.proc.stdin.write(cmd.encode() + b"\n")
+            await self.proc.stdin.drain()
+            return await asyncio.wait_for(fut, _CM_CMD_TIMEOUT)
+        except (OSError, asyncio.TimeoutError):
+            # A stuck or half-dead client could only pair replies out of
+            # sync; kill it and let the subprocess fallback take over.
+            self.stop()
+            return None
+
+    async def _read_loop(self) -> None:
+        block: list[bytes] | None = None
+        block_id: list[bytes] = []
+        try:
+            while True:
+                line = await self.proc.stdout.readline()
+                if not line:
+                    break
+                if block is not None:
+                    if line.startswith((b"%end ", b"%error ")):
+                        # Match timestamp+number so captured content that
+                        # merely starts with "%end" cannot close the block.
+                        if line.split()[1:3] == block_id:
+                            result = "" if line.startswith(b"%error") else \
+                                b"".join(block).decode("utf-8", "replace")
+                            if self._pending:
+                                fut = self._pending.popleft()
+                                if not fut.done():
+                                    fut.set_result(result)
+                            block = None
+                            continue
+                    block.append(line)
+                elif line.startswith(b"%begin "):
+                    block_id = line.split()[1:3]
+                    block = []
+                elif line.startswith(b"%output "):
+                    pane_id = line.split(b" ", 2)[1].decode("ascii", "replace")
+                    _MONITOR.wake(pane_id)
+                # All other notifications are irrelevant to the stream.
+        except Exception:
+            pass
+        finally:
+            self.stop()
+            while self._pending:
+                fut = self._pending.popleft()
+                if not fut.done():
+                    fut.set_result(None)
+            _MONITOR.client_gone(self)
+
+
+class _TmuxMonitor:
+    """Registry of control clients and the pane watchers they wake."""
+
+    def __init__(self):
+        self._clients: dict[str, _ControlClient] = {}
+        self._watchers: dict[str, set[asyncio.Event]] = {}
+        self._pane_session: dict[str, str] = {}
+        self._backoff_until: dict[str, float] = {}
+        self._spawn_lock: asyncio.Lock | None = None
+
+    def wake(self, pane_id: str) -> None:
+        for event in self._watchers.get(pane_id, ()):
+            event.set()
+
+    def watch(self, pane_id: str, event: asyncio.Event) -> None:
+        self._watchers.setdefault(pane_id, set()).add(event)
+
+    def unwatch(self, pane_id: str, event: asyncio.Event) -> None:
+        events = self._watchers.get(pane_id)
+        if events:
+            events.discard(event)
+            if not events:
+                del self._watchers[pane_id]
+        if pane_id in self._watchers:
+            return
+        session_id = self._pane_session.pop(pane_id, None)
+        if session_id and session_id not in self._pane_session.values():
+            client = self._clients.pop(session_id, None)
+            if client:
+                client.stop()
+
+    async def ensure(self, pane_id: str) -> str | None:
+        """Session id whose control client covers pane_id, or None.
+
+        Cheap when the client is already up or in backoff; attaches one
+        otherwise. pane_id must already be validated (_valid_tmux_id).
+        """
+        session_id = self._pane_session.get(pane_id)
+        if session_id is None:
+            raw = await asyncio.to_thread(
+                _tmux, "display-message", "-p", "-t", pane_id, "#{session_id}")
+            session_id = raw.strip()
+            if not _valid_tmux_id(session_id):
+                return None
+            if pane_id in self._watchers:
+                self._pane_session[pane_id] = session_id
+        client = self._clients.get(session_id)
+        if client is not None and client.alive:
+            return session_id
+        if time.monotonic() < self._backoff_until.get(session_id, 0.0):
+            return None
+        if self._spawn_lock is None:
+            self._spawn_lock = asyncio.Lock()
+        async with self._spawn_lock:
+            client = self._clients.get(session_id)  # lost a spawn race?
+            if client is not None and client.alive:
+                return session_id
+            client = _ControlClient(session_id)
+            if await client.start():
+                self._clients[session_id] = client
+                return session_id
+        self._backoff_until[session_id] = time.monotonic() + _CM_BACKOFF
+        return None
+
+    async def run(self, session_id: str, cmd: str) -> str | None:
+        client = self._clients.get(session_id)
+        if client is None or not client.alive:
+            return None
+        return await client.run(cmd)
+
+    def client_gone(self, client: _ControlClient) -> None:
+        # Reached on any reader exit. Only an unsolicited death still owns
+        # its registry slot (a deliberate stop() was already popped by
+        # unwatch), and only that death earns an attach backoff.
+        if self._clients.get(client.session_id) is client:
+            del self._clients[client.session_id]
+            self._backoff_until[client.session_id] = \
+                time.monotonic() + _CM_BACKOFF
+
+
+_MONITOR = _TmuxMonitor()
+
+
+async def cm_capture_pane(session_id: str | None, pane_id: str,
+                          history_lines: int = 200, ansi: bool = False,
+                          join: bool = False) -> str:
+    """tmux_capture_pane over the control client, subprocess fallback."""
+    if session_id and _valid_tmux_id(pane_id):
+        cmd = f"capture-pane -t {pane_id} -p"
+        if ansi:
+            cmd += " -e"
+        if join:
+            cmd += " -J"
+        cmd += f" -S -{history_lines}"
+        raw = await _MONITOR.run(session_id, cmd)
+        if raw is not None:
+            return raw if ansi else strip_ansi(raw)
+    return await asyncio.to_thread(
+        tmux_capture_pane, pane_id, history_lines, ansi, join)
+
+
+async def cm_cursor(session_id: str | None, pane_id: str) -> dict | None:
+    """tmux_cursor over the control client, subprocess fallback."""
+    if session_id and _valid_tmux_id(pane_id):
+        raw = await _MONITOR.run(
+            session_id, f'display-message -p -t {pane_id} "{_CURSOR_FMT}"')
+        if raw is not None:
+            return _cursor_from_raw(raw)
+    return await asyncio.to_thread(tmux_cursor, pane_id)
+
+
 # Pane stream cadence. _POLL_IDLE is the background tick; while keystrokes
 # are flowing (a send_keys within the last _POLL_ACTIVE_WINDOW seconds) the
 # stream ticks at _POLL_ACTIVE instead. A send_keys for the subscribed pane
@@ -813,6 +1058,10 @@ _POLL_IDLE = 0.5            # seconds between captures with no recent input
 _POLL_ACTIVE = 0.15         # seconds between captures while input flows
 _POLL_ACTIVE_WINDOW = 2.0   # seconds of fast cadence after a send_keys
 _KEYSTROKE_SETTLE = 0.03    # seconds between key injection and capture
+# With a control client pushing %output wakes, the tick is only a safety net
+# for anything a wake cannot carry (a lost notification, a dead client), so
+# it can be slow.
+_POLL_IDLE_MONITORED = 2.0
 
 def _valid_tmux_id(s: str) -> bool:
     return bool(s and _TMUX_ID_RE.match(s))
@@ -956,14 +1205,16 @@ class WsHandler(tornado.websocket.WebSocketHandler):
 
     async def _stream_pane(self, pane_id: str, history_lines: int, ansi: bool = False,
                            join: bool = False, patch: bool = False):
+        _MONITOR.watch(pane_id, self._stream_wake)
         try:
             self._stream_wake.clear()  # drop wakes aimed at a previous subscription
-            content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
+            session_id = await _MONITOR.ensure(pane_id)
+            content = await cm_capture_pane(session_id, pane_id, history_lines, ansi, join)
             # Join (-J) merges soft-wrapped lines, so screen rows no longer
             # map 1:1 to capture lines and the client falls back to its
             # end-of-buffer anchor anyway; skip the cursor entirely.
             cursor = None if join else _clamp_cursor(
-                await asyncio.to_thread(tmux_cursor, pane_id), content)
+                await cm_cursor(session_id, pane_id), content)
             msg = {"type": "snapshot", "pane_id": pane_id, "data": content}
             if cursor:
                 msg.update(cursor)
@@ -973,8 +1224,12 @@ class WsHandler(tornado.websocket.WebSocketHandler):
             # daemon tracks what it last sent, so no client acks are needed.
             # Both sides split on '\n' so op indices mean the same lines.
             last_lines = content.split("\n") if patch else None
+            last_capture_mono = time.monotonic()
             while True:
-                if time.monotonic() - self._last_input_mono < _POLL_ACTIVE_WINDOW:
+                session_id = await _MONITOR.ensure(pane_id)
+                if session_id:
+                    interval = _POLL_IDLE_MONITORED
+                elif time.monotonic() - self._last_input_mono < _POLL_ACTIVE_WINDOW:
                     interval = _POLL_ACTIVE
                 else:
                     interval = _POLL_IDLE
@@ -986,14 +1241,25 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                     # the settle delay.
                     pass
                 else:
-                    # Keystroke wake: let the shell echo land before capturing.
-                    # Wakes arriving inside the settle are absorbed by the
-                    # clear(), so a burst produces one capture.
+                    # Keystroke or %output wake: let the pty echo land before
+                    # capturing. Wakes arriving inside the settle are absorbed
+                    # by the clear(), so a burst produces one capture.
                     await asyncio.sleep(_KEYSTROKE_SETTLE)
                     self._stream_wake.clear()
-                content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
+                if session_id:
+                    # %output can fire per byte (a running `yes` produces
+                    # thousands of wakes a second); floor the capture rate at
+                    # the old active cadence so a busy pane costs what it
+                    # always did. Wakes landing inside the floor sleep are
+                    # coalesced into this capture by the clear().
+                    floor = _POLL_ACTIVE - (time.monotonic() - last_capture_mono)
+                    if floor > 0:
+                        await asyncio.sleep(floor)
+                        self._stream_wake.clear()
+                content = await cm_capture_pane(session_id, pane_id, history_lines, ansi, join)
                 cursor = None if join else _clamp_cursor(
-                    await asyncio.to_thread(tmux_cursor, pane_id), content)
+                    await cm_cursor(session_id, pane_id), content)
+                last_capture_mono = time.monotonic()
                 if content != last_content:
                     if patch:
                         new_lines = content.split("\n")
@@ -1032,6 +1298,8 @@ class WsHandler(tornado.websocket.WebSocketHandler):
             raise
         except Exception:
             self._send({"type": "error", "message": "pane stream error"})
+        finally:
+            _MONITOR.unwatch(pane_id, self._stream_wake)
 
     async def _handle(self, raw: str):
         # Handle unauthenticated state — expect auth message first

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -868,6 +868,10 @@ class WsHandler(tornado.websocket.WebSocketHandler):
         await super().get(*args, **kwargs)
 
     def open(self):
+        # Nagle would hold a small frame (a keystroke, a one-line patch) for
+        # up to an RTT waiting on ACKs; interactive latency outranks the few
+        # bytes of header overhead.
+        self.set_nodelay(True)
         self._stream_task: asyncio.Task | None = None
         self._stream_pane_id: str | None = None
         self._stream_wake = asyncio.Event()

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -389,16 +389,50 @@ def tmux_cursor(pane_id: str) -> dict | None:
     tmux invocations, so the cursor can be one screen-state newer than the
     content it rides with; it self-corrects on the next poll.
     """
-    return _cursor_from_raw(_tmux("display-message", "-p", "-t", pane_id, _CURSOR_FMT))
+    return _cursor_from_raw(_cursor_fields(pane_id))
 
-_CURSOR_FMT = "#{cursor_x} #{cursor_y} #{pane_height}"
+_CURSOR_FMT = "#{cursor_x} #{cursor_y} #{pane_height} #{pane_width}"
+
+def _join_cursor(content: str, x: int, y: int, height: int,
+                 width: int) -> dict | None:
+    """Map a screen cursor into joined (-J) capture coordinates.
+
+    A joined capture merges soft-wrapped rows, so #{cursor_y} no longer
+    indexes capture lines. Each joined line occupies ceil(cells/width)
+    screen rows; walking joined lines from the capture's end and summing
+    those rows locates the line holding the cursor's row, and the row's
+    position within that line turns cursor_x into an offset into the joined
+    line. Cells are approximated by code points of the ANSI-stripped line,
+    the same cell-vs-code-point approximation the client's anchor already
+    makes, so double-width characters drift the anchor the same way they
+    always did. None when the geometry is unusable; the client then falls
+    back to its end-of-buffer anchor.
+    """
+    if width <= 0 or not 0 <= y < height:
+        return None
+    lines = strip_ansi(content).split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()                        # the capture's closing newline
+    rows_below = height - 1 - y
+    acc = 0
+    for i in range(len(lines) - 1, -1, -1):
+        rows = max(1, -(-len(lines[i]) // width))
+        if acc + rows > rows_below:
+            row_from_top = rows - 1 - (rows_below - acc)
+            return {"cursor_x": row_from_top * width + x,
+                    "cursor_from_end": len(lines) - 1 - i}
+        acc += rows
+    return None
+
+def _cursor_fields(pane_id: str) -> str:
+    return _tmux("display-message", "-p", "-t", pane_id, _CURSOR_FMT)
 
 def _cursor_from_raw(raw: str) -> dict | None:
     parts = raw.split()
-    if len(parts) != 3:
+    if len(parts) != 4:
         return None
     try:
-        x, y, height = (int(p) for p in parts)
+        x, y, height, _width = (int(p) for p in parts)
     except ValueError:
         return None
     if not 0 <= y < height:
@@ -1069,6 +1103,25 @@ async def cm_cursor(session_id: str | None, pane_id: str) -> dict | None:
     return await asyncio.to_thread(tmux_cursor, pane_id)
 
 
+async def cm_join_cursor(session_id: str | None, pane_id: str,
+                         content: str) -> dict | None:
+    """Cursor for a joined (-J) capture, mapped by _join_cursor."""
+    raw = None
+    if session_id and _valid_tmux_id(pane_id):
+        raw = await _MONITOR.run(
+            session_id, f'display-message -p -t {pane_id} "{_CURSOR_FMT}"')
+    if raw is None:
+        raw = await asyncio.to_thread(_cursor_fields, pane_id)
+    parts = raw.split()
+    if len(parts) != 4:
+        return None
+    try:
+        x, y, height, width = (int(p) for p in parts)
+    except ValueError:
+        return None
+    return _join_cursor(content, x, y, height, width)
+
+
 # Pane stream cadence. _POLL_IDLE is the background tick; while keystrokes
 # are flowing (a send_keys within the last _POLL_ACTIVE_WINDOW seconds) the
 # stream ticks at _POLL_ACTIVE instead. A send_keys for the subscribed pane
@@ -1232,10 +1285,11 @@ class WsHandler(tornado.websocket.WebSocketHandler):
             session_id = await _MONITOR.ensure(pane_id)
             content = await cm_capture_pane(session_id, pane_id, history_lines, ansi, join)
             # Join (-J) merges soft-wrapped lines, so screen rows no longer
-            # map 1:1 to capture lines and the client falls back to its
-            # end-of-buffer anchor anyway; skip the cursor entirely.
-            cursor = None if join else _clamp_cursor(
-                await cm_cursor(session_id, pane_id), content)
+            # map 1:1 to capture lines; cm_join_cursor re-maps the cursor
+            # into joined coordinates instead.
+            cursor = _clamp_cursor(
+                await (cm_join_cursor(session_id, pane_id, content) if join
+                       else cm_cursor(session_id, pane_id)), content)
             msg = {"type": "snapshot", "pane_id": pane_id, "data": content}
             if cursor:
                 msg.update(cursor)
@@ -1278,8 +1332,9 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                         await asyncio.sleep(floor)
                         self._stream_wake.clear()
                 content = await cm_capture_pane(session_id, pane_id, history_lines, ansi, join)
-                cursor = None if join else _clamp_cursor(
-                    await cm_cursor(session_id, pane_id), content)
+                cursor = _clamp_cursor(
+                    await (cm_join_cursor(session_id, pane_id, content) if join
+                           else cm_cursor(session_id, pane_id)), content)
                 last_capture_mono = time.monotonic()
                 if content != last_content:
                     if patch:

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -757,6 +757,17 @@ _TMUX_ID_RE = re.compile(r"^[$@%]\d+$")
 _WS_RATE_WINDOW = 1.0   # seconds
 _WS_RATE_LIMIT  = 20    # max messages per window
 
+# Pane stream cadence. _POLL_IDLE is the background tick; while keystrokes
+# are flowing (a send_keys within the last _POLL_ACTIVE_WINDOW seconds) the
+# stream ticks at _POLL_ACTIVE instead. A send_keys for the subscribed pane
+# also wakes the stream immediately: the loop waits _KEYSTROKE_SETTLE before
+# capturing so the pty echo lands in the capture, and keystrokes arriving
+# inside one settle window are coalesced into a single capture.
+_POLL_IDLE = 0.5            # seconds between captures with no recent input
+_POLL_ACTIVE = 0.15         # seconds between captures while input flows
+_POLL_ACTIVE_WINDOW = 2.0   # seconds of fast cadence after a send_keys
+_KEYSTROKE_SETTLE = 0.03    # seconds between key injection and capture
+
 def _valid_tmux_id(s: str) -> bool:
     return bool(s and _TMUX_ID_RE.match(s))
 
@@ -791,6 +802,9 @@ class WsHandler(tornado.websocket.WebSocketHandler):
 
     def open(self):
         self._stream_task: asyncio.Task | None = None
+        self._stream_pane_id: str | None = None
+        self._stream_wake = asyncio.Event()
+        self._last_input_mono = 0.0
         self._topo_task: asyncio.Task | None = None
         self._auth_timer: asyncio.Task | None = None
         self._rate_window_start = time.monotonic()
@@ -872,11 +886,28 @@ class WsHandler(tornado.websocket.WebSocketHandler):
     async def _stream_pane(self, pane_id: str, history_lines: int, ansi: bool = False,
                            join: bool = False):
         try:
+            self._stream_wake.clear()  # drop wakes aimed at a previous subscription
             content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
             self._send({"type": "snapshot", "pane_id": pane_id, "data": content})
             last = content
             while True:
-                await asyncio.sleep(0.5)
+                if time.monotonic() - self._last_input_mono < _POLL_ACTIVE_WINDOW:
+                    interval = _POLL_ACTIVE
+                else:
+                    interval = _POLL_IDLE
+                try:
+                    await asyncio.wait_for(self._stream_wake.wait(), timeout=interval)
+                except asyncio.TimeoutError:
+                    # No clear() on this path: a wake racing the timeout must
+                    # survive to the next iteration, where its capture gets
+                    # the settle delay.
+                    pass
+                else:
+                    # Keystroke wake: let the shell echo land before capturing.
+                    # Wakes arriving inside the settle are absorbed by the
+                    # clear(), so a burst produces one capture.
+                    await asyncio.sleep(_KEYSTROKE_SETTLE)
+                    self._stream_wake.clear()
                 content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
                 if content != last:
                     self._send({"type": "update", "pane_id": pane_id, "data": content})
@@ -963,6 +994,7 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                     if self._stream_task:
                         self._stream_task.cancel()
                         await asyncio.gather(self._stream_task, return_exceptions=True)
+                    self._stream_pane_id = pane_id
                     self._stream_task = asyncio.ensure_future(
                         self._stream_pane(pane_id, lines, ansi, join)
                     )
@@ -1056,6 +1088,11 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                     literal = bool(msg.get("literal", True))
                     await asyncio.to_thread(tmux_send_keys, pane_id, keys, enter, literal)
                     del keys  # release sensitive content as early as possible
+                    if pane_id == self._stream_pane_id:
+                        # Wake the pane stream for an immediate capture and
+                        # start the fast-cadence window.
+                        self._last_input_mono = time.monotonic()
+                        self._stream_wake.set()
 
             elif mtype == "rename_window":
                 wid = msg.get("window_id", "")

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -372,6 +372,51 @@ def tmux_capture_pane(pane_id: str, history_lines: int = 200, ansi: bool = False
         raw = strip_ansi(raw)
     return raw
 
+def tmux_cursor(pane_id: str) -> dict | None:
+    """Cursor position for the subscribed pane, pre-mapped for the client.
+
+    #{cursor_y} is a row on the visible screen; a piped capture-pane keeps
+    trailing blank screen rows (_clamp_cursor defends against a tmux that
+    trims them), so the visible screen is exactly the capture's trailing
+    #{pane_height} lines and the cursor's line sits
+    pane_height - 1 - cursor_y lines from the end of the capture. Sending
+    that from-the-end index keeps the client mapping independent of how much
+    history the capture holds. cursor_x rides along for clients that want
+    column fidelity. None on any parse trouble: the client then falls back
+    to its end-of-buffer anchor. The capture and this call are two separate
+    tmux invocations, so the cursor can be one screen-state newer than the
+    content it rides with; it self-corrects on the next poll.
+    """
+    raw = _tmux("display-message", "-p", "-t", pane_id,
+                "#{cursor_x}\t#{cursor_y}\t#{pane_height}")
+    parts = raw.strip().split("\t")
+    if len(parts) != 3:
+        return None
+    try:
+        x, y, height = (int(p) for p in parts)
+    except ValueError:
+        return None
+    if not 0 <= y < height:
+        return None
+    return {"cursor_x": x, "cursor_from_end": height - 1 - y}
+
+def _clamp_cursor(cursor: dict | None, content: str) -> dict | None:
+    """Drop the cursor when the capture cannot contain its line.
+
+    tmux_cursor's mapping assumes a piped capture-pane keeps trailing blank
+    screen rows (verified on tmux 3.7b, but version behavior, not spec). A
+    tmux that trims them would make cursor_from_end point into scrollback;
+    dropping the fields degrades to the client's end-of-buffer anchor.
+    """
+    if cursor is None:
+        return None
+    if not content:
+        return None
+    lines = content.count("\n") + (0 if content.endswith("\n") else 1)
+    if cursor["cursor_from_end"] >= lines:
+        return None
+    return cursor
+
 def tmux_new_session(name: str) -> None:
     _tmux("new-session", "-d", "-s", name)
 
@@ -888,8 +933,16 @@ class WsHandler(tornado.websocket.WebSocketHandler):
         try:
             self._stream_wake.clear()  # drop wakes aimed at a previous subscription
             content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
-            self._send({"type": "snapshot", "pane_id": pane_id, "data": content})
-            last = content
+            # Join (-J) merges soft-wrapped lines, so screen rows no longer
+            # map 1:1 to capture lines and the client falls back to its
+            # end-of-buffer anchor anyway; skip the cursor entirely.
+            cursor = None if join else _clamp_cursor(
+                await asyncio.to_thread(tmux_cursor, pane_id), content)
+            msg = {"type": "snapshot", "pane_id": pane_id, "data": content}
+            if cursor:
+                msg.update(cursor)
+            self._send(msg)
+            last_content, last_cursor = content, cursor
             while True:
                 if time.monotonic() - self._last_input_mono < _POLL_ACTIVE_WINDOW:
                     interval = _POLL_ACTIVE
@@ -909,9 +962,25 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                     await asyncio.sleep(_KEYSTROKE_SETTLE)
                     self._stream_wake.clear()
                 content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
-                if content != last:
-                    self._send({"type": "update", "pane_id": pane_id, "data": content})
-                    last = content
+                cursor = None if join else _clamp_cursor(
+                    await asyncio.to_thread(tmux_cursor, pane_id), content)
+                if content != last_content:
+                    msg = {"type": "update", "pane_id": pane_id, "data": content}
+                    if cursor:
+                        msg.update(cursor)
+                    self._send(msg)
+                elif cursor != last_cursor:
+                    # Bare cursor move (vi h/j/k/l): the content is unchanged,
+                    # so a full update would make the client re-render (and
+                    # destroy any in-progress text selection) for nothing.
+                    # A data-less cursor message moves the ghost anchor alone;
+                    # fields absent means the cursor became unreadable and the
+                    # client falls back to its end-of-buffer anchor.
+                    msg = {"type": "cursor", "pane_id": pane_id}
+                    if cursor:
+                        msg.update(cursor)
+                    self._send(msg)
+                last_content, last_cursor = content, cursor
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -449,7 +449,28 @@ def tmux_kill_session(session_id: str) -> None:
 # the paste rather than submit — sending Enter immediately lands inside that
 # window, so Enter is silently swallowed. Codex's window is 120ms; settle
 # past it before sending Enter. https://github.com/dustinkirkland/byobu/issues/115
+#
+# Shells have no such heuristics, so when the process reading the pane's tty
+# is a bare shell prompt the settle is 150ms of pure added latency on every
+# submitted command; skip it there and keep it for everything else, where a
+# swallowed Enter costs far more than the wait.
 _PASTE_BURST_SETTLE = 0.15
+
+_SHELL_NAMES = frozenset(
+    {"bash", "zsh", "fish", "sh", "dash", "ash", "ksh", "tcsh", "csh"})
+
+def _pane_reader_is_shell(pane_id: str) -> bool:
+    """True when the pane's foreground process is a plain shell prompt.
+
+    Walks from pane_pid to the deepest first-child, same as the pane-name
+    display: a shell with a child is running that child, and the child gets
+    the settle. Any doubt (unreadable pid, unknown name) returns False so
+    the caller keeps the safe path.
+    """
+    pid = _tmux("display-message", "-p", "-t", pane_id, "#{pane_pid}").strip()
+    if not pid.isdigit():
+        return False
+    return _smarter_pane_name(pid, "") in _SHELL_NAMES
 
 def tmux_send_keys(pane_id: str, keys: str, enter: bool = True, literal: bool = True) -> None:
     if literal:
@@ -457,7 +478,7 @@ def tmux_send_keys(pane_id: str, keys: str, enter: bool = True, literal: bool = 
     else:
         _tmux("send-keys", "-t", pane_id, keys)
     if enter:
-        if literal:
+        if literal and not _pane_reader_is_shell(pane_id):
             time.sleep(_PASTE_BURST_SETTLE)
         _tmux("send-keys", "-t", pane_id, "Enter")
 

--- a/mobile/trustmux/_daemon.py
+++ b/mobile/trustmux/_daemon.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import base64
 from datetime import datetime
+import difflib
 import getpass
 import glob
 import hmac
@@ -823,6 +824,27 @@ def _valid_tmux_name(s: str) -> bool:
     return bool(s) and not _TMUX_NAME_BAD.search(s)
 
 
+def _diff_line_ops(old: list[str], new: list[str]) -> list[dict]:
+    """Line-wise ops that turn old into new, for patch subscribers.
+
+    Each op carries indices into the old list ([start, end) half-open) in
+    ascending start order; the client applies them in reverse so earlier
+    indices stay valid without re-mapping. autojunk stays off: a capture
+    repeats blank lines far past the popularity heuristic's 1% threshold,
+    which would junk them and shred a clean scroll into replaces.
+    """
+    ops = []
+    matcher = difflib.SequenceMatcher(None, old, new, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        op = {"op": tag, "start": i1, "end": i2}
+        if tag != "delete":
+            op["lines"] = new[j1:j2]
+        ops.append(op)
+    return ops
+
+
 class WsHandler(tornado.websocket.WebSocketHandler):
     """One WebSocket connection per browser tab.
 
@@ -929,7 +951,7 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                 pass
 
     async def _stream_pane(self, pane_id: str, history_lines: int, ansi: bool = False,
-                           join: bool = False):
+                           join: bool = False, patch: bool = False):
         try:
             self._stream_wake.clear()  # drop wakes aimed at a previous subscription
             content = await asyncio.to_thread(tmux_capture_pane, pane_id, history_lines, ansi, join)
@@ -943,6 +965,10 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                 msg.update(cursor)
             self._send(msg)
             last_content, last_cursor = content, cursor
+            # Patch subscribers get line-diff ops instead of full updates; the
+            # daemon tracks what it last sent, so no client acks are needed.
+            # Both sides split on '\n' so op indices mean the same lines.
+            last_lines = content.split("\n") if patch else None
             while True:
                 if time.monotonic() - self._last_input_mono < _POLL_ACTIVE_WINDOW:
                     interval = _POLL_ACTIVE
@@ -965,7 +991,24 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                 cursor = None if join else _clamp_cursor(
                     await asyncio.to_thread(tmux_cursor, pane_id), content)
                 if content != last_content:
-                    msg = {"type": "update", "pane_id": pane_id, "data": content}
+                    if patch:
+                        new_lines = content.split("\n")
+                        ops = _diff_line_ops(last_lines, new_lines)
+                        # A diff at least as large as the content buys
+                        # nothing; fall back to a full update, which also
+                        # resyncs a client that lost its line state. Both
+                        # sides go through json.dumps with default
+                        # ensure_ascii, matching how _send encodes them on
+                        # the wire, so \uXXXX escaping of non-ASCII (box
+                        # drawing) inflates ops and content alike instead of
+                        # biasing such panes toward full updates.
+                        if len(json.dumps(ops)) < len(json.dumps(content)):
+                            msg = {"type": "patch", "pane_id": pane_id, "ops": ops}
+                        else:
+                            msg = {"type": "update", "pane_id": pane_id, "data": content}
+                        last_lines = new_lines
+                    else:
+                        msg = {"type": "update", "pane_id": pane_id, "data": content}
                     if cursor:
                         msg.update(cursor)
                     self._send(msg)
@@ -1060,12 +1103,15 @@ class WsHandler(tornado.websocket.WebSocketHandler):
                         lines = 300
                     ansi = bool(msg.get("ansi", False))
                     join = bool(msg.get("join", False))
+                    # Opt-in like join was: clients that never send it keep
+                    # getting full updates, byte-identical to before.
+                    patch = bool(msg.get("patch", False))
                     if self._stream_task:
                         self._stream_task.cancel()
                         await asyncio.gather(self._stream_task, return_exceptions=True)
                     self._stream_pane_id = pane_id
                     self._stream_task = asyncio.ensure_future(
-                        self._stream_pane(pane_id, lines, ansi, join)
+                        self._stream_pane(pane_id, lines, ansi, join, patch)
                     )
 
             elif mtype == "new_session":

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -977,9 +977,9 @@ function setKbdMode(mode) {
   setTimeout(() => inp.focus(), 50);
 }
 
-function showKbdModePopup() {
+function showKbdModePopup(anchor = btnKbdMode) {
   hideEscapePopup();
-  const rect = btnKbdMode.getBoundingClientRect();
+  const rect = anchor.getBoundingClientRect();
   kbdModePopup.style.display = 'flex';
   kbdModePopup.style.right   = (window.innerWidth - rect.right) + 'px';
   kbdModePopup.style.bottom  = (window.innerHeight - rect.top + 8) + 'px';
@@ -993,10 +993,14 @@ btnKbdMode.addEventListener('click', e => {
   e.stopPropagation();
   kbdModePopup.style.display === 'none' ? showKbdModePopup() : hideKbdModePopup();
 });
-// Same cycle from the key bar (the row's button is display:none while the
-// row is collapsed). pointerdown preventDefault keeps focus in the text box
-// like the other bar buttons; the shared handler refocuses anyway.
-keybarKbdMode.addEventListener('click', () => btnKbdMode.click());
+// Same popup from the key bar, anchored to the bar's own button: the row's
+// button is display:none while the row is collapsed, so its rect is unusable
+// as an anchor there. pointerdown preventDefault keeps focus in the text box
+// like the other bar buttons.
+keybarKbdMode.addEventListener('click', e => {
+  e.stopPropagation();
+  kbdModePopup.style.display === 'none' ? showKbdModePopup(keybarKbdMode) : hideKbdModePopup();
+});
 keybarKbdMode.addEventListener('pointerdown', e => e.preventDefault());
 
 kbdModePopupButtons[0].addEventListener('click', () => { setKbdMode(0); hideKbdModePopup(); });
@@ -1078,7 +1082,8 @@ keybarWrap.addEventListener('pointerdown', e => e.preventDefault());
 document.addEventListener('click', () => { hideEscapePopup(); hideKbdModePopup(); });
 document.addEventListener('touchstart', e => {
   if (!escapePopup.contains(e.target) && e.target !== btnEscape) hideEscapePopup();
-  if (!kbdModePopup.contains(e.target) && e.target !== btnKbdMode) hideKbdModePopup();
+  if (!kbdModePopup.contains(e.target) && e.target !== btnKbdMode
+      && e.target !== keybarKbdMode) hideKbdModePopup();
 }, { passive: true });
 
 // ── key bar (Esc, Ctrl, Tab, arrows; direct key mode for TUIs like vi) ─────

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -808,7 +808,7 @@ function applyKbdMode() {
     cmdInput.setAttribute('autocorrect', direct ? 'off' : 'on');
     cmdInput.setAttribute('autocapitalize', direct ? 'none' : 'sentences');
     btnKbdMode.textContent = 'Aa';
-    btnKbdMode.title = 'Text mode — tap to change';
+    btnKbdMode.title = 'Text mode: tap to choose a mode';
     btnKbdMode.style.color = 'var(--accent)';
     // Don't advertise spell check while direct mode has it forced off.
     if (direct) {
@@ -820,11 +820,11 @@ function applyKbdMode() {
     cmdInput.setAttribute('autocorrect', 'off');
     cmdInput.setAttribute('autocapitalize', 'none');
     btnKbdMode.textContent = '$_';
-    btnKbdMode.title = 'Terminal mode — tap to change';
+    btnKbdMode.title = 'Terminal mode: tap to choose a mode';
     btnKbdMode.style.color = '';
   } else {
     btnKbdMode.textContent = '**';
-    btnKbdMode.title = 'Password mode — tap to change';
+    btnKbdMode.title = 'Password mode: tap to choose a mode';
     btnKbdMode.style.color = 'var(--accent)';
   }
   for (const [mode, btn] of Object.entries(kbdModePopupButtons)) {
@@ -844,6 +844,9 @@ function applyKbdMode() {
 }
 
 function setKbdMode(mode) {
+  // Tapping the already-active mode in the popup is a no-op: without this
+  // guard the wrap default below would clobber a manual Wrap toggle.
+  if (mode === kbdMode) return;
   kbdMode = mode;
   if (currentPane) _saveKbdMode(currentPane, kbdMode);
   // Aa defaults to wrapped text, Terminal/Password to unwrapped -- applied

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -10,6 +10,13 @@ let forcedSessionId = null; // set after creating a new session
 let forcedPaneId = null;    // set after creating a new window (specific pane to navigate to)
 let _scrollTopOnNextSnapshot = false; // scroll to top instead of bottom on next snapshot
 let _paneLoading = false; // output holds the loading placeholder, not pane content
+// Ghost anchor from the daemon: the cursor's capture line as a
+// from-the-end index (0 = last line) plus its column, riding snapshot/update
+// messages and carried alone by data-less cursor messages on a bare cursor
+// move. null when the daemon predates the fields or could not read the
+// cursor; the ghost then falls back to its end-of-buffer anchor.
+let _cursorFromEnd = null;
+let _cursorX = null;
 let statusInterval = null;
 
 // ── pane snapshot cache (in-memory only — never persisted) ────────────────
@@ -160,6 +167,7 @@ const cmdInput      = document.getElementById('cmd');
 const pwdInput      = document.getElementById('pwd');
 const btnSend       = document.getElementById('btn-send');
 const btnKbdMode    = document.getElementById('btn-kbd-mode');
+const keybarKbdMode = document.getElementById('keybar-kbd-mode');
 const machineSelect    = document.getElementById('machine-select');
 const btnInstall       = document.getElementById('btn-install');
 const iosInstallTip    = document.getElementById('ios-install-tip');
@@ -345,13 +353,26 @@ function connect() {
         const forceTop = _scrollTopOnNextSnapshot;
         if (forceTop) _scrollTopOnNextSnapshot = false;
         const atBottom = output.scrollHeight - output.scrollTop <= output.clientHeight + 60;
+        _cursorFromEnd = Number.isInteger(msg.cursor_from_end) ? msg.cursor_from_end : null;
+        _cursorX = Number.isInteger(msg.cursor_x) ? msg.cursor_x : null;
         renderOutput(msg.data, !forceTop && atBottom);
         if (forceTop) output.scrollTop = 0;
       }
     } else if (msg.type === 'update') {
       if (msg.pane_id !== currentPane) return;
       const atBottom = output.scrollHeight - output.scrollTop <= output.clientHeight + 60;
+      _cursorFromEnd = Number.isInteger(msg.cursor_from_end) ? msg.cursor_from_end : null;
+      _cursorX = Number.isInteger(msg.cursor_x) ? msg.cursor_x : null;
       renderOutput(msg.data, atBottom);
+    } else if (msg.type === 'cursor') {
+      // Bare cursor move: no data field, so no re-render (an innerHTML
+      // replacement would destroy any in-progress text selection); just
+      // re-anchor the ghost. Fields absent means the daemon could not read
+      // the cursor and the end-of-buffer fallback applies.
+      if (msg.pane_id !== currentPane) return;
+      _cursorFromEnd = Number.isInteger(msg.cursor_from_end) ? msg.cursor_from_end : null;
+      _cursorX = Number.isInteger(msg.cursor_x) ? msg.cursor_x : null;
+      _ghostSync();
     } else if (msg.type === 'error') {
       setStatus(`error: ${msg.message}`, 'error');
     }
@@ -474,6 +495,14 @@ function navigateTo(sessionId, windowId, paneId) {
   // The composition ghost is view state, never pane content: strip it before
   // the innerHTML read so it cannot be cached and replayed on a later switch.
   _ghostRemove();
+  // Streamed text stays in the departing pane, un-reconciled: the pane keeps
+  // whatever was streamed so far. The surviving draft (the box's text lives
+  // across switches) re-streams in full to the arriving pane on the next
+  // input event, so the record resets here.
+  _streamed = '';
+  // Cached HTML carries no cursor; end-of-buffer anchor until the snapshot.
+  _cursorFromEnd = null;
+  _cursorX = null;
   if (currentPane && output.innerHTML) {
     _paneCache.set(currentPane, { html: output.innerHTML, scrollTop: output.scrollTop });
     if (_paneCache.size > _PANE_CACHE_MAX) _paneCache.delete(_paneCache.keys().next().value);
@@ -680,11 +709,28 @@ function activeInput() { return kbdMode === 2 ? pwdInput : cmdInput; }
 function sendKeys() {
   const inp  = activeInput();
   const keys = inp.value;
-  if (!keys || !currentPane) return;
-  send({ type: 'send_keys', pane_id: currentPane, keys, enter: true });
+  if (!currentPane) return;
+  // Streaming may already have delivered a prefix of the box to the pane,
+  // including a draft left over from hiding the bar mid-composition; a Send
+  // must reconcile the pane to the box, never resend the prefix. The
+  // reconcile runs before the emptiness check: a fully deleted box still
+  // BSpaces the stale streamed draft off the prompt. The full streaming
+  // diff runs so an edited draft BSpaces the stale streamed suffix before
+  // the tail goes out; a bare Enter then commits, and after the reconcile
+  // an emptied or fully streamed draft sends just that Enter.
+  if (inp === cmdInput && _streamed) {
+    streamDirectInput(inp);
+    send({ type: 'send_keys', pane_id: currentPane, keys: 'Enter', enter: false, literal: false });
+  } else {
+    if (!keys) return;
+    send({ type: 'send_keys', pane_id: currentPane, keys, enter: true });
+  }
+  _streamed = '';
   inp.value = '';
   if (inp === cmdInput) {
-    cmdInput.style.height = 'auto';
+    // '' not 'auto': an inline height would override the direct-mode
+    // collapsed-sliver CSS; without the bar both compute the same.
+    cmdInput.style.height = '';
   }
   // A Send tap mid-composition empties the box; the ghost must follow.
   _ghostSync();
@@ -698,6 +744,10 @@ cmdInput.addEventListener('keydown', e => {
   if (e.isComposing || e.keyCode === 229) return;
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
+    // In direct mode Enter consumes the streamed text but _streamed keeps
+    // recording it: resetting would re-stream the word onto the fresh
+    // prompt. Known edge (like the hide-bar one in setKeybarVisible): a
+    // post-Enter autocorrect rewrite BSpaces the new prompt instead.
     keybarVisible() ? sendNamedKey('Enter') : sendKeys();
   } else if (e.key === 'Backspace' && keybarVisible() && !cmdInput.value) {
     e.preventDefault();
@@ -742,6 +792,11 @@ function applyKbdMode() {
   const inPwd = kbdMode === 2;
   cmdInput.style.display = inPwd ? 'none' : '';
   pwdInput.style.display = inPwd ? 'block' : 'none';
+  // Drives the direct-mode row collapse in the CSS: while the key bar is on
+  // the input row leaves the layout so the pane gets its space, except in
+  // password mode, whose visible row the collapse rules exempt via this
+  // class. Every keybar/mode transition funnels through here.
+  document.body.classList.toggle('kbd-pwd', inPwd);
 
   // Direct mode needs raw keystrokes: under spell-check Gboard composes
   // plain typing and only commits whole words, so force terminal attributes
@@ -775,6 +830,11 @@ function applyKbdMode() {
   for (const [mode, btn] of Object.entries(kbdModePopupButtons)) {
     btn.classList.toggle('current', Number(mode) === kbdMode);
   }
+  // Non-password direct mode hides the row's button column, so the bar
+  // carries a mirror of the mode button; keep the two in sync here.
+  keybarKbdMode.textContent = btnKbdMode.textContent;
+  keybarKbdMode.title = btnKbdMode.title;
+  keybarKbdMode.style.color = btnKbdMode.style.color;
   // Every keybar/mode transition funnels through here, so this one call
   // covers show (attach), hide (remove, ahead of the blur+refocus dance so
   // the ghost never flashes) and the switch to password mode (remove: pwd
@@ -819,6 +879,11 @@ btnKbdMode.addEventListener('click', e => {
   e.stopPropagation();
   kbdModePopup.style.display === 'none' ? showKbdModePopup() : hideKbdModePopup();
 });
+// Same cycle from the key bar (the row's button is display:none while the
+// row is collapsed). pointerdown preventDefault keeps focus in the text box
+// like the other bar buttons; the shared handler refocuses anyway.
+keybarKbdMode.addEventListener('click', () => btnKbdMode.click());
+keybarKbdMode.addEventListener('pointerdown', e => e.preventDefault());
 
 kbdModePopupButtons[0].addEventListener('click', () => { setKbdMode(0); hideKbdModePopup(); });
 kbdModePopupButtons[1].addEventListener('click', () => { setKbdMode(1); hideKbdModePopup(); });
@@ -867,6 +932,7 @@ document.getElementById('escape-popup-keys').addEventListener('click', () => {
 // toggle after that still sticks until the keyboard mode is changed again.
 let wrapOn = false;
 const escapePopupWrap = document.getElementById('escape-popup-wrap');
+const keybarWrap = document.getElementById('keybar-wrap');
 
 function applyWrap() {
   output.style.whiteSpace = wrapOn ? 'pre-wrap' : 'pre';
@@ -874,6 +940,11 @@ function applyWrap() {
   // color alone.
   escapePopupWrap.textContent = (wrapOn ? '✓ ' : '⤶ ') + 'Wrap';
   escapePopupWrap.style.color = wrapOn ? 'var(--accent)' : '';
+  // The wrap toggle also lives on the key bar: the ⎋ popup is unreachable
+  // while non-password direct mode collapses the input row.
+  keybarWrap.textContent = wrapOn ? '✓⤶' : '⤶';
+  keybarWrap.title = (wrapOn ? 'Line wrap on' : 'Line wrap off') + ': tap to toggle';
+  keybarWrap.style.color = wrapOn ? 'var(--accent)' : '';
 }
 
 escapePopupWrap.addEventListener('click', () => {
@@ -887,6 +958,8 @@ escapePopupWrap.addEventListener('click', () => {
   scrollOutputToBottom();
   hideEscapePopup();
 });
+keybarWrap.addEventListener('click', () => escapePopupWrap.click());
+keybarWrap.addEventListener('pointerdown', e => e.preventDefault());
 
 document.addEventListener('click', () => { hideEscapePopup(); hideKbdModePopup(); });
 document.addEventListener('touchstart', e => {
@@ -928,6 +1001,10 @@ function setKeybarVisible(show) {
   // survive typing.
   document.body.classList.toggle('keybar-on', show);
   if (!show) setCtrlArmed(false);
+  // Hiding the bar keeps the streamed record: a draft mid-composition stays
+  // in the box with its streamed prefix already in the pane, and the trim
+  // in sendKeys delivers only the un-streamed tail on the next Send.
+  // navigateTo and the sends themselves reset the record.
   cmdInput.placeholder = show ? '' : _cmdPlaceholder;
   pwdInput.placeholder = show ? _directPwdPlaceholder : _pwdPlaceholder;
   // Re-apply so direct mode forces terminal input attributes and hiding
@@ -936,9 +1013,18 @@ function setKeybarVisible(show) {
   // Like btnKbdMode: Android keyboards only re-evaluate input attributes on
   // refocus, so toggling the bar while the box is focused needs the same
   // blur + refocus dance for the forced attributes to take effect.
+  // Entering direct mode focuses unconditionally: the input row is gone,
+  // so the soft keyboard and the ghost caret are the only signs typing is
+  // live, and they must appear without a second tap.
   const inp = activeInput();
-  if (document.activeElement === inp) {
-    inp.blur();
+  const wasFocused = document.activeElement === inp;
+  if (wasFocused) inp.blur();
+  if (show) {
+    // The auto-grow inline height would override the collapsed sliver's
+    // CSS height; clear it (direct-mode drains reset it to '' as well).
+    cmdInput.style.height = '';
+    setTimeout(() => inp.focus(), 50);
+  } else if (wasFocused) {
     setTimeout(() => inp.focus(), 50);
   }
 }
@@ -969,11 +1055,13 @@ keybarCtrl.addEventListener('pointerdown', e => e.preventDefault());
 // per-pane persistence stays in one place.
 document.getElementById('keybar-close').addEventListener('click', toggleKeybar);
 
+// Whole-box drain, now the password-box path only: #cmd streams per input
+// event via streamDirectInput below.
 function drainDirectInput(inp) {
   const text = inp.value;
   if (!text) return;
   inp.value = '';
-  if (inp === cmdInput) cmdInput.style.height = 'auto';
+  if (inp === cmdInput) cmdInput.style.height = '';
   if (!currentPane) return;
   if (_ctrlArmed) {
     setCtrlArmed(false);
@@ -994,18 +1082,96 @@ function drainDirectInput(inp) {
   send({ type: 'send_keys', pane_id: currentPane, keys: text, enter: false, literal: true });
 }
 
+// ── direct-mode composition streaming ──────────────────────────────────────
+// Composing keyboards (Gboard, swipe) mutate a draft in the box instead of
+// emitting discrete characters. Streaming diffs the box against what already
+// reached the pane on every input event: BSpace over the stale suffix, then
+// the new tail as literal text, so the pane tracks the draft character by
+// character like a real terminal. The box is never touched mid-composition
+// (clearing it corrupts the IME draft); compositionend reconciles the
+// committed text and clears. Non-composing keyboards degrade to the old
+// one-event-one-char drain: the box is empty before each event, so the diff
+// is exactly the new text and no BSpace is ever sent.
+// Accepted hazard: the BSpaces are real terminal backspaces. Line editors
+// delete on them, but vi normal mode and some TUIs treat backspace as
+// cursor-left, so an autocorrect rewrite can garble state there. Direct
+// mode always streams; there is no toggle.
+let _streamed = '';
+
+// Common prefix length of two code-point arrays (callers spread strings so
+// no UTF-16 surrogate half is ever compared), shared by the streaming diff and
+// the ghost's un-streamed-tail computation so the two cannot drift apart.
+// Code points, not UTF-16 units: a rewrite must never backspace through
+// half a surrogate pair (same reason the sticky-Ctrl gate splits this way).
+function _cpCommonPrefix(a, b) {
+  let common = 0;
+  while (common < a.length && common < b.length && a[common] === b[common]) common++;
+  return common;
+}
+
+function streamDirectInput(inp) {
+  if (!currentPane) return;
+  const value = inp.value;
+  if (value === _streamed) return;
+  const sent = [..._streamed];
+  const cur  = [...value];
+  const common = _cpCommonPrefix(sent, cur);
+  for (let i = sent.length; i > common; i--) {
+    send({ type: 'send_keys', pane_id: currentPane, keys: 'BSpace', enter: false, literal: false });
+  }
+  let tail = cur.slice(common).join('');
+  // Sticky Ctrl consumes the first un-streamed character, same combining
+  // rule as drainDirectInput; the rest streams as literal text. The consumed
+  // character still counts as streamed, so a later rewrite over it sends one
+  // BSpace, the closest approximation available.
+  if (tail && _ctrlArmed) {
+    setCtrlArmed(false);
+    const first = [...tail][0];
+    if (/^[a-z@\[\\\]^_ ]$/i.test(first)) {
+      const key = first === ' ' ? 'C-Space' : 'C-' + first.toLowerCase();
+      send({ type: 'send_keys', pane_id: currentPane, keys: key, enter: false, literal: false });
+      tail = tail.slice(first.length);
+    }
+  }
+  if (tail) send({ type: 'send_keys', pane_id: currentPane, keys: tail, enter: false, literal: true });
+  _streamed = value;
+}
+
 // ── direct-mode composition ghost ──────────────────────────────────────────
-// While the key bar is on, the text box is invisible (body.keybar-on #cmd in
-// the CSS) and its un-sent content is mirrored into the pane as ghost text:
-// a composition in progress, or plain text the next input event will drain.
-// The pane becomes the only prompt. Rendering is strictly read-only; the
-// drain and IME guards below stay untouched, and reading inp.value mid-
-// composition is safe (only clearing it is not). Cursor caveat: end of the
-// last line is an approximation of the real cursor, exact at a shell prompt,
+// While the key bar is on, the text box is out of flow and invisible (the
+// body.keybar-on rules in the CSS) and its un-streamed tail is mirrored
+// into the pane as ghost text. With streaming this is normally empty
+// (characters reach the pane as they are typed); it shows text only for a
+// draft that predates streaming, e.g. box content left from before the key
+// bar was turned on. The span
+// attaches even with no tail: its CSS ::after is the block caret that marks
+// where typing lands (filled while the box is focused, hollow when the
+// keyboard was dismissed), so the pane is the only prompt. Rendering is
+// strictly read-only; reading inp.value mid-composition is safe (only
+// clearing it is not). The anchor is the pane's cursor cell (daemon-sent
+// cursor_from_end and cursor_x); without the fields, or with wrap on, it
+// degrades to the end of the last line, exact at a shell prompt,
 // approximate in full-screen TUIs.
 function _ghostRemove() {
   const el = document.getElementById('compose-ghost');
-  if (el) el.remove();
+  if (!el) return;
+  const prev = el.previousSibling;
+  const next = el.nextSibling;
+  el.remove();
+  // Re-join the text node that splitText cut around the span. Without this
+  // every cursor-only sync leaves one more fragment behind (splitText on
+  // static content mints an extra text node per message) and the TreeWalker
+  // scans grow until the next full re-render. Merging adjacent text nodes is
+  // serialization-neutral, the same argument as splitting them, so the
+  // cache-strip guarantee only tightens. Targeted to the span's siblings:
+  // no whole-tree normalize per render. Accepted trade: a selection
+  // endpoint inside the merged node can collapse (a mid-drag cursor-only
+  // sync across the anchor), rarer than the fragment leak this prevents.
+  if (prev && next
+      && prev.nodeType === Node.TEXT_NODE && next.nodeType === Node.TEXT_NODE) {
+    prev.textContent += next.textContent;
+    next.remove();
+  }
 }
 
 function _ghostSync() {
@@ -1017,17 +1183,81 @@ function _ghostSync() {
   // Not over the loading placeholder either: composing during a cache-miss
   // pane switch would glue the ghost to "loading..." until the snapshot.
   if (_paneLoading) return;
-  const text = cmdInput.value;
-  if (!text) return;
+  // Streaming already delivered the box's prefix to the pane, so the ghost
+  // mirrors only the un-streamed tail (value minus the streamed prefix,
+  // diffed by code point). Normally empty: it shows text only when nothing
+  // could stream, e.g. with no pane at the time of typing.
+  const full = [...cmdInput.value];
+  const sent = [..._streamed];
+  const text = full.slice(_cpCommonPrefix(sent, full)).join('');
   const span = document.createElement('span');
   span.id = 'compose-ghost';
   span.textContent = text;
-  // Insert after the last rendered character but before any trailing
-  // newlines, so the ghost sits at the end of the last line rather than on
-  // a line of its own. Splitting a text node is serialization-neutral:
-  // adjacent text nodes read back as the same innerHTML, so once the ghost
-  // is removed (navigateTo strips it before every cache save) nothing of
-  // this leaks into _paneCache.
+  // Cursor-accurate anchor: the daemon maps #{cursor_y} against
+  // #{pane_height} into cursor_from_end, the cursor's capture line as a
+  // from-the-end index, so the ghost lands on the real cursor line even in
+  // full-screen TUIs whose cursor sits mid-screen. Unusable with wrap on:
+  // the -J join capture merges soft-wrapped lines, so screen rows no longer
+  // map 1:1 to capture lines and the index would point at the wrong line;
+  // fall back to end-of-buffer then, as when the fields are missing.
+  // cursor_x places the ghost at the cursor's column within that line: TUIs
+  // that pad the cursor line to the pane width (a bordered input box) put
+  // line-end at the right border while typing lands mid-line. A mid-line
+  // insert shifts the rest of the line right by the ghost's width while it
+  // exists; with streaming the tail is normally empty, so that is the caret
+  // block only, accepted.
+  if (!wrapOn && Number.isInteger(_cursorFromEnd) && _cursorFromEnd >= 0
+      && Number.isInteger(_cursorX) && _cursorX >= 0) {
+    const all = output.textContent;
+    // Offset of the end of the target line: step back one newline per
+    // from-the-end index, starting before the final line-closing newline.
+    let end = all.length;
+    if (all.endsWith('\n')) end--;
+    let ok = all.length > 0;
+    for (let i = 0; ok && i < _cursorFromEnd; i++) {
+      // end === 0 guard: lastIndexOf clamps fromIndex -1 to 0, so a leading
+      // newline would match forever instead of falling through to the
+      // end-of-buffer anchor (unreachable while the daemon clamps, but the
+      // client stays self-contained).
+      const nl = end > 0 ? all.lastIndexOf('\n', end - 1) : -1;
+      if (nl === -1) ok = false;
+      else end = nl;
+    }
+    if (ok) {
+      // Insertion offset: line start plus cursor_x clamped to the line's
+      // length, counted in code points (spread) so the split never lands
+      // inside a surrogate pair. cursor_x is a terminal CELL column, so the
+      // caret drifts one cell right past each double-width character or tab
+      // before it; accepted like the other approximations here.
+      // Guard end 0: lastIndexOf clamps a -1 fromIndex to 0, so a leading
+      // newline would match itself and put lineStart past end.
+      const lineStart = end > 0 ? all.lastIndexOf('\n', end - 1) + 1 : 0;
+      const cps = [...all.slice(lineStart, end)];
+      const at = lineStart + cps.slice(0, Math.min(_cursorX, cps.length)).join('').length;
+      let node = null, start = 0;
+      const w = document.createTreeWalker(output, NodeFilter.SHOW_TEXT);
+      while (w.nextNode()) {
+        const n = w.currentNode;
+        if (start + n.textContent.length >= at) { node = n; break; }
+        start += n.textContent.length;
+      }
+      if (node) {
+        // A mid-buffer insert cannot climb out of a styled ANSI span without
+        // moving the anchor, so an SGR-underline merging into the ghost's
+        // dotted cue is accepted here (the end-of-buffer fallback climbs).
+        const tail = node.splitText(at - start);
+        tail.parentNode.insertBefore(span, tail);
+        return;
+      }
+    }
+    // Capture shorter than the index or no text nodes: fall through.
+  }
+  // End-of-buffer fallback: insert after the last rendered character but
+  // before any trailing newlines, so the ghost sits at the end of the last
+  // line rather than on a line of its own. Splitting a text node is
+  // serialization-neutral: adjacent text nodes read back as the same
+  // innerHTML, so once the ghost is removed (navigateTo strips it before
+  // every cache save) nothing of this leaks into _paneCache.
   let last = null;
   const walker = document.createTreeWalker(output, NodeFilter.SHOW_TEXT);
   while (walker.nextNode()) last = walker.currentNode;
@@ -1051,30 +1281,69 @@ function _ghostSync() {
   }
 }
 
+// The ghost caret's fill tracks the box's focus (see #compose-ghost::after
+// in the CSS): filled means keystrokes are live, hollow means tap the pane
+// to bring the keyboard back. A body class so it is pure CSS from here on.
+cmdInput.addEventListener('focus', () => document.body.classList.add('cmd-focused'));
+cmdInput.addEventListener('blur',  () => document.body.classList.remove('cmd-focused'));
+
 // Direct mode has no visible box to tap, so any blur (tapping the pane to
 // look at it) would leave keystrokes with no target: nothing drains, no
 // ghost, dead input. Tapping the pane focuses the hidden input instead,
 // like tapping a real terminal. Skipped in scroll mode and while the user
-// is selecting text to copy.
+// is selecting text to copy. Android's back gesture dismisses the keyboard
+// without blurring the box, and focus() on an already-focused element will
+// not re-open it; when the visual viewport is back to full height (no
+// keyboard) a focus bounce re-summons it.
 output.addEventListener('click', () => {
   if (!keybarVisible() || _scrollMode) return;
   if (window.getSelection && String(window.getSelection())) return;
-  activeInput().focus();
+  const inp = activeInput();
+  if (document.activeElement !== inp) { inp.focus(); return; }
+  const vv = window.visualViewport;
+  if (!vv || vv.height >= window.innerHeight - 50) {
+    inp.blur();
+    setTimeout(() => inp.focus(), 50);
+  }
 });
 
-// IME guard: mobile keyboards fire input events mid-composition; draining
-// (which clears the box) then would duplicate or drop characters. Skip
-// while composing and drain once on compositionend. The ghost syncs after
-// the drain decision either way: mid-composition it mirrors the growing
-// word, after a drain (including a sticky-Ctrl C- send) the emptied box
-// clears it.
+// IME guard: mobile keyboards fire input events mid-composition, and the
+// box must never be cleared then (that corrupts the IME draft). Streaming
+// sidesteps the guard for #cmd: every input event diffs the box against the
+// streamed record without touching the box; only outside a composition
+// (and on compositionend, the one safe point) is the box cleared, which
+// keeps the empty-box Backspace keydown path and the beforeinput fallback
+// live. The password box never streams and keeps the old drain-per-event
+// flow. The ghost syncs after either path.
 for (const inp of [cmdInput, pwdInput]) {
   inp.addEventListener('input', e => {
-    if (keybarVisible() && !e.isComposing) drainDirectInput(inp);
+    if (keybarVisible()) {
+      if (inp === cmdInput) {
+        streamDirectInput(inp);
+        if (!e.isComposing) {
+          inp.value = '';
+          _streamed = '';
+          cmdInput.style.height = '';
+        }
+      } else if (!e.isComposing) {
+        drainDirectInput(inp);
+      }
+    }
     _ghostSync();
   });
   inp.addEventListener('compositionend', () => {
-    if (keybarVisible()) drainDirectInput(inp);
+    if (keybarVisible()) {
+      if (inp === cmdInput) {
+        // Reconcile the committed text against the streamed record: usually
+        // a no-op, or a short BSpace-and-resend on an autocorrect rewrite.
+        streamDirectInput(inp);
+        inp.value = '';
+        _streamed = '';
+        cmdInput.style.height = '';
+      } else {
+        drainDirectInput(inp);
+      }
+    }
     _ghostSync();
   });
   // Gboard reports empty-field backspace as keyCode 229, so the keydown
@@ -2193,11 +2462,30 @@ document.addEventListener('keydown', e => {
 // #app to the current visual viewport on every change (keyboard open/close,
 // resize, orientation) and cancel any page-level scroll iOS applies.
 const appEl = document.getElementById('app');
+let _vvAppliedH = -1;
+let _vvAppliedTop = -1;
 function syncViewportToKeyboard() {
   const vv = window.visualViewport;
   if (!vv) return;
-  appEl.style.height = vv.height + 'px';
-  appEl.style.top = vv.offsetTop + 'px';
+  // Some keyboards report a visualViewport height that oscillates by about
+  // a pixel per keystroke; writing every reading through re-lays-out #app
+  // and the whole screen shifts with it. Round, and skip writes within 1px
+  // of the last applied value (2px hysteresis against the applied value, so
+  // a slow slide still lands within 1px). Keyboard open/close moves the
+  // height by hundreds of pixels and always passes.
+  const h = Math.round(vv.height);
+  const top = Math.round(vv.offsetTop);
+  if (Math.abs(h - _vvAppliedH) > 1 || Math.abs(top - _vvAppliedTop) > 1) {
+    _vvAppliedH = h;
+    _vvAppliedTop = top;
+    appEl.style.height = h + 'px';
+    appEl.style.top = top + 'px';
+  }
+  // The ghost caret fills on actual keyboard visibility, not focus:
+  // Android's back gesture dismisses the keyboard without blurring the box,
+  // so focus alone would keep a filled caret over dead keystrokes. Same
+  // threshold as the pane-tap re-summon check.
+  document.body.classList.toggle('kbd-open', vv.height < window.innerHeight - 50);
   window.scrollTo(0, 0);
 }
 if (window.visualViewport) {

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -1415,17 +1415,17 @@ function _ghostSync() {
   // Cursor-accurate anchor: the daemon maps #{cursor_y} against
   // #{pane_height} into cursor_from_end, the cursor's capture line as a
   // from-the-end index, so the ghost lands on the real cursor line even in
-  // full-screen TUIs whose cursor sits mid-screen. Unusable with wrap on:
-  // the -J join capture merges soft-wrapped lines, so screen rows no longer
-  // map 1:1 to capture lines and the index would point at the wrong line;
-  // fall back to end-of-buffer then, as when the fields are missing.
+  // full-screen TUIs whose cursor sits mid-screen. With wrap on the daemon
+  // re-maps the cursor into joined-capture coordinates (cm_join_cursor), so
+  // the same anchor math applies; a daemon that cannot map (or predates the
+  // mapping) omits the fields and this falls back to end-of-buffer.
   // cursor_x places the ghost at the cursor's column within that line: TUIs
   // that pad the cursor line to the pane width (a bordered input box) put
   // line-end at the right border while typing lands mid-line. A mid-line
   // insert shifts the rest of the line right by the ghost's width while it
   // exists; with streaming the tail is normally empty, so that is the caret
   // block only, accepted.
-  if (!wrapOn && Number.isInteger(_cursorFromEnd) && _cursorFromEnd >= 0
+  if (Number.isInteger(_cursorFromEnd) && _cursorFromEnd >= 0
       && Number.isInteger(_cursorX) && _cursorX >= 0) {
     const all = output.textContent;
     // Offset of the end of the target line: step back one newline per

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -405,6 +405,13 @@ function connect() {
 }
 
 function send(obj) {
+  // A named key (Enter, an arrow, C-x) moves pane state in ways an appended
+  // character cannot describe; standing predictions are void. Rewrite
+  // BSpaces from streamDirectInput are exempt: they reconciled _pending
+  // themselves before sending.
+  if (obj && obj.type === 'send_keys' && obj.literal === false && !_predSquelch) {
+    _predClear(false);
+  }
   if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
 }
 
@@ -535,6 +542,9 @@ function navigateTo(sessionId, windowId, paneId) {
   // across switches) re-streams in full to the arriving pane on the next
   // input event, so the record resets here.
   _streamed = '';
+  // Predictions are per pane: the arriving pane owes no echo for characters
+  // streamed into the departing one, and its echo behavior is unknown.
+  _predClear(true);
   // Cached HTML carries no cursor; end-of-buffer anchor until the snapshot.
   _cursorFromEnd = null;
   _cursorX = null;
@@ -1194,11 +1204,17 @@ function drainDirectInput(inp) {
       send({ type: 'send_keys', pane_id: currentPane,
              keys: key, enter: false, literal: false });
       const rest = text.slice(first.length);
-      if (rest) send({ type: 'send_keys', pane_id: currentPane, keys: rest, enter: false, literal: true });
+      if (rest) {
+        send({ type: 'send_keys', pane_id: currentPane, keys: rest, enter: false, literal: true });
+        if (inp === cmdInput) _predPush(rest);
+      }
       return;
     }
   }
   send({ type: 'send_keys', pane_id: currentPane, keys: text, enter: false, literal: true });
+  // Never track the password box: _pending would hold the secret in plain
+  // text, and the ghost is hidden in that mode anyway.
+  if (inp === cmdInput) _predPush(text);
 }
 
 // ── direct-mode composition streaming ──────────────────────────────────────
@@ -1235,9 +1251,20 @@ function streamDirectInput(inp) {
   const sent = [..._streamed];
   const cur  = [...value];
   const common = _cpCommonPrefix(sent, cur);
+  const nBs = sent.length - common;
+  if (nBs > 0) {
+    // Rewrite BSpaces first cancel still-pending predictions (the newest
+    // chars, never displayed as deleted); BSpaces beyond that erase echoed
+    // text, which the ghost cannot represent, so drop the rest and let the
+    // server frame show the deletion.
+    if (nBs >= _pending.length) _predClear(false);
+    else _pending.length -= nBs;
+  }
+  _predSquelch = true;
   for (let i = sent.length; i > common; i--) {
     send({ type: 'send_keys', pane_id: currentPane, keys: 'BSpace', enter: false, literal: false });
   }
+  _predSquelch = false;
   let tail = cur.slice(common).join('');
   // Sticky Ctrl consumes the first un-streamed character, same combining
   // rule as drainDirectInput; the rest streams as literal text. The consumed
@@ -1252,8 +1279,76 @@ function streamDirectInput(inp) {
       tail = tail.slice(first.length);
     }
   }
-  if (tail) send({ type: 'send_keys', pane_id: currentPane, keys: tail, enter: false, literal: true });
+  if (tail) {
+    send({ type: 'send_keys', pane_id: currentPane, keys: tail, enter: false, literal: true });
+    _predPush(tail);
+  }
   _streamed = value;
+}
+
+// ── predictive local echo ───────────────────────────────────────────────────
+// Streamed characters are invisible until the daemon's capture echoes them
+// back, a full round trip (~80-100ms on a 36ms-RTT tailnet). Track each
+// streamed printable in _pending and mirror it through the composition
+// ghost at the cursor cell, so typing renders immediately; the ghost's dim
+// dotted-underline style doubles as the provisional cue. Server truth
+// always wins: a prediction is dropped the moment the text left of the
+// caret ends with it (the echo arrived), or after _PRED_TTL if it never
+// does. Display is gated on _predOk, set by the first confirmed echo and
+// cleared by an expiry, so a pane that does not echo (vim normal mode, a
+// password prompt inside the shell) shows at most one wrong burst and then
+// stays quiet until echo provably works again.
+let _pending = [];        // {ch, ts} per streamed code point, oldest first
+let _predOk = false;      // predictions render only after one confirmed echo
+let _predSquelch = false; // rewrite BSpaces already reconciled _pending
+let _predTimer = null;
+const _PRED_TTL = 1200;   // ms before an unconfirmed prediction is abandoned
+
+function _predClear(dropConfidence) {
+  _pending = [];
+  if (dropConfidence) _predOk = false;
+  if (_predTimer) { clearTimeout(_predTimer); _predTimer = null; }
+}
+
+function _predPush(text) {
+  const now = Date.now();
+  for (const ch of text) {
+    // A control character's effect on the line is not an append; anything
+    // already pending is now unverifiable.
+    if (ch < ' ') { _predClear(false); return; }
+    _pending.push({ ch, ts: now });
+  }
+  _predArm();
+}
+
+// Expiry cannot ride on a server message (the failure case is exactly that
+// no echo message comes), so it needs its own timer.
+function _predArm() {
+  if (_predTimer) clearTimeout(_predTimer);
+  _predTimer = setTimeout(_ghostSync, _PRED_TTL + 50);
+}
+
+function _predConfirm(before) {
+  // The longest prefix of _pending that `before` (text left of the caret)
+  // now ends with is echo that came back: drop it, and let any hit license
+  // rendering the rest. Longest-first so a repeated character confirms as
+  // many copies as actually echoed.
+  for (let k = _pending.length; k > 0; k--) {
+    if (before.endsWith(_pending.slice(0, k).map(p => p.ch).join(''))) {
+      _pending.splice(0, k);
+      _predOk = true;
+      break;
+    }
+  }
+}
+
+// Reconcile against `before`, then fill the ghost with the surviving
+// predictions ahead of the un-streamed tail.
+function _ghostFill(span, before, tail) {
+  _predConfirm(before);
+  const pred = _predOk ? _pending.map(p => p.ch).join('') : '';
+  span.textContent = pred + tail;
+  if (_pending.length) _predArm();
 }
 
 // ── direct-mode composition ghost ──────────────────────────────────────────
@@ -1306,12 +1401,17 @@ function _ghostSync() {
   // mirrors only the un-streamed tail (value minus the streamed prefix,
   // diffed by code point). Normally empty: it shows text only when nothing
   // could stream, e.g. with no pane at the time of typing.
+  // Predictions that outlived the round trip are wrong: a pane that does
+  // not echo, or a dropped frame. Drop them and stop rendering predictions
+  // until an echo confirms again.
+  if (_pending.length && Date.now() - _pending[0].ts > _PRED_TTL) {
+    _predClear(true);
+  }
   const full = [...cmdInput.value];
   const sent = [..._streamed];
   const text = full.slice(_cpCommonPrefix(sent, full)).join('');
   const span = document.createElement('span');
   span.id = 'compose-ghost';
-  span.textContent = text;
   // Cursor-accurate anchor: the daemon maps #{cursor_y} against
   // #{pane_height} into cursor_from_end, the cursor's capture line as a
   // from-the-end index, so the ghost lands on the real cursor line even in
@@ -1361,6 +1461,7 @@ function _ghostSync() {
         start += n.textContent.length;
       }
       if (node) {
+        _ghostFill(span, all.slice(0, at), text);
         // A mid-buffer insert cannot climb out of a styled ANSI span without
         // moving the anchor, so an SGR-underline merging into the ghost's
         // dotted cue is accepted here (the end-of-buffer fallback climbs).
@@ -1377,13 +1478,25 @@ function _ghostSync() {
   // serialization-neutral: adjacent text nodes read back as the same
   // innerHTML, so once the ghost is removed (navigateTo strips it before
   // every cache save) nothing of this leaks into _paneCache.
+  // Last text node with a non-newline character: every rendered line is its
+  // own span, so the trailing blank screen rows are bare "\n" nodes and the
+  // plain last-node walk would park the ghost on the bottom blank row
+  // instead of after the prompt (visible in wrap mode, where this fallback
+  // is the only anchor). A join capture preserves the prompt's trailing
+  // space, so landing after it puts the ghost exactly at the caret cell.
   let last = null;
   const walker = document.createTreeWalker(output, NodeFilter.SHOW_TEXT);
-  while (walker.nextNode()) last = walker.currentNode;
+  while (walker.nextNode()) {
+    if (/[^\n]/.test(walker.currentNode.textContent)) last = walker.currentNode;
+  }
   if (!last) {
+    _ghostFill(span, '', text);
     output.appendChild(span);
     return;
   }
+  // The fallback caret sits after the last rendered character, so the text
+  // left of it is everything up to the trailing newlines.
+  _ghostFill(span, output.textContent.replace(/\n+$/, ''), text);
   const m = last.textContent.match(/\n+$/);
   if (m) {
     const tail = last.splitText(last.textContent.length - m[0].length);
@@ -1391,12 +1504,18 @@ function _ghostSync() {
   } else {
     // Climb out of styled ANSI spans: text-decoration propagates into
     // children and cannot be reset from a descendant, so an SGR-underlined
-    // last line would merge its underline into the ghost's dotted one.
-    // (The trailing-newline branch above keeps in-place insertion; moving
-    // the ghost outside that span would land it after the newlines.)
+    // ancestor would merge its underline into the ghost's dotted one.
+    // Stop at the line span's child, not the line span itself: inserting
+    // inside the line, before its trailing "\n" text node, keeps a
+    // mid-buffer anchor (a styled prompt with blank rows below it, the
+    // wrap-mode norm) on the prompt's line; inserting after the whole line
+    // span would land past that newline and start the next line.
     let anchor = last;
-    while (anchor.parentNode !== output) anchor = anchor.parentNode;
-    output.insertBefore(span, anchor.nextSibling);
+    while (anchor.parentNode !== output
+           && anchor.parentNode.parentNode !== output) {
+      anchor = anchor.parentNode;
+    }
+    anchor.parentNode.insertBefore(span, anchor.nextSibling);
   }
 }
 

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -17,6 +17,13 @@ let _paneLoading = false; // output holds the loading placeholder, not pane cont
 // cursor; the ghost then falls back to its end-of-buffer anchor.
 let _cursorFromEnd = null;
 let _cursorX = null;
+// Per-line model of the current subscription's capture: element i mirrors
+// the daemon's content.split('\n'), so patch op indices mean the same lines
+// on both sides and #output's children map 1:1 onto it. null whenever the
+// DOM does not hold a snapshot-built render (pane switch, cache restore,
+// loading placeholder); a patch arriving then is a straggler and is dropped
+// (the state that nulled this also subscribed, so a snapshot is coming).
+let _lines = null;
 let statusInterval = null;
 
 // ── pane snapshot cache (in-memory only — never persisted) ────────────────
@@ -311,7 +318,7 @@ function connect() {
     _connectedAt = Date.now();
     startClock();
     send({ type: 'list_sessions' });
-    if (currentPane) send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
+    if (currentPane) subscribePane(currentPane);
   };
   ws.onclose = (evt) => {
     stopClock();
@@ -364,6 +371,24 @@ function connect() {
       _cursorFromEnd = Number.isInteger(msg.cursor_from_end) ? msg.cursor_from_end : null;
       _cursorX = Number.isInteger(msg.cursor_x) ? msg.cursor_x : null;
       renderOutput(msg.data, atBottom);
+    } else if (msg.type === 'patch') {
+      if (msg.pane_id !== currentPane) return;
+      // _lines null (pane switch, cache restore, loading placeholder) means
+      // a subscribe is already in flight for this pane; this is a straggler
+      // from the stream that subscribe is about to replace, so drop it and
+      // wait for the snapshot rather than cancel-restarting the new stream.
+      if (!_lines) return;
+      const atBottom = output.scrollHeight - output.scrollTop <= output.clientHeight + 60;
+      _cursorFromEnd = Number.isInteger(msg.cursor_from_end) ? msg.cursor_from_end : null;
+      _cursorX = Number.isInteger(msg.cursor_x) ? msg.cursor_x : null;
+      // A mismatching op means the line state diverged from the daemon's;
+      // resubscribe for a fresh snapshot.
+      if (!applyPatch(msg.ops || [])) {
+        _lines = null;
+        subscribePane(currentPane);
+        return;
+      }
+      if (atBottom) scrollOutputToBottom();
     } else if (msg.type === 'cursor') {
       // Bare cursor move: no data field, so no re-render (an innerHTML
       // replacement would destroy any in-progress text selection); just
@@ -381,6 +406,16 @@ function connect() {
 
 function send(obj) {
   if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
+}
+
+// The one subscribe shape: full history with ANSI, join following wrap mode,
+// and incremental patches opted into for unjoined captures only. Join
+// subscribers stay on full snapshots: -J reshuffles soft-wrap line identity
+// on every width-crossing change, so line-indexed patches would churn most
+// of the buffer anyway, and the cursor is already absent under join.
+function subscribePane(paneId) {
+  send({ type: 'subscribe', pane_id: paneId, lines: 300, ansi: true,
+         join: wrapOn, patch: !wrapOn });
 }
 
 // ── current context helpers ───────────────────────────────────────────────
@@ -503,6 +538,10 @@ function navigateTo(sessionId, windowId, paneId) {
   // Cached HTML carries no cursor; end-of-buffer anchor until the snapshot.
   _cursorFromEnd = null;
   _cursorX = null;
+  // The DOM is about to hold cached HTML or the loading placeholder, neither
+  // of which the line model describes; the arriving pane's snapshot rebuilds
+  // it, and a patch racing that snapshot is dropped instead of spliced.
+  _lines = null;
   if (currentPane && output.innerHTML) {
     _paneCache.set(currentPane, { html: output.innerHTML, scrollTop: output.scrollTop });
     if (_paneCache.size > _PANE_CACHE_MAX) _paneCache.delete(_paneCache.keys().next().value);
@@ -547,7 +586,7 @@ function navigateTo(sessionId, windowId, paneId) {
     _paneLoading = true;
   }
 
-  send({ type: 'subscribe', pane_id: paneId, lines: 300, ansi: true, join: wrapOn });
+  subscribePane(paneId);
   updateXYZLabel();
   updateContextName();
 }
@@ -693,14 +732,86 @@ function ansiToHtml(text) {
   return out;
 }
 
+// One span per capture line, so a patch re-renders only its lines and never
+// touches the nodes (or an in-progress text selection) of untouched ones.
+// The newline lives inside the span: output.textContent reads back as the
+// exact capture, which the ghost anchor depends on (it counts newlines).
+// Per-line ansiToHtml resets SGR state at each line, which is safe because
+// tmux capture-pane -e re-emits the full attribute set at the start of every
+// line and resets at its end (verified on tmux 3.7b): capture lines are
+// self-contained, no color leaks across them.
+function _renderLine(line, withNewline) {
+  const span = document.createElement('span');
+  span.innerHTML = ansiToHtml(line) + (withNewline ? '\n' : '');
+  return span;
+}
+
 function renderOutput(text, scrollToBottom) {
   output.className = '';
   _paneLoading = false;
-  // innerHTML replacement drops the composition ghost; re-attach before the
+  _lines = text.split('\n');
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < _lines.length; i++) {
+    frag.appendChild(_renderLine(_lines[i], i < _lines.length - 1));
+  }
+  // Child replacement drops the composition ghost; re-attach before the
   // scroll so scrollHeight includes it.
-  output.innerHTML = ansiToHtml(text);
+  output.replaceChildren(frag);
   _ghostSync();
   if (scrollToBottom) scrollOutputToBottom();
+}
+
+// Apply daemon line-diff ops to _lines and the matching #output spans.
+// Returns false on any shape/bounds mismatch, before touching either, so the
+// caller can resubscribe for a fresh snapshot instead of guessing.
+function applyPatch(ops) {
+  for (const op of ops) {
+    if (!op || !Number.isInteger(op.start) || !Number.isInteger(op.end)
+        || op.start < 0 || op.end < op.start || op.end > _lines.length
+        || (op.op !== 'delete' && !Array.isArray(op.lines))) return false;
+  }
+  // Ghost out first: its splitText fragments merge back and its climb-out
+  // case (a direct #output child) would break the child index = line index
+  // mapping the splices below rely on.
+  _ghostRemove();
+  // Ops are ascending and non-overlapping, so only the final op can reach
+  // the old tail; note it now, before the splices move the end.
+  const oldLen = _lines.length;
+  const tailTouched = ops.length > 0
+    && ops[ops.length - 1].end === oldLen;
+  // Ops carry old-array indices in ascending start order; applying from the
+  // end keeps every earlier op's indices valid.
+  for (let k = ops.length - 1; k >= 0; k--) {
+    const op = ops[k];
+    const lines = op.lines || [];
+    // A pure append after the old tail: difflib emits an insert with
+    // start === end === old length when the trailing '' is absorbed into a
+    // longer equal block (['a',''] -> ['a','','x','']). The old tail span,
+    // rendered without '\n', survives mid-buffer, so give it one while
+    // children indices are still old-array indices; the tailTouched
+    // re-render below only fixes the new last element.
+    if (k === ops.length - 1 && op.start === op.end && op.end === oldLen
+        && op.start > 0) {
+      output.replaceChild(_renderLine(_lines[op.start - 1], true),
+                          output.children[op.start - 1]);
+    }
+    _lines.splice(op.start, op.end - op.start, ...lines);
+    for (let i = op.end - 1; i >= op.start; i--) output.children[i].remove();
+    const anchor = output.children[op.start] || null;
+    for (const line of lines) output.insertBefore(_renderLine(line, true), anchor);
+  }
+  // Inserted spans always carry '\n'; when the ops touched the tail the
+  // element now in last position has one too many (an inserted final line,
+  // or a delete promoting a mid-buffer span). An untouched tail keeps its
+  // ends aligned (equal suffix) and its selection endpoints, so re-render
+  // only when the ops reached it: textContent comparison would strip SGR
+  // escapes and mismatch every styled final line.
+  const lastEl = output.lastElementChild;
+  if (tailTouched && lastEl) {
+    output.replaceChild(_renderLine(_lines[_lines.length - 1], false), lastEl);
+  }
+  _ghostSync();
+  return true;
 }
 
 // ── send keys ─────────────────────────────────────────────────────────────
@@ -856,7 +967,7 @@ function setKbdMode(mode) {
   wrapOn = (kbdMode === 1);
   if (currentPane) {
     _saveWrap(currentPane, wrapOn);
-    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
+    subscribePane(currentPane);
   }
   applyWrap();
   applyKbdMode();
@@ -955,7 +1066,7 @@ escapePopupWrap.addEventListener('click', () => {
   if (currentPane) {
     _saveWrap(currentPane, wrapOn);
     // Resubscribe so the snapshot is re-captured with the new join flag.
-    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
+    subscribePane(currentPane);
   }
   applyWrap();
   scrollOutputToBottom();
@@ -2084,12 +2195,10 @@ function applyTheme() {
 // palette.
 function rerenderTerminal() {
   _paneCache.clear();
-  if (currentPane) {
-    // join must ride every resubscribe: without it the daemon captures this
-    // pane unjoined, and with wrap on the re-render hard-breaks long lines
-    // at the tmux pane width until the next pane switch.
-    send({ type: 'subscribe', pane_id: currentPane, lines: 300, ansi: true, join: wrapOn });
-  }
+  // subscribePane carries join on every resubscribe: without it the daemon
+  // would capture this pane unjoined, and with wrap on the re-render would
+  // hard-break long lines at the tmux pane width until the next pane switch.
+  if (currentPane) subscribePane(currentPane);
 }
 
 // Live-update while in auto mode when the device scheme flips.

--- a/mobile/trustmux/static/app.js
+++ b/mobile/trustmux/static/app.js
@@ -9,6 +9,7 @@ let currentWindowId = null;
 let forcedSessionId = null; // set after creating a new session
 let forcedPaneId = null;    // set after creating a new window (specific pane to navigate to)
 let _scrollTopOnNextSnapshot = false; // scroll to top instead of bottom on next snapshot
+let _paneLoading = false; // output holds the loading placeholder, not pane content
 let statusInterval = null;
 
 // ── pane snapshot cache (in-memory only — never persisted) ────────────────
@@ -470,6 +471,9 @@ function rebuildPaneTree() {
 
 function navigateTo(sessionId, windowId, paneId) {
   // Save departing pane's rendered content + scroll position + keyboard mode.
+  // The composition ghost is view state, never pane content: strip it before
+  // the innerHTML read so it cannot be cached and replayed on a later switch.
+  _ghostRemove();
   if (currentPane && output.innerHTML) {
     _paneCache.set(currentPane, { html: output.innerHTML, scrollTop: output.scrollTop });
     if (_paneCache.size > _PANE_CACHE_MAX) _paneCache.delete(_paneCache.keys().next().value);
@@ -504,8 +508,14 @@ function navigateTo(sessionId, windowId, paneId) {
   if (cached) {
     output.innerHTML  = cached.html;
     output.scrollTop  = cached.scrollTop;
+    // setKeybarVisible ran before the cached HTML landed; re-attach the
+    // ghost onto the restored content (the box's text survives pane
+    // switches). On a cache miss there is only the loading placeholder to
+    // anchor to, so wait for the snapshot render to attach it instead.
+    _ghostSync();
   } else {
     output.textContent = 'loading…';
+    _paneLoading = true;
   }
 
   send({ type: 'subscribe', pane_id: paneId, lines: 300, ansi: true, join: wrapOn });
@@ -656,7 +666,11 @@ function ansiToHtml(text) {
 
 function renderOutput(text, scrollToBottom) {
   output.className = '';
+  _paneLoading = false;
+  // innerHTML replacement drops the composition ghost; re-attach before the
+  // scroll so scrollHeight includes it.
   output.innerHTML = ansiToHtml(text);
+  _ghostSync();
   if (scrollToBottom) scrollOutputToBottom();
 }
 
@@ -672,6 +686,8 @@ function sendKeys() {
   if (inp === cmdInput) {
     cmdInput.style.height = 'auto';
   }
+  // A Send tap mid-composition empties the box; the ghost must follow.
+  _ghostSync();
 }
 
 // ── events ─────────────────────────────────────────────────────────────────
@@ -689,6 +705,9 @@ cmdInput.addEventListener('keydown', e => {
   }
 });
 cmdInput.addEventListener('input', () => {
+  // No auto-grow while the box is invisible in direct mode: a second row
+  // would shrink the pane and shift the ghost the user is watching.
+  if (keybarVisible()) return;
   cmdInput.style.height = 'auto';
   cmdInput.style.height = Math.min(cmdInput.scrollHeight, 160) + 'px';
 });
@@ -756,6 +775,11 @@ function applyKbdMode() {
   for (const [mode, btn] of Object.entries(kbdModePopupButtons)) {
     btn.classList.toggle('current', Number(mode) === kbdMode);
   }
+  // Every keybar/mode transition funnels through here, so this one call
+  // covers show (attach), hide (remove, ahead of the blur+refocus dance so
+  // the ghost never flashes) and the switch to password mode (remove: pwd
+  // stays a visible box and never ghosts).
+  _ghostSync();
   scrollOutputToBottom();
 }
 
@@ -881,8 +905,9 @@ const keybar     = document.getElementById('keybar');
 const keybarCtrl = document.getElementById('keybar-ctrl');
 const _cmdPlaceholder = cmdInput.placeholder;
 const _pwdPlaceholder = pwdInput.placeholder;
-const _directPlaceholder = 'Direct mode: keys go straight to the pane';
-// The password box keeps its keyboard-privacy hint in direct mode too.
+// The direct-mode text box is invisible (see body.keybar-on #cmd in the
+// CSS), so it carries no placeholder while the bar is on; the password box
+// stays visible and keeps its keyboard-privacy hint.
 const _directPwdPlaceholder = 'Direct mode: not saved by keyboard';
 let _ctrlArmed = false;
 
@@ -903,7 +928,7 @@ function setKeybarVisible(show) {
   // survive typing.
   document.body.classList.toggle('keybar-on', show);
   if (!show) setCtrlArmed(false);
-  cmdInput.placeholder = show ? _directPlaceholder : _cmdPlaceholder;
+  cmdInput.placeholder = show ? '' : _cmdPlaceholder;
   pwdInput.placeholder = show ? _directPwdPlaceholder : _pwdPlaceholder;
   // Re-apply so direct mode forces terminal input attributes and hiding
   // the bar restores the user's mode. Also scrolls output to bottom.
@@ -969,15 +994,88 @@ function drainDirectInput(inp) {
   send({ type: 'send_keys', pane_id: currentPane, keys: text, enter: false, literal: true });
 }
 
+// ── direct-mode composition ghost ──────────────────────────────────────────
+// While the key bar is on, the text box is invisible (body.keybar-on #cmd in
+// the CSS) and its un-sent content is mirrored into the pane as ghost text:
+// a composition in progress, or plain text the next input event will drain.
+// The pane becomes the only prompt. Rendering is strictly read-only; the
+// drain and IME guards below stay untouched, and reading inp.value mid-
+// composition is safe (only clearing it is not). Cursor caveat: end of the
+// last line is an approximation of the real cursor, exact at a shell prompt,
+// approximate in full-screen TUIs.
+function _ghostRemove() {
+  const el = document.getElementById('compose-ghost');
+  if (el) el.remove();
+}
+
+function _ghostSync() {
+  _ghostRemove();
+  // No ghost in password mode (the pwd box stays a visible input), in
+  // scroll mode (the viewport is browsing history, not the prompt), or
+  // without a pane to anchor to.
+  if (!keybarVisible() || kbdMode === 2 || _scrollMode || !currentPane) return;
+  // Not over the loading placeholder either: composing during a cache-miss
+  // pane switch would glue the ghost to "loading..." until the snapshot.
+  if (_paneLoading) return;
+  const text = cmdInput.value;
+  if (!text) return;
+  const span = document.createElement('span');
+  span.id = 'compose-ghost';
+  span.textContent = text;
+  // Insert after the last rendered character but before any trailing
+  // newlines, so the ghost sits at the end of the last line rather than on
+  // a line of its own. Splitting a text node is serialization-neutral:
+  // adjacent text nodes read back as the same innerHTML, so once the ghost
+  // is removed (navigateTo strips it before every cache save) nothing of
+  // this leaks into _paneCache.
+  let last = null;
+  const walker = document.createTreeWalker(output, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) last = walker.currentNode;
+  if (!last) {
+    output.appendChild(span);
+    return;
+  }
+  const m = last.textContent.match(/\n+$/);
+  if (m) {
+    const tail = last.splitText(last.textContent.length - m[0].length);
+    tail.parentNode.insertBefore(span, tail);
+  } else {
+    // Climb out of styled ANSI spans: text-decoration propagates into
+    // children and cannot be reset from a descendant, so an SGR-underlined
+    // last line would merge its underline into the ghost's dotted one.
+    // (The trailing-newline branch above keeps in-place insertion; moving
+    // the ghost outside that span would land it after the newlines.)
+    let anchor = last;
+    while (anchor.parentNode !== output) anchor = anchor.parentNode;
+    output.insertBefore(span, anchor.nextSibling);
+  }
+}
+
+// Direct mode has no visible box to tap, so any blur (tapping the pane to
+// look at it) would leave keystrokes with no target: nothing drains, no
+// ghost, dead input. Tapping the pane focuses the hidden input instead,
+// like tapping a real terminal. Skipped in scroll mode and while the user
+// is selecting text to copy.
+output.addEventListener('click', () => {
+  if (!keybarVisible() || _scrollMode) return;
+  if (window.getSelection && String(window.getSelection())) return;
+  activeInput().focus();
+});
+
 // IME guard: mobile keyboards fire input events mid-composition; draining
 // (which clears the box) then would duplicate or drop characters. Skip
-// while composing and drain once on compositionend.
+// while composing and drain once on compositionend. The ghost syncs after
+// the drain decision either way: mid-composition it mirrors the growing
+// word, after a drain (including a sticky-Ctrl C- send) the emptied box
+// clears it.
 for (const inp of [cmdInput, pwdInput]) {
   inp.addEventListener('input', e => {
     if (keybarVisible() && !e.isComposing) drainDirectInput(inp);
+    _ghostSync();
   });
   inp.addEventListener('compositionend', () => {
     if (keybarVisible()) drainDirectInput(inp);
+    _ghostSync();
   });
   // Gboard reports empty-field backspace as keyCode 229, so the keydown
   // path misses it; catch it here instead. When keydown does handle a
@@ -1892,6 +1990,9 @@ function enterScrollMode() {
   const ae = document.activeElement;
   if (ae && typeof ae.blur === 'function') ae.blur();
   _showKbdChip('SCROLL');
+  // Hide the composition ghost: while browsing history it would masquerade
+  // as pane content.
+  _ghostSync();
 }
 function exitScrollMode() {
   _scrollMode = false;
@@ -1900,6 +2001,7 @@ function exitScrollMode() {
   // next keystrokes would go nowhere. Scroll mode is only reachable via a
   // hardware Ctrl+B, so refocusing cannot pop a soft keyboard.
   activeInput().focus();
+  _ghostSync();
 }
 
 function handleScrollKey(e) {

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -330,7 +330,8 @@
     #output.placeholder { white-space: normal; color: var(--term-dim); font-style: italic; }
 
     /* ── direct-mode composition ghost (attached by _ghostSync in app.js) ──
-       un-sent text-box content shown at the end of the pane's last line.
+       un-streamed tail of the text box shown at the end of the pane's last
+       line; with composition streaming this is normally empty.
        Dim plus dotted underline: distinct in both themes, never color
        alone. Explicit normal weight/style and transparent background so an
        ANSI-styled parent span cannot restyle it; pre-wrap so a long ghost
@@ -340,6 +341,8 @@
       font-weight: normal; font-style: normal;
       text-decoration: underline dotted;
       white-space: pre-wrap; word-break: break-all;
+      /* containing block for the absolutely positioned ::after caret */
+      position: relative;
     }
 
     /* ── byobu status line ── */
@@ -448,21 +451,77 @@
          so keys scroll under it instead of showing through */
       position: sticky; right: 0; background: var(--bg2);
       border-color: transparent;
+      /* clearance so the last real button can scroll fully out from under
+         the pinned ✕: at max scroll the ✕ otherwise paints over it (its
+         opaque pinned box lands on the rightmost button). Margin on the ✕
+         rather than padding-right on #keybar: browsers are inconsistent
+         about honoring a scroll container's inline-end padding, a margin
+         between flex items always counts as scrollable content. 44px
+         matches the ✕'s own min-width. No sticky-left element exists. */
+      margin-left: 44px;
       /* var(--text), not --dim: --dim over --bg2 is ~2.9:1, the contrast
          class e894f3db removed, and this X is the bar's exit path */
       color: var(--text); font-size: 15px;
     }
     #keybar #keybar-close:active { background: var(--bg3); color: var(--text); }
-    /* direct mode cues on the input row: accent border on the row, Send
-       recedes (it still sends a chunk, but keystrokes bypass it) */
+    /* direct mode cues on the input row while it is still visible (password
+       mode): accent border on the row, Send recedes (it still sends a
+       chunk, but keystrokes bypass it). In non-password direct mode the
+       row-collapse rules below override both. */
     body.keybar-on #inputbar { border-top: 1px solid var(--accent); }
     body.keybar-on #btn-send:not(:disabled) { opacity: 0.45; }
-    /* direct mode: the pane's composition ghost is the only prompt, so the
-       text box goes fully transparent. Opacity rather than display or a
-       zero height: the box must stay focused, keep receiving keys and
-       composition events, and Android IMEs misbehave when their anchor
-       collapses. The password box (kbdMode 2) stays a visible input. */
-    body.keybar-on #cmd { opacity: 0; caret-color: transparent; }
+    /* direct mode: the input row leaves the layout so the pane gets its
+       space; the ghost caret in the pane is the only prompt. The text box
+       must stay rendered and focusable (Android IMEs misbehave when their
+       anchor collapses), so it goes out of flow instead of display:none: a
+       transparent 2px sliver absolutely positioned at the bottom of #app,
+       which syncViewportToKeyboard pins to the visual viewport, so the
+       sliver always stays on screen (the xterm.js hidden-textarea pattern).
+       The password box (kbdMode 2, body.kbd-pwd, toggled by applyKbdMode)
+       keeps the visible row exactly as before; only #cmd ever collapses. */
+    body.keybar-on:not(.kbd-pwd) #inputbar { padding: 0; border-top: none; }
+    body.keybar-on:not(.kbd-pwd) #btn-right-col,
+    body.keybar-on:not(.kbd-pwd) #btn-send { display: none; }
+    body.keybar-on:not(.kbd-pwd) #cmd {
+      position: absolute; left: 0; right: 0; bottom: 0;
+      height: 2px; min-height: 0; padding: 0; border: none;
+      opacity: 0; caret-color: transparent; overflow: hidden;
+    }
+    /* with the row gone the key bar is the bottom edge: it takes over the
+       accent cue and the home-indicator clearance the row provided */
+    body.keybar-on:not(.kbd-pwd) #keybar {
+      border-top-color: var(--accent);
+      padding-bottom: max(6px, env(safe-area-inset-bottom));
+    }
+    /* ghost caret: block cursor at the ghost position, the pane-side signal
+       that direct-mode typing is live. Filled while the box is focused AND
+       the keyboard is actually open (body.kbd-open, set from visualViewport:
+       Android's back gesture dismisses the keyboard without blurring, so
+       focus alone would lie); hollow otherwise, meaning tap the pane to
+       summon the keyboard. Hardware and floating keyboards never shrink the
+       visual viewport, so kbd-open never sets there and the caret stays
+       hollow while typing is live; that is a known limit, not a bug.
+       ::after so the caret lives and dies with #compose-ghost and the
+       cache-strip rules need no change. Absolutely positioned (off the
+       ghost's own inline box) so it can NEVER change the line-box height:
+       the earlier inline-block caret overflowed the line box, growing the
+       cursor line whenever the ghost existed and shrinking it when the tail
+       emptied, a 1px whole-screen jitter per keystroke via #output's
+       scrollHeight and the bottom anchor. Out of flow also keeps the
+       ghost's dotted underline off it (text-decoration does not propagate
+       to out-of-flow descendants). left:100% of the ghost's box puts it
+       right after the ghost text, on the anchor itself when empty. */
+    #compose-ghost::after {
+      content: ""; position: absolute;
+      left: 100%; bottom: 0; width: 0.6em; height: 1.1em;
+      box-shadow: inset 0 0 0 1px var(--term-dim);
+    }
+    body.kbd-open.cmd-focused #compose-ghost::after {
+      box-shadow: none; background: var(--term-dim);
+    }
+    /* password mode shows the real input row again; the key bar mirrors of
+       the mode and wrap buttons would duplicate it */
+    body.kbd-pwd #keybar-kbd-mode, body.kbd-pwd #keybar-wrap { display: none; }
 
 
     /* ── pairing overlay ── */
@@ -775,6 +834,10 @@
     <button data-key="Right" title="Right">→</button>
     <button data-key="BSpace" title="Backspace">⌫</button>
     <button data-key="Enter" title="Enter">⏎</button>
+    <!-- direct mode hides the input row's button column, so the keyboard-mode
+         cycle and the wrap toggle live on the bar too -->
+    <button id="keybar-kbd-mode" title="Terminal mode: tap to enable spell check">$_</button>
+    <button id="keybar-wrap" title="Toggle line wrap">⤶</button>
     <button id="keybar-close" title="Close key bar: back to chunked input">✕</button>
   </div>
 

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -835,8 +835,8 @@
     <button data-key="BSpace" title="Backspace">⌫</button>
     <button data-key="Enter" title="Enter">⏎</button>
     <!-- direct mode hides the input row's button column, so the keyboard-mode
-         cycle and the wrap toggle live on the bar too -->
-    <button id="keybar-kbd-mode" title="Terminal mode: tap to enable spell check">$_</button>
+         popup opener and the wrap toggle live on the bar too -->
+    <button id="keybar-kbd-mode" title="Terminal mode: tap to choose a mode">$_</button>
     <button id="keybar-wrap" title="Toggle line wrap">⤶</button>
     <button id="keybar-close" title="Close key bar: back to chunked input">✕</button>
   </div>
@@ -851,7 +851,7 @@
            disabled>
     <div id="btn-right-col">
       <button id="btn-escape" class="icon-btn" title="Esc / Ctrl-C / key bar">⎋</button>
-      <button id="btn-kbd-mode" class="icon-btn" title="Terminal mode — tap to enable spell check">$_</button>
+      <button id="btn-kbd-mode" class="icon-btn" title="Terminal mode: tap to choose a mode">$_</button>
     </div>
     <button id="btn-send" title="Send" disabled>↵</button>
   </div>

--- a/mobile/trustmux/static/index.html
+++ b/mobile/trustmux/static/index.html
@@ -329,6 +329,19 @@
     }
     #output.placeholder { white-space: normal; color: var(--term-dim); font-style: italic; }
 
+    /* ── direct-mode composition ghost (attached by _ghostSync in app.js) ──
+       un-sent text-box content shown at the end of the pane's last line.
+       Dim plus dotted underline: distinct in both themes, never color
+       alone. Explicit normal weight/style and transparent background so an
+       ANSI-styled parent span cannot restyle it; pre-wrap so a long ghost
+       wraps instead of widening a non-wrap pane. */
+    #compose-ghost {
+      color: var(--term-dim); background: transparent;
+      font-weight: normal; font-style: normal;
+      text-decoration: underline dotted;
+      white-space: pre-wrap; word-break: break-all;
+    }
+
     /* ── byobu status line ── */
     #statusline {
       display: flex; align-items: center; justify-content: space-between;
@@ -444,6 +457,12 @@
        recedes (it still sends a chunk, but keystrokes bypass it) */
     body.keybar-on #inputbar { border-top: 1px solid var(--accent); }
     body.keybar-on #btn-send:not(:disabled) { opacity: 0.45; }
+    /* direct mode: the pane's composition ghost is the only prompt, so the
+       text box goes fully transparent. Opacity rather than display or a
+       zero height: the box must stay focused, keep receiving keys and
+       composition events, and Android IMEs misbehave when their anchor
+       collapses. The password box (kbdMode 2) stays a visible input. */
+    body.keybar-on #cmd { opacity: 0; caret-color: transparent; }
 
 
     /* ── pairing overlay ── */


### PR DESCRIPTION
**Stacked on #147**: only the last 5 commits are new here; the rest is #147's series. Marked draft until #147 merges, then this rebases to show just its own commits.

Five commits take typing latency from poll-bound to network-bound, then hide the network too. They help every mode (tailscale serve, direct, local).

## What

1. **TCP_NODELAY on the websocket**: Tornado leaves Nagle on, so a keystroke or one-line patch could wait up to an RTT for an ACK.
2. **Event-driven pane stream via tmux control mode**: one `tmux -C attach-session -f ignore-size` client per streamed session pushes %output wakes, demoting the 150/500ms poll to a 2s safety net; capture-pane and the cursor query ride the same connection instead of two fork+execs per tick. Subprocess fallback throughout, capture rate floored at the old active cadence, only validated ids ever enter a control-mode command line. Measured on loopback: externally generated output reaches the websocket in ~36ms against a ~250ms mean before. Notes from probing tmux 3.7 are in the commit message (read-only client flag breaks external send-keys; reply blocks pair by %begin/%end timestamp+number; replies are byte-identical to subprocess output).
3. **Conditional Enter settle**: the 150ms paste-burst settle (GH #115 workaround) now applies only when the pane's foreground process is not a plain shell. Command submit at a prompt: ~160ms to ~11ms server-side.
4. **Predictive local echo**: streamed printables render immediately through the composition ghost at the cursor cell and are dropped when the echo confirms them, or after 1.2s. Display is gated on one confirmed echo, so panes that do not echo (vim normal mode, read -s) stay quiet. Named keys void predictions; the password box is never tracked.
5. **Wrap-mode cursor mapping**: join (-J) subscriptions previously sent no cursor; the daemon now maps the screen cursor into joined-capture coordinates, so the ghost and the predictions anchor correctly in wrap mode, including TUI input lines.

## How a keystroke flows

1. The PWA renders the key instantly as provisional ghost text and sends a send_keys frame over the WebSocket (TCP_NODELAY flushes it at once).
2. The daemon runs tmux send-keys; tmux writes the byte to the pane's pty and the pane's program echoes it.
3. tmux pushes %output down the pipe to the daemon's control-mode client, waking the stream: no poll tick to wait for.
4. The daemon coalesces for 30ms, fetches capture and cursor over that same connection (no fork per frame), and diffs.
5. The patch frame reaches the PWA, which applies it and drops the ghost character the real echo now confirms.

The control-mode client is in effect an event listener bolted onto tmux for a daemon that could previously only poll; the old poll survives as a 2s safety net behind a subprocess fallback.

## Testing

527 tests pass (34 new across control-mode parsing, wake dispatch, settle conditions, and join-cursor mapping). Client behavior verified against real Firefox (geckodriver, touch pointer) and Chromium driving the served app; daily-driven on Android Firefox over a real tailnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracking issue: #149
